### PR TITLE
feat: Add send-as email alias support

### DIFF
--- a/src/components/composer/FromSelector.tsx
+++ b/src/components/composer/FromSelector.tsx
@@ -1,0 +1,39 @@
+import type { SendAsAlias } from "@/services/db/sendAsAliases";
+
+interface FromSelectorProps {
+  aliases: SendAsAlias[];
+  selectedEmail: string;
+  onChange: (alias: SendAsAlias) => void;
+}
+
+/**
+ * Dropdown for selecting a send-as alias in the composer.
+ * Only visible when more than one alias is available.
+ */
+export function FromSelector({ aliases, selectedEmail, onChange }: FromSelectorProps) {
+  if (aliases.length <= 1) return null;
+
+  return (
+    <div className="flex items-center gap-2">
+      <span className="text-xs text-text-tertiary w-8 shrink-0">
+        From
+      </span>
+      <select
+        value={selectedEmail}
+        onChange={(e) => {
+          const alias = aliases.find((a) => a.email === e.target.value);
+          if (alias) onChange(alias);
+        }}
+        className="flex-1 bg-transparent text-sm text-text-primary outline-none cursor-pointer hover:bg-bg-hover rounded px-1 py-0.5 -ml-1 border-none"
+      >
+        {aliases.map((alias) => (
+          <option key={alias.id} value={alias.email}>
+            {alias.displayName
+              ? `${alias.displayName} <${alias.email}>`
+              : alias.email}
+          </option>
+        ))}
+      </select>
+    </div>
+  );
+}

--- a/src/services/db/migrations.ts
+++ b/src/services/db/migrations.ts
@@ -411,6 +411,27 @@ const MIGRATIONS = [
         ('auto_archive_after_unsubscribe', 'true');
     `,
   },
+  {
+    version: 7,
+    description: "Send-as aliases",
+    sql: `
+      CREATE TABLE IF NOT EXISTS send_as_aliases (
+        id TEXT PRIMARY KEY,
+        account_id TEXT NOT NULL REFERENCES accounts(id) ON DELETE CASCADE,
+        email TEXT NOT NULL,
+        display_name TEXT,
+        reply_to_address TEXT,
+        signature_id TEXT,
+        is_primary INTEGER DEFAULT 0,
+        is_default INTEGER DEFAULT 0,
+        treat_as_alias INTEGER DEFAULT 1,
+        verification_status TEXT DEFAULT 'accepted',
+        created_at INTEGER DEFAULT (unixepoch()),
+        UNIQUE(account_id, email)
+      );
+      CREATE INDEX idx_send_as_account ON send_as_aliases(account_id);
+    `,
+  },
 ];
 
 /**

--- a/src/services/db/sendAsAliases.test.ts
+++ b/src/services/db/sendAsAliases.test.ts
@@ -1,0 +1,230 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+
+vi.mock("@/services/db/connection", () => ({
+  getDb: vi.fn(),
+}));
+
+import { getDb } from "@/services/db/connection";
+import {
+  getAliasesForAccount,
+  upsertAlias,
+  getDefaultAlias,
+  setDefaultAlias,
+  deleteAlias,
+  mapDbAlias,
+  type DbSendAsAlias,
+} from "./sendAsAliases";
+
+const mockDb = {
+  select: vi.fn(() => Promise.resolve([])),
+  execute: vi.fn(() => Promise.resolve({ rowsAffected: 1 })),
+};
+
+describe("sendAsAliases service", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(getDb).mockResolvedValue(
+      mockDb as unknown as Awaited<ReturnType<typeof getDb>>,
+    );
+  });
+
+  describe("getAliasesForAccount", () => {
+    it("queries aliases ordered by is_primary DESC, email", async () => {
+      await getAliasesForAccount("acc-1");
+
+      expect(mockDb.select).toHaveBeenCalledWith(
+        expect.stringContaining("SELECT * FROM send_as_aliases WHERE account_id = $1"),
+        ["acc-1"],
+      );
+    });
+  });
+
+  describe("upsertAlias", () => {
+    it("inserts an alias with correct parameters", async () => {
+      await upsertAlias({
+        accountId: "acc-1",
+        email: "user@example.com",
+        displayName: "User Name",
+        isPrimary: true,
+        isDefault: false,
+        treatAsAlias: true,
+        verificationStatus: "accepted",
+      });
+
+      expect(mockDb.execute).toHaveBeenCalledWith(
+        expect.stringContaining("INSERT INTO send_as_aliases"),
+        expect.arrayContaining([
+          "acc-1",
+          "user@example.com",
+          "User Name",
+          null, // replyToAddress
+          null, // signatureId
+          1, // isPrimary
+          0, // isDefault
+          1, // treatAsAlias
+          "accepted",
+        ]),
+      );
+    });
+
+    it("defaults treatAsAlias to 1 when not specified", async () => {
+      await upsertAlias({
+        accountId: "acc-1",
+        email: "user@example.com",
+      });
+
+      expect(mockDb.execute).toHaveBeenCalledWith(
+        expect.stringContaining("INSERT INTO send_as_aliases"),
+        expect.arrayContaining([
+          1, // treatAsAlias default
+          "accepted", // verificationStatus default
+        ]),
+      );
+    });
+  });
+
+  describe("getDefaultAlias", () => {
+    it("returns the default alias when one exists", async () => {
+      const alias: DbSendAsAlias = {
+        id: "alias-1",
+        account_id: "acc-1",
+        email: "default@example.com",
+        display_name: "Default",
+        reply_to_address: null,
+        signature_id: null,
+        is_primary: 0,
+        is_default: 1,
+        treat_as_alias: 1,
+        verification_status: "accepted",
+        created_at: 1000,
+      };
+      mockDb.select.mockResolvedValueOnce([alias]);
+
+      const result = await getDefaultAlias("acc-1");
+
+      expect(result).toEqual(alias);
+      expect(mockDb.select).toHaveBeenCalledWith(
+        expect.stringContaining("is_default = 1"),
+        ["acc-1"],
+      );
+    });
+
+    it("falls back to primary alias when no default exists", async () => {
+      const primary: DbSendAsAlias = {
+        id: "alias-2",
+        account_id: "acc-1",
+        email: "primary@example.com",
+        display_name: "Primary",
+        reply_to_address: null,
+        signature_id: null,
+        is_primary: 1,
+        is_default: 0,
+        treat_as_alias: 1,
+        verification_status: "accepted",
+        created_at: 1000,
+      };
+      mockDb.select
+        .mockResolvedValueOnce([]) // no default
+        .mockResolvedValueOnce([primary]); // primary fallback
+
+      const result = await getDefaultAlias("acc-1");
+
+      expect(result).toEqual(primary);
+    });
+
+    it("returns null when no aliases exist", async () => {
+      mockDb.select
+        .mockResolvedValueOnce([]) // no default
+        .mockResolvedValueOnce([]); // no primary
+
+      const result = await getDefaultAlias("acc-1");
+
+      expect(result).toBeNull();
+    });
+  });
+
+  describe("setDefaultAlias", () => {
+    it("clears existing defaults and sets the specified one", async () => {
+      await setDefaultAlias("acc-1", "alias-3");
+
+      expect(mockDb.execute).toHaveBeenCalledTimes(2);
+      expect(mockDb.execute).toHaveBeenCalledWith(
+        expect.stringContaining("UPDATE send_as_aliases SET is_default = 0"),
+        ["acc-1"],
+      );
+      expect(mockDb.execute).toHaveBeenCalledWith(
+        expect.stringContaining("UPDATE send_as_aliases SET is_default = 1"),
+        ["alias-3", "acc-1"],
+      );
+    });
+  });
+
+  describe("deleteAlias", () => {
+    it("deletes the alias by id", async () => {
+      await deleteAlias("alias-5");
+
+      expect(mockDb.execute).toHaveBeenCalledWith(
+        "DELETE FROM send_as_aliases WHERE id = $1",
+        ["alias-5"],
+      );
+    });
+  });
+
+  describe("mapDbAlias", () => {
+    it("maps DB row to domain object", () => {
+      const db: DbSendAsAlias = {
+        id: "alias-1",
+        account_id: "acc-1",
+        email: "test@example.com",
+        display_name: "Test User",
+        reply_to_address: "reply@example.com",
+        signature_id: "sig-1",
+        is_primary: 1,
+        is_default: 0,
+        treat_as_alias: 1,
+        verification_status: "accepted",
+        created_at: 1700000000,
+      };
+
+      const result = mapDbAlias(db);
+
+      expect(result).toEqual({
+        id: "alias-1",
+        accountId: "acc-1",
+        email: "test@example.com",
+        displayName: "Test User",
+        replyToAddress: "reply@example.com",
+        signatureId: "sig-1",
+        isPrimary: true,
+        isDefault: false,
+        treatAsAlias: true,
+        verificationStatus: "accepted",
+      });
+    });
+
+    it("maps zero values to false booleans", () => {
+      const db: DbSendAsAlias = {
+        id: "alias-2",
+        account_id: "acc-1",
+        email: "test@example.com",
+        display_name: null,
+        reply_to_address: null,
+        signature_id: null,
+        is_primary: 0,
+        is_default: 0,
+        treat_as_alias: 0,
+        verification_status: "pending",
+        created_at: 1700000000,
+      };
+
+      const result = mapDbAlias(db);
+
+      expect(result.isPrimary).toBe(false);
+      expect(result.isDefault).toBe(false);
+      expect(result.treatAsAlias).toBe(false);
+      expect(result.displayName).toBeNull();
+      expect(result.replyToAddress).toBeNull();
+      expect(result.signatureId).toBeNull();
+    });
+  });
+});

--- a/src/services/db/sendAsAliases.ts
+++ b/src/services/db/sendAsAliases.ts
@@ -1,0 +1,135 @@
+import { getDb } from "./connection";
+
+export interface DbSendAsAlias {
+  id: string;
+  account_id: string;
+  email: string;
+  display_name: string | null;
+  reply_to_address: string | null;
+  signature_id: string | null;
+  is_primary: number;
+  is_default: number;
+  treat_as_alias: number;
+  verification_status: string;
+  created_at: number;
+}
+
+export interface SendAsAlias {
+  id: string;
+  accountId: string;
+  email: string;
+  displayName: string | null;
+  replyToAddress: string | null;
+  signatureId: string | null;
+  isPrimary: boolean;
+  isDefault: boolean;
+  treatAsAlias: boolean;
+  verificationStatus: string;
+}
+
+export function mapDbAlias(db: DbSendAsAlias): SendAsAlias {
+  return {
+    id: db.id,
+    accountId: db.account_id,
+    email: db.email,
+    displayName: db.display_name,
+    replyToAddress: db.reply_to_address,
+    signatureId: db.signature_id,
+    isPrimary: db.is_primary === 1,
+    isDefault: db.is_default === 1,
+    treatAsAlias: db.treat_as_alias === 1,
+    verificationStatus: db.verification_status,
+  };
+}
+
+export async function getAliasesForAccount(
+  accountId: string,
+): Promise<DbSendAsAlias[]> {
+  const db = await getDb();
+  return db.select<DbSendAsAlias[]>(
+    "SELECT * FROM send_as_aliases WHERE account_id = $1 ORDER BY is_primary DESC, email",
+    [accountId],
+  );
+}
+
+export async function upsertAlias(alias: {
+  accountId: string;
+  email: string;
+  displayName?: string | null;
+  replyToAddress?: string | null;
+  signatureId?: string | null;
+  isPrimary?: boolean;
+  isDefault?: boolean;
+  treatAsAlias?: boolean;
+  verificationStatus?: string;
+}): Promise<string> {
+  const db = await getDb();
+  const id = crypto.randomUUID();
+
+  await db.execute(
+    `INSERT INTO send_as_aliases (id, account_id, email, display_name, reply_to_address, signature_id, is_primary, is_default, treat_as_alias, verification_status)
+     VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)
+     ON CONFLICT(account_id, email) DO UPDATE SET
+       display_name = excluded.display_name,
+       reply_to_address = excluded.reply_to_address,
+       signature_id = excluded.signature_id,
+       is_primary = excluded.is_primary,
+       treat_as_alias = excluded.treat_as_alias,
+       verification_status = excluded.verification_status`,
+    [
+      id,
+      alias.accountId,
+      alias.email,
+      alias.displayName ?? null,
+      alias.replyToAddress ?? null,
+      alias.signatureId ?? null,
+      alias.isPrimary ? 1 : 0,
+      alias.isDefault ? 1 : 0,
+      alias.treatAsAlias !== false ? 1 : 0,
+      alias.verificationStatus ?? "accepted",
+    ],
+  );
+
+  return id;
+}
+
+export async function getDefaultAlias(
+  accountId: string,
+): Promise<DbSendAsAlias | null> {
+  const db = await getDb();
+  // Try to get the explicitly set default
+  const defaults = await db.select<DbSendAsAlias[]>(
+    "SELECT * FROM send_as_aliases WHERE account_id = $1 AND is_default = 1 LIMIT 1",
+    [accountId],
+  );
+  if (defaults[0]) return defaults[0];
+
+  // Fall back to the primary alias
+  const primaries = await db.select<DbSendAsAlias[]>(
+    "SELECT * FROM send_as_aliases WHERE account_id = $1 AND is_primary = 1 LIMIT 1",
+    [accountId],
+  );
+  return primaries[0] ?? null;
+}
+
+export async function setDefaultAlias(
+  accountId: string,
+  aliasId: string,
+): Promise<void> {
+  const db = await getDb();
+  // Clear all defaults for this account
+  await db.execute(
+    "UPDATE send_as_aliases SET is_default = 0 WHERE account_id = $1",
+    [accountId],
+  );
+  // Set the specified alias as default
+  await db.execute(
+    "UPDATE send_as_aliases SET is_default = 1 WHERE id = $1 AND account_id = $2",
+    [aliasId, accountId],
+  );
+}
+
+export async function deleteAlias(id: string): Promise<void> {
+  const db = await getDb();
+  await db.execute("DELETE FROM send_as_aliases WHERE id = $1", [id]);
+}

--- a/src/services/gmail/sendAs.test.ts
+++ b/src/services/gmail/sendAs.test.ts
@@ -1,0 +1,103 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+
+vi.mock("@/services/db/sendAsAliases", () => ({
+  upsertAlias: vi.fn(() => Promise.resolve("mock-id")),
+}));
+
+import { upsertAlias } from "@/services/db/sendAsAliases";
+import { fetchSendAsAliases } from "./sendAs";
+
+describe("fetchSendAsAliases", () => {
+  const mockClient = {
+    request: vi.fn(),
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("fetches aliases and upserts each one", async () => {
+    mockClient.request.mockResolvedValue({
+      sendAs: [
+        {
+          sendAsEmail: "primary@example.com",
+          displayName: "Primary User",
+          isPrimary: true,
+          treatAsAlias: false,
+          verificationStatus: "accepted",
+        },
+        {
+          sendAsEmail: "alias@example.com",
+          displayName: "Alias User",
+          replyToAddress: "reply@example.com",
+          isPrimary: false,
+          treatAsAlias: true,
+          verificationStatus: "accepted",
+        },
+      ],
+    });
+
+    await fetchSendAsAliases(mockClient as never, "acc-1");
+
+    expect(mockClient.request).toHaveBeenCalledWith("/settings/sendAs");
+    expect(upsertAlias).toHaveBeenCalledTimes(2);
+
+    expect(upsertAlias).toHaveBeenCalledWith({
+      accountId: "acc-1",
+      email: "primary@example.com",
+      displayName: "Primary User",
+      replyToAddress: null,
+      isPrimary: true,
+      treatAsAlias: false,
+      verificationStatus: "accepted",
+    });
+
+    expect(upsertAlias).toHaveBeenCalledWith({
+      accountId: "acc-1",
+      email: "alias@example.com",
+      displayName: "Alias User",
+      replyToAddress: "reply@example.com",
+      isPrimary: false,
+      treatAsAlias: true,
+      verificationStatus: "accepted",
+    });
+  });
+
+  it("handles empty sendAs array gracefully", async () => {
+    mockClient.request.mockResolvedValue({ sendAs: [] });
+
+    await fetchSendAsAliases(mockClient as never, "acc-1");
+
+    expect(upsertAlias).not.toHaveBeenCalled();
+  });
+
+  it("handles missing sendAs property gracefully", async () => {
+    mockClient.request.mockResolvedValue({});
+
+    await fetchSendAsAliases(mockClient as never, "acc-1");
+
+    expect(upsertAlias).not.toHaveBeenCalled();
+  });
+
+  it("defaults optional fields", async () => {
+    mockClient.request.mockResolvedValue({
+      sendAs: [
+        {
+          sendAsEmail: "minimal@example.com",
+        },
+      ],
+    });
+
+    await fetchSendAsAliases(mockClient as never, "acc-1");
+
+    expect(upsertAlias).toHaveBeenCalledWith({
+      accountId: "acc-1",
+      email: "minimal@example.com",
+      displayName: null,
+      replyToAddress: null,
+      isPrimary: false,
+      treatAsAlias: true,
+      verificationStatus: "accepted",
+    });
+  });
+});

--- a/src/services/gmail/sendAs.ts
+++ b/src/services/gmail/sendAs.ts
@@ -1,0 +1,42 @@
+import type { GmailClient } from "./client";
+import { upsertAlias } from "../db/sendAsAliases";
+
+interface GmailSendAsEntry {
+  sendAsEmail: string;
+  displayName?: string;
+  replyToAddress?: string;
+  isPrimary?: boolean;
+  treatAsAlias?: boolean;
+  verificationStatus?: string;
+  signature?: string;
+}
+
+interface GmailSendAsResponse {
+  sendAs: GmailSendAsEntry[];
+}
+
+/**
+ * Fetch send-as aliases from Gmail API and store them locally.
+ */
+export async function fetchSendAsAliases(
+  client: GmailClient,
+  accountId: string,
+): Promise<void> {
+  const response = await client.request<GmailSendAsResponse>(
+    "/settings/sendAs",
+  );
+
+  if (!response.sendAs) return;
+
+  for (const entry of response.sendAs) {
+    await upsertAlias({
+      accountId,
+      email: entry.sendAsEmail,
+      displayName: entry.displayName ?? null,
+      replyToAddress: entry.replyToAddress ?? null,
+      isPrimary: entry.isPrimary ?? false,
+      treatAsAlias: entry.treatAsAlias ?? true,
+      verificationStatus: entry.verificationStatus ?? "accepted",
+    });
+  }
+}

--- a/src/stores/composerStore.ts
+++ b/src/stores/composerStore.ts
@@ -28,6 +28,7 @@ export interface ComposerState {
   attachments: ComposerAttachment[];
   lastSavedAt: number | null;
   isSaving: boolean;
+  fromEmail: string | null;
   signatureHtml: string;
   signatureId: string | null;
 
@@ -57,6 +58,7 @@ export interface ComposerState {
   clearAttachments: () => void;
   setLastSavedAt: (ts: number | null) => void;
   setIsSaving: (saving: boolean) => void;
+  setFromEmail: (email: string | null) => void;
   setSignatureHtml: (html: string) => void;
   setSignatureId: (id: string | null) => void;
 }
@@ -76,6 +78,7 @@ export const useComposerStore = create<ComposerState>((set) => ({
   undoSendTimer: null,
   undoSendVisible: false,
   attachments: [],
+  fromEmail: null,
   lastSavedAt: null,
   isSaving: false,
   signatureHtml: "",
@@ -94,6 +97,7 @@ export const useComposerStore = create<ComposerState>((set) => ({
       inReplyToMessageId: opts?.inReplyToMessageId ?? null,
       showCcBcc: (opts?.cc?.length ?? 0) > 0 || (opts?.bcc?.length ?? 0) > 0,
       draftId: opts?.draftId ?? null,
+      fromEmail: null,
       attachments: [],
       lastSavedAt: null,
       isSaving: false,
@@ -113,6 +117,7 @@ export const useComposerStore = create<ComposerState>((set) => ({
       inReplyToMessageId: null,
       showCcBcc: false,
       draftId: null,
+      fromEmail: null,
       attachments: [],
       lastSavedAt: null,
       isSaving: false,
@@ -137,6 +142,7 @@ export const useComposerStore = create<ComposerState>((set) => ({
   clearAttachments: () => set({ attachments: [] }),
   setLastSavedAt: (lastSavedAt) => set({ lastSavedAt }),
   setIsSaving: (isSaving) => set({ isSaving }),
+  setFromEmail: (fromEmail) => set({ fromEmail }),
   setSignatureHtml: (signatureHtml) => set({ signatureHtml }),
   setSignatureId: (signatureId) => set({ signatureId }),
 }));

--- a/src/utils/resolveFromAddress.test.ts
+++ b/src/utils/resolveFromAddress.test.ts
@@ -1,0 +1,116 @@
+import { describe, it, expect } from "vitest";
+import { resolveFromAddress } from "./resolveFromAddress";
+import type { SendAsAlias } from "@/services/db/sendAsAliases";
+
+function makeAlias(overrides: Partial<SendAsAlias> = {}): SendAsAlias {
+  return {
+    id: "alias-1",
+    accountId: "acc-1",
+    email: "primary@example.com",
+    displayName: null,
+    replyToAddress: null,
+    signatureId: null,
+    isPrimary: false,
+    isDefault: false,
+    treatAsAlias: true,
+    verificationStatus: "accepted",
+    ...overrides,
+  };
+}
+
+describe("resolveFromAddress", () => {
+  it("returns null for empty aliases", () => {
+    const result = resolveFromAddress([], "someone@test.com", null);
+    expect(result).toBeNull();
+  });
+
+  it("resolves matching alias from To field", () => {
+    const aliases = [
+      makeAlias({ id: "a1", email: "primary@example.com", isPrimary: true }),
+      makeAlias({ id: "a2", email: "alias@example.com" }),
+    ];
+
+    const result = resolveFromAddress(aliases, "alias@example.com, other@test.com", null);
+    expect(result?.id).toBe("a2");
+    expect(result?.email).toBe("alias@example.com");
+  });
+
+  it("resolves matching alias from CC field", () => {
+    const aliases = [
+      makeAlias({ id: "a1", email: "primary@example.com", isPrimary: true }),
+      makeAlias({ id: "a2", email: "work@example.com" }),
+    ];
+
+    const result = resolveFromAddress(aliases, "someone@test.com", "work@example.com");
+    expect(result?.id).toBe("a2");
+    expect(result?.email).toBe("work@example.com");
+  });
+
+  it("is case-insensitive when matching addresses", () => {
+    const aliases = [
+      makeAlias({ id: "a1", email: "User@Example.COM", isPrimary: true }),
+    ];
+
+    const result = resolveFromAddress(aliases, "user@example.com", null);
+    expect(result?.id).toBe("a1");
+  });
+
+  it("falls back to default when no match", () => {
+    const aliases = [
+      makeAlias({ id: "a1", email: "primary@example.com", isPrimary: true }),
+      makeAlias({ id: "a2", email: "default@example.com", isDefault: true }),
+    ];
+
+    const result = resolveFromAddress(aliases, "unknown@test.com", null);
+    expect(result?.id).toBe("a2");
+  });
+
+  it("falls back to primary when no default and no match", () => {
+    const aliases = [
+      makeAlias({ id: "a1", email: "secondary@example.com" }),
+      makeAlias({ id: "a2", email: "primary@example.com", isPrimary: true }),
+    ];
+
+    const result = resolveFromAddress(aliases, "unknown@test.com", null);
+    expect(result?.id).toBe("a2");
+  });
+
+  it("falls back to first alias when no default, no primary, no match", () => {
+    const aliases = [
+      makeAlias({ id: "a1", email: "first@example.com" }),
+      makeAlias({ id: "a2", email: "second@example.com" }),
+    ];
+
+    const result = resolveFromAddress(aliases, "unknown@test.com", null);
+    expect(result?.id).toBe("a1");
+  });
+
+  it("handles null toAddresses and ccAddresses", () => {
+    const aliases = [
+      makeAlias({ id: "a1", email: "primary@example.com", isPrimary: true }),
+      makeAlias({ id: "a2", email: "default@example.com", isDefault: true }),
+    ];
+
+    const result = resolveFromAddress(aliases, null, null);
+    expect(result?.id).toBe("a2");
+  });
+
+  it("handles empty string addresses", () => {
+    const aliases = [
+      makeAlias({ id: "a1", email: "primary@example.com", isPrimary: true }),
+    ];
+
+    const result = resolveFromAddress(aliases, "", "");
+    expect(result?.id).toBe("a1");
+  });
+
+  it("prefers To match over default alias", () => {
+    const aliases = [
+      makeAlias({ id: "a1", email: "default@example.com", isDefault: true }),
+      makeAlias({ id: "a2", email: "match@example.com" }),
+    ];
+
+    const result = resolveFromAddress(aliases, "match@example.com", null);
+    expect(result?.id).toBe("a2");
+  });
+});

--- a/src/utils/resolveFromAddress.ts
+++ b/src/utils/resolveFromAddress.ts
@@ -1,0 +1,53 @@
+import type { SendAsAlias } from "@/services/db/sendAsAliases";
+
+/**
+ * Resolve which send-as alias to use as the "From" address.
+ *
+ * When replying: checks if any alias email matches an address in the
+ * To or CC fields of the original message. If found, uses that alias
+ * so the reply comes from the address the message was originally sent to.
+ *
+ * Falls back to the default alias (isDefault), then primary alias.
+ * Returns null if no aliases are available.
+ */
+export function resolveFromAddress(
+  aliases: SendAsAlias[],
+  toAddresses: string | null,
+  ccAddresses: string | null,
+): SendAsAlias | null {
+  if (aliases.length === 0) return null;
+
+  // Collect all addresses from To and CC into a normalized set
+  const recipientEmails = new Set<string>();
+  if (toAddresses) {
+    for (const addr of toAddresses.split(",")) {
+      const trimmed = addr.trim().toLowerCase();
+      if (trimmed) recipientEmails.add(trimmed);
+    }
+  }
+  if (ccAddresses) {
+    for (const addr of ccAddresses.split(",")) {
+      const trimmed = addr.trim().toLowerCase();
+      if (trimmed) recipientEmails.add(trimmed);
+    }
+  }
+
+  // Check if any alias matches a recipient address
+  if (recipientEmails.size > 0) {
+    const match = aliases.find((a) =>
+      recipientEmails.has(a.email.toLowerCase()),
+    );
+    if (match) return match;
+  }
+
+  // Fall back to default alias
+  const defaultAlias = aliases.find((a) => a.isDefault);
+  if (defaultAlias) return defaultAlias;
+
+  // Fall back to primary alias
+  const primaryAlias = aliases.find((a) => a.isPrimary);
+  if (primaryAlias) return primaryAlias;
+
+  // Last resort: return first alias
+  return aliases[0] ?? null;
+}


### PR DESCRIPTION
## Summary
- Fetches send-as aliases from Gmail API (`/settings/sendAs`) on startup
- Auto-resolves correct from-address for replies based on To/CC matching
- FromSelector dropdown in composer when multiple aliases available
- Alias list display in Settings > Accounts with default alias selection
- Database migration for `send_as_aliases` table

## Test plan
- [ ] Verify aliases are fetched after account initialization
- [ ] Open reply to email sent to an alias — verify correct from-address selected
- [ ] Compose new email — verify default alias is pre-selected
- [ ] Click FromSelector to switch between aliases
- [ ] View aliases in Settings > Accounts
- [ ] Set a different alias as default
- [ ] 24 new tests passing (DB CRUD, resolution, Gmail API)

🤖 Generated with [Claude Code](https://claude.com/claude-code)