### PR TITLE
feat: Add SPF/DKIM/DMARC authentication display

### DIFF
--- a/src/components/email/AuthBadge.test.tsx
+++ b/src/components/email/AuthBadge.test.tsx
@@ -1,0 +1,62 @@
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { AuthBadge } from "./AuthBadge";
+import type { AuthResult } from "@/services/gmail/authParser";
+
+function makeAuthResults(aggregate: AuthResult["aggregate"]): string {
+  const result: AuthResult = {
+    spf: { result: aggregate === "pass" ? "pass" : "fail", detail: null },
+    dkim: { result: aggregate === "pass" ? "pass" : "fail", detail: null },
+    dmarc: { result: aggregate === "pass" ? "pass" : "fail", detail: null },
+    aggregate,
+  };
+  return JSON.stringify(result);
+}
+
+describe("AuthBadge", () => {
+  it("should render ShieldCheck for pass aggregate", () => {
+    const { container } = render(
+      <AuthBadge authResults={makeAuthResults("pass")} />,
+    );
+
+    const badge = container.querySelector("[aria-label='Authentication passed']");
+    expect(badge).toBeInTheDocument();
+    expect(badge?.className).toContain("text-success");
+  });
+
+  it("should render ShieldX for fail aggregate", () => {
+    const { container } = render(
+      <AuthBadge authResults={makeAuthResults("fail")} />,
+    );
+
+    const badge = container.querySelector("[aria-label='Authentication failed']");
+    expect(badge).toBeInTheDocument();
+    expect(badge?.className).toContain("text-danger");
+  });
+
+  it("should render nothing for null authResults", () => {
+    const { container } = render(<AuthBadge authResults={null} />);
+
+    expect(container.innerHTML).toBe("");
+  });
+
+  it("should render ShieldAlert for warning aggregate", () => {
+    const { container } = render(
+      <AuthBadge authResults={makeAuthResults("warning")} />,
+    );
+
+    const badge = container.querySelector("[aria-label='Authentication warning']");
+    expect(badge).toBeInTheDocument();
+    expect(badge?.className).toContain("text-warning");
+  });
+
+  it("should render ShieldQuestion for unknown aggregate", () => {
+    const { container } = render(
+      <AuthBadge authResults={makeAuthResults("unknown")} />,
+    );
+
+    const badge = container.querySelector("[aria-label='Authentication unknown']");
+    expect(badge).toBeInTheDocument();
+    expect(badge?.className).toContain("text-text-tertiary");
+  });
+});

--- a/src/components/email/AuthBadge.tsx
+++ b/src/components/email/AuthBadge.tsx
@@ -1,0 +1,74 @@
+import { useState } from "react";
+import { ShieldCheck, ShieldAlert, ShieldX, ShieldQuestion } from "lucide-react";
+import type { AuthResult } from "@/services/gmail/authParser";
+
+interface AuthBadgeProps {
+  authResults: string | null;
+}
+
+export function AuthBadge({ authResults }: AuthBadgeProps) {
+  const [showTooltip, setShowTooltip] = useState(false);
+
+  if (!authResults) return null;
+
+  let parsed: AuthResult;
+  try {
+    parsed = JSON.parse(authResults) as AuthResult;
+  } catch {
+    return null;
+  }
+
+  const { aggregate, spf, dkim, dmarc } = parsed;
+
+  const tooltipLines = [
+    `SPF: ${spf.result}${spf.detail ? ` (${spf.detail})` : ""}`,
+    `DKIM: ${dkim.result}${dkim.detail ? ` (${dkim.detail})` : ""}`,
+    `DMARC: ${dmarc.result}${dmarc.detail ? ` (${dmarc.detail})` : ""}`,
+  ].join("\n");
+
+  const iconProps = { size: 14, className: "shrink-0" };
+
+  let icon: React.ReactNode;
+  let colorClass: string;
+  let label: string;
+
+  switch (aggregate) {
+    case "pass":
+      icon = <ShieldCheck {...iconProps} />;
+      colorClass = "text-success";
+      label = "Authentication passed";
+      break;
+    case "warning":
+      icon = <ShieldAlert {...iconProps} />;
+      colorClass = "text-warning";
+      label = "Authentication warning";
+      break;
+    case "fail":
+      icon = <ShieldX {...iconProps} />;
+      colorClass = "text-danger";
+      label = "Authentication failed";
+      break;
+    default:
+      icon = <ShieldQuestion {...iconProps} />;
+      colorClass = "text-text-tertiary";
+      label = "Authentication unknown";
+      break;
+  }
+
+  return (
+    <span
+      className={`relative inline-flex items-center ${colorClass}`}
+      onMouseEnter={() => setShowTooltip(true)}
+      onMouseLeave={() => setShowTooltip(false)}
+      aria-label={label}
+      role="img"
+    >
+      {icon}
+      {showTooltip && (
+        <span className="absolute bottom-full left-1/2 -translate-x-1/2 mb-1 px-2 py-1.5 text-xs rounded-md bg-bg-tertiary text-text-primary border border-border-secondary shadow-md whitespace-pre z-50 pointer-events-none">
+          {tooltipLines}
+        </span>
+      )}
+    </span>
+  );
+}

--- a/src/components/email/AuthWarningBanner.test.tsx
+++ b/src/components/email/AuthWarningBanner.test.tsx
@@ -1,0 +1,56 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { AuthWarningBanner } from "./AuthWarningBanner";
+import type { AuthResult } from "@/services/gmail/authParser";
+
+function makeAuthResults(aggregate: AuthResult["aggregate"]): string {
+  const result: AuthResult = {
+    spf: { result: aggregate === "pass" ? "pass" : "fail", detail: null },
+    dkim: { result: aggregate === "pass" ? "pass" : "fail", detail: null },
+    dmarc: { result: aggregate === "pass" ? "pass" : "fail", detail: null },
+    aggregate,
+  };
+  return JSON.stringify(result);
+}
+
+describe("AuthWarningBanner", () => {
+  it("should render for fail aggregate", () => {
+    render(
+      <AuthWarningBanner
+        authResults={makeAuthResults("fail")}
+        senderAddress="bad@example.com"
+        onDismiss={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByText("Authentication failed")).toBeInTheDocument();
+    expect(screen.getByText(/bad@example\.com/)).toBeInTheDocument();
+  });
+
+  it("should not render for pass aggregate", () => {
+    const { container } = render(
+      <AuthWarningBanner
+        authResults={makeAuthResults("pass")}
+        senderAddress="good@example.com"
+        onDismiss={vi.fn()}
+      />,
+    );
+
+    expect(container.innerHTML).toBe("");
+  });
+
+  it("should call onDismiss when dismiss button is clicked", () => {
+    const onDismiss = vi.fn();
+    render(
+      <AuthWarningBanner
+        authResults={makeAuthResults("fail")}
+        senderAddress="bad@example.com"
+        onDismiss={onDismiss}
+      />,
+    );
+
+    const dismissBtn = screen.getByLabelText("Dismiss warning");
+    fireEvent.click(dismissBtn);
+    expect(onDismiss).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/components/email/AuthWarningBanner.tsx
+++ b/src/components/email/AuthWarningBanner.tsx
@@ -1,0 +1,45 @@
+import { ShieldX, X } from "lucide-react";
+import type { AuthResult } from "@/services/gmail/authParser";
+
+interface AuthWarningBannerProps {
+  authResults: string | null;
+  senderAddress: string | null;
+  onDismiss: () => void;
+}
+
+export function AuthWarningBanner({ authResults, senderAddress, onDismiss }: AuthWarningBannerProps) {
+  if (!authResults) return null;
+
+  let parsed: AuthResult;
+  try {
+    parsed = JSON.parse(authResults) as AuthResult;
+  } catch {
+    return null;
+  }
+
+  if (parsed.aggregate !== "fail") return null;
+
+  const sender = senderAddress ?? "this sender";
+
+  return (
+    <div className="bg-danger/10 border border-danger/20 rounded-lg p-3 mb-3 flex items-start gap-2">
+      <ShieldX size={16} className="text-danger shrink-0 mt-0.5" />
+      <div className="flex-1 min-w-0">
+        <p className="text-sm text-danger font-medium">
+          Authentication failed
+        </p>
+        <p className="text-xs text-text-secondary mt-0.5">
+          This message from {sender} failed email authentication checks (SPF/DKIM/DMARC).
+          Be cautious with any links or attachments.
+        </p>
+      </div>
+      <button
+        onClick={onDismiss}
+        className="shrink-0 p-0.5 rounded hover:bg-danger/10 text-text-tertiary hover:text-text-secondary transition-colors"
+        aria-label="Dismiss warning"
+      >
+        <X size={14} />
+      </button>
+    </div>
+  );
+}

--- a/src/components/email/MessageItem.tsx
+++ b/src/components/email/MessageItem.tsx
@@ -6,6 +6,8 @@ import { AttachmentList, getAttachmentsForMessage } from "./AttachmentList";
 import type { DbMessage } from "@/services/db/messages";
 import type { DbAttachment } from "@/services/db/attachments";
 import { MailMinus } from "lucide-react";
+import { AuthBadge } from "./AuthBadge";
+import { AuthWarningBanner } from "./AuthWarningBanner";
 
 interface MessageItemProps {
   message: DbMessage;
@@ -21,6 +23,7 @@ export function MessageItem({ message, isLast, blockImages, senderAllowlisted, a
   const [expanded, setExpanded] = useState(isLast);
   const [attachments, setAttachments] = useState<DbAttachment[]>([]);
   const [, setPreviewAttachment] = useState<DbAttachment | null>(null);
+  const [authBannerDismissed, setAuthBannerDismissed] = useState(false);
   const attachmentsLoadedRef = useRef(false);
 
   const loadAttachments = async () => {
@@ -64,8 +67,9 @@ export function MessageItem({ message, isLast, blockImages, senderAllowlisted, a
               {fromDisplay[0]?.toUpperCase()}
             </div>
             <div className="min-w-0">
-              <span className="text-sm font-medium text-text-primary truncate block">
+              <span className="text-sm font-medium text-text-primary truncate flex items-center gap-1">
                 {fromDisplay}
+                <AuthBadge authResults={message.auth_results} />
               </span>
               {!expanded && (
                 <span className="text-xs text-text-tertiary truncate block">
@@ -90,6 +94,14 @@ export function MessageItem({ message, isLast, blockImages, senderAllowlisted, a
       {/* Body — shown when expanded and image setting resolved */}
       {expanded && (
         <div className="px-4 pb-4">
+          {!authBannerDismissed && (
+            <AuthWarningBanner
+              authResults={message.auth_results}
+              senderAddress={message.from_address}
+              onDismiss={() => setAuthBannerDismissed(true)}
+            />
+          )}
+
           {message.list_unsubscribe && (
             <UnsubscribeLink
               header={message.list_unsubscribe}

--- a/src/services/db/messages.ts
+++ b/src/services/db/messages.ts
@@ -22,6 +22,7 @@ export interface DbMessage {
   internal_date: number | null;
   list_unsubscribe: string | null;
   list_unsubscribe_post: string | null;
+  auth_results: string | null;
 }
 
 export async function getMessagesForThread(
@@ -56,18 +57,20 @@ export async function upsertMessage(msg: {
   internalDate: number | null;
   listUnsubscribe?: string | null;
   listUnsubscribePost?: string | null;
+  authResults?: string | null;
 }): Promise<void> {
   const db = await getDb();
   await db.execute(
-    `INSERT INTO messages (id, account_id, thread_id, from_address, from_name, to_addresses, cc_addresses, bcc_addresses, reply_to, subject, snippet, date, is_read, is_starred, body_html, body_text, body_cached, raw_size, internal_date, list_unsubscribe, list_unsubscribe_post)
-     VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20, $21)
+    `INSERT INTO messages (id, account_id, thread_id, from_address, from_name, to_addresses, cc_addresses, bcc_addresses, reply_to, subject, snippet, date, is_read, is_starred, body_html, body_text, body_cached, raw_size, internal_date, list_unsubscribe, list_unsubscribe_post, auth_results)
+     VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20, $21, $22)
      ON CONFLICT(account_id, id) DO UPDATE SET
        from_address = $4, from_name = $5, to_addresses = $6, cc_addresses = $7,
        bcc_addresses = $8, reply_to = $9, subject = $10, snippet = $11,
        date = $12, is_read = $13, is_starred = $14,
        body_html = COALESCE($15, body_html), body_text = COALESCE($16, body_text),
        body_cached = CASE WHEN $15 IS NOT NULL THEN 1 ELSE body_cached END,
-       raw_size = $18, internal_date = $19, list_unsubscribe = $20, list_unsubscribe_post = $21`,
+       raw_size = $18, internal_date = $19, list_unsubscribe = $20, list_unsubscribe_post = $21,
+       auth_results = $22`,
     [
       msg.id,
       msg.accountId,
@@ -90,6 +93,7 @@ export async function upsertMessage(msg: {
       msg.internalDate,
       msg.listUnsubscribe ?? null,
       msg.listUnsubscribePost ?? null,
+      msg.authResults ?? null,
     ],
   );
 }

--- a/src/services/db/migrations.ts
+++ b/src/services/db/migrations.ts
@@ -411,6 +411,11 @@ const MIGRATIONS = [
         ('auto_archive_after_unsubscribe', 'true');
     `,
   },
+  {
+    version: 7,
+    description: "Email authentication results",
+    sql: `ALTER TABLE messages ADD COLUMN auth_results TEXT;`,
+  },
 ];
 
 /**

--- a/src/services/gmail/authParser.test.ts
+++ b/src/services/gmail/authParser.test.ts
@@ -1,0 +1,223 @@
+import { describe, it, expect } from "vitest";
+import { parseAuthenticationResults } from "./authParser";
+
+function makeHeaders(
+  ...entries: { name: string; value: string }[]
+): { name: string; value: string }[] {
+  return entries;
+}
+
+describe("parseAuthenticationResults", () => {
+  it("should parse full pass (spf=pass, dkim=pass, dmarc=pass)", () => {
+    const headers = makeHeaders({
+      name: "Authentication-Results",
+      value:
+        "mx.google.com; spf=pass (google.com: domain of sender@example.com) smtp.mailfrom=sender@example.com; dkim=pass header.d=example.com; dmarc=pass (p=REJECT) header.from=example.com",
+    });
+
+    const result = parseAuthenticationResults(headers);
+    expect(result).not.toBeNull();
+    expect(result!.spf.result).toBe("pass");
+    expect(result!.dkim.result).toBe("pass");
+    expect(result!.dmarc.result).toBe("pass");
+    expect(result!.aggregate).toBe("pass");
+  });
+
+  it("should return aggregate fail when DMARC fails", () => {
+    const headers = makeHeaders({
+      name: "Authentication-Results",
+      value: "mx.google.com; spf=pass; dkim=pass; dmarc=fail (p=REJECT)",
+    });
+
+    const result = parseAuthenticationResults(headers);
+    expect(result).not.toBeNull();
+    expect(result!.dmarc.result).toBe("fail");
+    expect(result!.aggregate).toBe("fail");
+  });
+
+  it("should return aggregate fail when both SPF and DKIM fail", () => {
+    const headers = makeHeaders({
+      name: "Authentication-Results",
+      value: "mx.google.com; spf=fail; dkim=fail",
+    });
+
+    const result = parseAuthenticationResults(headers);
+    expect(result).not.toBeNull();
+    expect(result!.spf.result).toBe("fail");
+    expect(result!.dkim.result).toBe("fail");
+    expect(result!.aggregate).toBe("fail");
+  });
+
+  it("should return aggregate warning for SPF softfail with others pass", () => {
+    const headers = makeHeaders({
+      name: "Authentication-Results",
+      value: "mx.google.com; spf=softfail; dkim=pass; dmarc=none",
+    });
+
+    const result = parseAuthenticationResults(headers);
+    expect(result).not.toBeNull();
+    expect(result!.spf.result).toBe("softfail");
+    expect(result!.dkim.result).toBe("pass");
+    expect(result!.aggregate).toBe("warning");
+  });
+
+  it("should return aggregate warning for mixed results", () => {
+    const headers = makeHeaders({
+      name: "Authentication-Results",
+      value: "mx.google.com; spf=pass; dkim=fail; dmarc=none",
+    });
+
+    const result = parseAuthenticationResults(headers);
+    expect(result).not.toBeNull();
+    expect(result!.aggregate).toBe("warning");
+  });
+
+  it("should fallback to ARC-Authentication-Results", () => {
+    const headers = makeHeaders({
+      name: "ARC-Authentication-Results",
+      value:
+        "i=1; mx.google.com; spf=pass; dkim=pass; dmarc=pass",
+    });
+
+    const result = parseAuthenticationResults(headers);
+    expect(result).not.toBeNull();
+    expect(result!.spf.result).toBe("pass");
+    expect(result!.dkim.result).toBe("pass");
+    expect(result!.dmarc.result).toBe("pass");
+    expect(result!.aggregate).toBe("pass");
+  });
+
+  it("should fallback to Received-SPF for SPF only", () => {
+    const headers = makeHeaders({
+      name: "Received-SPF",
+      value: "pass (google.com: domain of user@example.com designates 1.2.3.4 as permitted sender)",
+    });
+
+    const result = parseAuthenticationResults(headers);
+    expect(result).not.toBeNull();
+    expect(result!.spf.result).toBe("pass");
+    expect(result!.spf.detail).toContain("google.com");
+    expect(result!.dkim.result).toBe("unknown");
+    expect(result!.dmarc.result).toBe("unknown");
+  });
+
+  it("should return null when no auth headers exist", () => {
+    const headers = makeHeaders(
+      { name: "From", value: "sender@example.com" },
+      { name: "Subject", value: "Hello" },
+    );
+
+    const result = parseAuthenticationResults(headers);
+    expect(result).toBeNull();
+  });
+
+  it("should handle multiple DKIM entries (one pass, one fail) as pass", () => {
+    const headers = makeHeaders({
+      name: "Authentication-Results",
+      value:
+        "mx.google.com; spf=pass; dkim=fail (wrong key) header.d=other.com; dkim=pass header.d=example.com; dmarc=pass",
+    });
+
+    const result = parseAuthenticationResults(headers);
+    expect(result).not.toBeNull();
+    expect(result!.dkim.result).toBe("pass");
+    expect(result!.aggregate).toBe("pass");
+  });
+
+  it("should handle malformed header gracefully", () => {
+    const headers = makeHeaders({
+      name: "Authentication-Results",
+      value: "garbage; not-a-real-header; @@##$$",
+    });
+
+    const result = parseAuthenticationResults(headers);
+    expect(result).not.toBeNull();
+    // All should be unknown since nothing could be parsed
+    expect(result!.spf.result).toBe("unknown");
+    expect(result!.dkim.result).toBe("unknown");
+    expect(result!.dmarc.result).toBe("unknown");
+    expect(result!.aggregate).toBe("unknown");
+  });
+
+  it("should return aggregate pass when DMARC passes alone", () => {
+    const headers = makeHeaders({
+      name: "Authentication-Results",
+      value: "mx.google.com; dmarc=pass (p=NONE)",
+    });
+
+    const result = parseAuthenticationResults(headers);
+    expect(result).not.toBeNull();
+    expect(result!.dmarc.result).toBe("pass");
+    expect(result!.aggregate).toBe("pass");
+  });
+
+  it("should handle headers with extra whitespace and newlines", () => {
+    const headers = makeHeaders({
+      name: "Authentication-Results",
+      value:
+        "mx.google.com;\r\n   spf=pass (google.com);\r\n   dkim=pass\r\n   header.d=example.com;\r\n   dmarc=pass (p=REJECT)",
+    });
+
+    const result = parseAuthenticationResults(headers);
+    expect(result).not.toBeNull();
+    expect(result!.spf.result).toBe("pass");
+    expect(result!.dkim.result).toBe("pass");
+    expect(result!.dmarc.result).toBe("pass");
+    expect(result!.aggregate).toBe("pass");
+  });
+
+  it("should extract parenthetical detail for SPF", () => {
+    const headers = makeHeaders({
+      name: "Authentication-Results",
+      value:
+        "mx.google.com; spf=pass (domain of sender@example.com designates 1.2.3.4); dkim=pass; dmarc=pass",
+    });
+
+    const result = parseAuthenticationResults(headers);
+    expect(result).not.toBeNull();
+    expect(result!.spf.detail).toContain("domain of sender@example.com");
+  });
+
+  it("should prefer Authentication-Results over ARC-Authentication-Results", () => {
+    const headers = makeHeaders(
+      {
+        name: "Authentication-Results",
+        value: "mx.google.com; spf=pass; dkim=pass; dmarc=pass",
+      },
+      {
+        name: "ARC-Authentication-Results",
+        value: "i=1; mx.google.com; spf=fail; dkim=fail; dmarc=fail",
+      },
+    );
+
+    const result = parseAuthenticationResults(headers);
+    expect(result).not.toBeNull();
+    expect(result!.aggregate).toBe("pass");
+  });
+
+  it("should return aggregate pass when SPF and DKIM both pass but DMARC is unknown", () => {
+    const headers = makeHeaders({
+      name: "Authentication-Results",
+      value: "mx.google.com; spf=pass; dkim=pass",
+    });
+
+    const result = parseAuthenticationResults(headers);
+    expect(result).not.toBeNull();
+    expect(result!.spf.result).toBe("pass");
+    expect(result!.dkim.result).toBe("pass");
+    expect(result!.dmarc.result).toBe("unknown");
+    expect(result!.aggregate).toBe("pass");
+  });
+
+  it("should handle Received-SPF with softfail result", () => {
+    const headers = makeHeaders({
+      name: "Received-SPF",
+      value: "softfail (transitioning domain)",
+    });
+
+    const result = parseAuthenticationResults(headers);
+    expect(result).not.toBeNull();
+    expect(result!.spf.result).toBe("softfail");
+    expect(result!.spf.detail).toBe("transitioning domain");
+  });
+});

--- a/src/services/gmail/authParser.ts
+++ b/src/services/gmail/authParser.ts
@@ -1,0 +1,170 @@
+export interface AuthVerdict {
+  result: string;
+  detail: string | null;
+}
+
+export interface AuthResult {
+  spf: AuthVerdict;
+  dkim: AuthVerdict;
+  dmarc: AuthVerdict;
+  aggregate: "pass" | "warning" | "fail" | "unknown";
+}
+
+/**
+ * Parse a single auth mechanism result from the Authentication-Results header value.
+ * Matches patterns like: spf=pass (detail text)
+ */
+function parseVerdict(headerValue: string, mechanism: string): AuthVerdict | null {
+  // Match mechanism=result, optionally followed by parenthetical details
+  // Use case-insensitive matching and allow whitespace/newlines
+  const normalized = headerValue.replace(/\r?\n\s*/g, " ");
+  const regex = new RegExp(
+    `${mechanism}\\s*=\\s*(\\w+)(?:\\s*\\(([^)]+)\\))?`,
+    "i",
+  );
+  const match = normalized.match(regex);
+  if (!match) return null;
+  return {
+    result: match[1]!.toLowerCase(),
+    detail: match[2]?.trim() ?? null,
+  };
+}
+
+/**
+ * Parse SPF result from Received-SPF header as a fallback.
+ * Format: "pass (detail text) ..." or just "pass ..."
+ */
+function parseReceivedSpf(headerValue: string): AuthVerdict | null {
+  const normalized = headerValue.replace(/\r?\n\s*/g, " ").trim();
+  const match = normalized.match(/^(\w+)(?:\s*\(([^)]+)\))?/i);
+  if (!match) return null;
+  return {
+    result: match[1]!.toLowerCase(),
+    detail: match[2]?.trim() ?? null,
+  };
+}
+
+function unknownVerdict(): AuthVerdict {
+  return { result: "unknown", detail: null };
+}
+
+/**
+ * Compute the aggregate verdict from individual results.
+ *
+ * - pass: DMARC passes, OR all three pass
+ * - fail: DMARC fails, OR both SPF and DKIM fail
+ * - warning: mixed results (some pass, some don't)
+ * - unknown: no meaningful data
+ */
+function computeAggregate(
+  spf: AuthVerdict,
+  dkim: AuthVerdict,
+  dmarc: AuthVerdict,
+): "pass" | "warning" | "fail" | "unknown" {
+  const dmarcResult = dmarc.result;
+  const spfResult = spf.result;
+  const dkimResult = dkim.result;
+
+  // If DMARC passes, aggregate is pass
+  if (dmarcResult === "pass") return "pass";
+
+  // If DMARC explicitly fails, aggregate is fail
+  if (dmarcResult === "fail") return "fail";
+
+  // If both SPF and DKIM fail, aggregate is fail
+  const spfFailed = spfResult === "fail" || spfResult === "hardfail";
+  const dkimFailed = dkimResult === "fail" || dkimResult === "hardfail";
+  if (spfFailed && dkimFailed) return "fail";
+
+  // If all are unknown, aggregate is unknown
+  if (
+    spfResult === "unknown" &&
+    dkimResult === "unknown" &&
+    dmarcResult === "unknown"
+  ) {
+    return "unknown";
+  }
+
+  // If all known results pass
+  const spfPassed = spfResult === "pass";
+  const dkimPassed = dkimResult === "pass";
+  const dmarcUnknown = dmarcResult === "unknown";
+
+  if (spfPassed && dkimPassed && dmarcUnknown) return "pass";
+
+  // Mixed results
+  return "warning";
+}
+
+/**
+ * Parse email authentication results from message headers.
+ *
+ * Tries these headers in order:
+ * 1. Authentication-Results
+ * 2. ARC-Authentication-Results
+ * 3. Received-SPF (SPF only fallback)
+ *
+ * Returns null if no authentication headers are found at all.
+ */
+export function parseAuthenticationResults(
+  headers: { name: string; value: string }[],
+): AuthResult | null {
+  // Try Authentication-Results first
+  const authResultsHeader = headers.find(
+    (h) => h.name.toLowerCase() === "authentication-results",
+  );
+
+  // Fallback to ARC-Authentication-Results
+  const arcHeader =
+    authResultsHeader ??
+    headers.find(
+      (h) => h.name.toLowerCase() === "arc-authentication-results",
+    );
+
+  // Fallback to Received-SPF for SPF only
+  const receivedSpfHeader = headers.find(
+    (h) => h.name.toLowerCase() === "received-spf",
+  );
+
+  // No auth headers at all
+  if (!arcHeader && !receivedSpfHeader) return null;
+
+  let spf: AuthVerdict = unknownVerdict();
+  let dkim: AuthVerdict = unknownVerdict();
+  let dmarc: AuthVerdict = unknownVerdict();
+
+  if (arcHeader) {
+    const headerValue = arcHeader.value;
+
+    spf = parseVerdict(headerValue, "spf") ?? unknownVerdict();
+
+    // For DKIM, there might be multiple results. If any passes, consider it a pass.
+    const normalized = headerValue.replace(/\r?\n\s*/g, " ");
+    const dkimMatches = [...normalized.matchAll(/dkim\s*=\s*(\w+)(?:\s*\(([^)]+)\))?/gi)];
+    if (dkimMatches.length > 0) {
+      const hasPass = dkimMatches.some((m) => m[1]!.toLowerCase() === "pass");
+      if (hasPass) {
+        const passMatch = dkimMatches.find((m) => m[1]!.toLowerCase() === "pass");
+        dkim = {
+          result: "pass",
+          detail: passMatch?.[2]?.trim() ?? null,
+        };
+      } else {
+        // Use the first result
+        dkim = {
+          result: dkimMatches[0]![1]!.toLowerCase(),
+          detail: dkimMatches[0]![2]?.trim() ?? null,
+        };
+      }
+    }
+
+    dmarc = parseVerdict(headerValue, "dmarc") ?? unknownVerdict();
+  } else if (receivedSpfHeader) {
+    // Only SPF info available
+    spf = parseReceivedSpf(receivedSpfHeader.value) ?? unknownVerdict();
+  }
+
+  const aggregate = computeAggregate(spf, dkim, dmarc);
+
+  return { spf, dkim, dmarc, aggregate };
+}

--- a/src/services/gmail/messageParser.ts
+++ b/src/services/gmail/messageParser.ts
@@ -1,4 +1,5 @@
 import type { GmailMessage, GmailMessagePart, GmailHeader } from "./client";
+import { parseAuthenticationResults } from "./authParser";
 
 export interface ParsedAttachment {
   filename: string;
@@ -32,6 +33,7 @@ export interface ParsedMessage {
   attachments: ParsedAttachment[];
   listUnsubscribe: string | null;
   listUnsubscribePost: string | null;
+  authResults: string | null;
 }
 
 export function parseGmailMessage(msg: GmailMessage): ParsedMessage {
@@ -42,6 +44,7 @@ export function parseGmailMessage(msg: GmailMessage): ParsedMessage {
   const bodyHtml = extractBody(msg.payload, "text/html");
   const bodyText = extractBody(msg.payload, "text/plain");
   const attachments = extractAttachments(msg.payload);
+  const authResult = parseAuthenticationResults(headers);
 
   return {
     id: msg.id,
@@ -66,6 +69,7 @@ export function parseGmailMessage(msg: GmailMessage): ParsedMessage {
     attachments,
     listUnsubscribe: getHeader(headers, "List-Unsubscribe"),
     listUnsubscribePost: getHeader(headers, "List-Unsubscribe-Post"),
+    authResults: authResult ? JSON.stringify(authResult) : null,
   };
 }
 

--- a/src/services/gmail/sync.ts
+++ b/src/services/gmail/sync.ts
@@ -130,6 +130,7 @@ async function processAndStoreThread(
       internalDate: parsed.internalDate,
       listUnsubscribe: parsed.listUnsubscribe,
       listUnsubscribePost: parsed.listUnsubscribePost,
+      authResults: parsed.authResults,
     });
 
     for (const att of parsed.attachments) {


### PR DESCRIPTION
## Summary
- Parses Authentication-Results headers during sync (with ARC and Received-SPF fallbacks)
- Stores parsed auth results as JSON in `messages.auth_results` column
- Shield badge (pass/warning/fail/unknown) next to sender name on every message
- Red warning banner for messages that fail authentication checks
- Tooltip with per-protocol SPF/DKIM/DMARC details

## Test plan
- [ ] Re-sync to populate auth_results for existing messages
- [ ] Verify green shield badge on authenticated messages
- [ ] Verify red shield + warning banner on failed auth messages
- [ ] Dismiss warning banner and verify it stays dismissed
- [ ] Hover over badge to see detailed tooltip
- [ ] 24 new tests passing (authParser, AuthBadge, AuthWarningBanner)

🤖 Generated with [Claude Code](https://claude.com/claude-code)