### PR TITLE
Add expandable composer: full-page mode and pop-out window

### DIFF
--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -5,7 +5,8 @@
   "windows": [
     "main",
     "splashscreen",
-    "thread-*"
+    "thread-*",
+    "compose-*"
   ],
   "permissions": [
     "core:default",

--- a/src/ComposerWindow.tsx
+++ b/src/ComposerWindow.tsx
@@ -1,0 +1,193 @@
+import { useEffect, useState } from "react";
+import { Composer } from "./components/composer/Composer";
+import { UndoSendToast } from "./components/composer/UndoSendToast";
+import { useAccountStore } from "./stores/accountStore";
+import { useComposerStore } from "./stores/composerStore";
+import { useUIStore } from "./stores/uiStore";
+import { runMigrations } from "./services/db/migrations";
+import { getAllAccounts } from "./services/db/accounts";
+import { getSetting } from "./services/db/settings";
+import { initializeClients } from "./services/gmail/tokenManager";
+import { getThemeById, COLOR_THEMES } from "./constants/themes";
+import type { ColorThemeId } from "./constants/themes";
+import type { ComposerMode } from "./stores/composerStore";
+
+export default function ComposerWindow() {
+  const { setTheme, setFontScale, setColorTheme } = useUIStore();
+  const { setAccounts } = useAccountStore();
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    const params = new URLSearchParams(window.location.search);
+
+    async function init() {
+      try {
+        await runMigrations();
+
+        // Restore theme
+        const savedTheme = await getSetting("theme");
+        if (savedTheme === "light" || savedTheme === "dark" || savedTheme === "system") {
+          setTheme(savedTheme);
+        }
+
+        // Restore font scale
+        const savedFontScale = await getSetting("font_size");
+        if (savedFontScale === "small" || savedFontScale === "default" || savedFontScale === "large" || savedFontScale === "xlarge") {
+          setFontScale(savedFontScale);
+        }
+
+        // Restore color theme
+        const savedColorTheme = await getSetting("color_theme");
+        if (savedColorTheme && COLOR_THEMES.some((t) => t.id === savedColorTheme)) {
+          setColorTheme(savedColorTheme as ColorThemeId);
+        }
+
+        // Load accounts into store
+        const dbAccounts = await getAllAccounts();
+        const mapped = dbAccounts.map((a) => ({
+          id: a.id,
+          email: a.email,
+          displayName: a.display_name,
+          avatarUrl: a.avatar_url,
+          isActive: a.is_active === 1,
+        }));
+        setAccounts(mapped);
+
+        // Initialize Gmail clients
+        await initializeClients();
+
+        // Parse composer state from URL params
+        const mode = (params.get("mode") as ComposerMode) ?? "new";
+        const to = params.get("to")?.split(",").filter(Boolean) ?? [];
+        const cc = params.get("cc")?.split(",").filter(Boolean) ?? [];
+        const bcc = params.get("bcc")?.split(",").filter(Boolean) ?? [];
+        const subject = params.get("subject") ?? "";
+        const threadId = params.get("threadId") ?? null;
+        const inReplyToMessageId = params.get("inReplyToMessageId") ?? null;
+        const draftId = params.get("draftId") ?? null;
+        const fromEmail = params.get("fromEmail");
+
+        // Decode base64 body
+        let bodyHtml = "";
+        const bodyParam = params.get("body");
+        if (bodyParam) {
+          try {
+            bodyHtml = decodeURIComponent(escape(atob(bodyParam)));
+          } catch {
+            bodyHtml = "";
+          }
+        }
+
+        // Open composer with parsed state
+        useComposerStore.getState().openComposer({
+          mode,
+          to,
+          cc,
+          bcc,
+          subject,
+          bodyHtml,
+          threadId,
+          inReplyToMessageId,
+          draftId,
+        });
+
+        // Set fromEmail and force fullpage mode
+        if (fromEmail) {
+          useComposerStore.getState().setFromEmail(fromEmail);
+        }
+        useComposerStore.getState().setViewMode("fullpage");
+      } catch (err) {
+        console.error("Failed to initialize composer window:", err);
+        setError("Failed to load composer");
+      }
+      setLoading(false);
+    }
+
+    init();
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- store setters are stable references
+  }, []);
+
+  // Sync theme class to <html>
+  const theme = useUIStore((s) => s.theme);
+  useEffect(() => {
+    const root = document.documentElement;
+    if (theme === "dark") {
+      root.classList.add("dark");
+    } else if (theme === "light") {
+      root.classList.remove("dark");
+    } else {
+      const mq = window.matchMedia("(prefers-color-scheme: dark)");
+      const apply = () => {
+        if (mq.matches) root.classList.add("dark");
+        else root.classList.remove("dark");
+      };
+      apply();
+      mq.addEventListener("change", apply);
+      return () => mq.removeEventListener("change", apply);
+    }
+  }, [theme]);
+
+  // Sync font-scale class to <html>
+  const fontScale = useUIStore((s) => s.fontScale);
+  useEffect(() => {
+    const root = document.documentElement;
+    root.classList.remove("font-scale-small", "font-scale-default", "font-scale-large", "font-scale-xlarge");
+    root.classList.add(`font-scale-${fontScale}`);
+  }, [fontScale]);
+
+  // Apply color theme CSS custom properties to <html>
+  const colorTheme = useUIStore((s) => s.colorTheme);
+  useEffect(() => {
+    const root = document.documentElement;
+    const props = ["--color-accent", "--color-accent-hover", "--color-accent-light", "--color-bg-selected", "--color-sidebar-active"];
+
+    const apply = () => {
+      if (colorTheme === "indigo") {
+        for (const p of props) root.style.removeProperty(p);
+        return;
+      }
+      const themeData = getThemeById(colorTheme);
+      const isDark =
+        theme === "dark" ||
+        (theme === "system" && window.matchMedia("(prefers-color-scheme: dark)").matches);
+      const colors = isDark ? themeData.dark : themeData.light;
+      root.style.setProperty("--color-accent", colors.accent);
+      root.style.setProperty("--color-accent-hover", colors.accentHover);
+      root.style.setProperty("--color-accent-light", colors.accentLight);
+      root.style.setProperty("--color-bg-selected", colors.bgSelected);
+      root.style.setProperty("--color-sidebar-active", colors.sidebarActive);
+    };
+
+    apply();
+
+    if (theme === "system") {
+      const mq = window.matchMedia("(prefers-color-scheme: dark)");
+      mq.addEventListener("change", apply);
+      return () => mq.removeEventListener("change", apply);
+    }
+  }, [colorTheme, theme]);
+
+  if (loading) {
+    return (
+      <div className="flex h-screen items-center justify-center bg-bg-primary text-text-secondary">
+        <span className="text-sm">Loading composer...</span>
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="flex h-screen items-center justify-center bg-bg-primary text-text-secondary">
+        <span className="text-sm">{error}</span>
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex flex-col h-screen bg-bg-primary text-text-primary">
+      <Composer />
+      <UndoSendToast />
+    </div>
+  );
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -2,13 +2,21 @@ import { StrictMode } from "react";
 import { createRoot } from "react-dom/client";
 import App from "./App";
 import ThreadWindow from "./ThreadWindow";
+import ComposerWindow from "./ComposerWindow";
 import "./styles/globals.css";
 
 const params = new URLSearchParams(window.location.search);
 const isThreadWindow = params.has("thread") && params.has("account");
+const isComposerWindow = params.has("compose");
+
+function Root() {
+  if (isThreadWindow) return <ThreadWindow />;
+  if (isComposerWindow) return <ComposerWindow />;
+  return <App />;
+}
 
 createRoot(document.getElementById("root")!).render(
   <StrictMode>
-    {isThreadWindow ? <ThreadWindow /> : <App />}
+    <Root />
   </StrictMode>,
 );

--- a/src/stores/composerStore.test.ts
+++ b/src/stores/composerStore.test.ts
@@ -20,6 +20,7 @@ describe("composerStore", () => {
       attachments: [],
       lastSavedAt: null,
       isSaving: false,
+      viewMode: "modal",
       signatureHtml: "",
       signatureId: null,
     });
@@ -212,5 +213,29 @@ describe("composerStore", () => {
 
     useComposerStore.getState().setSignatureId("sig-1");
     expect(useComposerStore.getState().signatureId).toBe("sig-1");
+  });
+
+  it("viewMode defaults to modal", () => {
+    expect(useComposerStore.getState().viewMode).toBe("modal");
+  });
+
+  it("setViewMode updates viewMode", () => {
+    useComposerStore.getState().setViewMode("fullpage");
+    expect(useComposerStore.getState().viewMode).toBe("fullpage");
+
+    useComposerStore.getState().setViewMode("modal");
+    expect(useComposerStore.getState().viewMode).toBe("modal");
+  });
+
+  it("closeComposer resets viewMode to modal", () => {
+    useComposerStore.getState().setViewMode("fullpage");
+    useComposerStore.getState().closeComposer();
+    expect(useComposerStore.getState().viewMode).toBe("modal");
+  });
+
+  it("openComposer resets viewMode to modal", () => {
+    useComposerStore.getState().setViewMode("fullpage");
+    useComposerStore.getState().openComposer();
+    expect(useComposerStore.getState().viewMode).toBe("modal");
   });
 });

--- a/src/stores/composerStore.ts
+++ b/src/stores/composerStore.ts
@@ -1,6 +1,7 @@
 import { create } from "zustand";
 
 export type ComposerMode = "new" | "reply" | "replyAll" | "forward";
+export type ComposerViewMode = "modal" | "fullpage";
 
 export interface ComposerAttachment {
   id: string;
@@ -29,6 +30,7 @@ export interface ComposerState {
   lastSavedAt: number | null;
   isSaving: boolean;
   fromEmail: string | null;
+  viewMode: ComposerViewMode;
   signatureHtml: string;
   signatureId: string | null;
 
@@ -59,6 +61,7 @@ export interface ComposerState {
   setLastSavedAt: (ts: number | null) => void;
   setIsSaving: (saving: boolean) => void;
   setFromEmail: (email: string | null) => void;
+  setViewMode: (mode: ComposerViewMode) => void;
   setSignatureHtml: (html: string) => void;
   setSignatureId: (id: string | null) => void;
 }
@@ -78,6 +81,7 @@ export const useComposerStore = create<ComposerState>((set) => ({
   undoSendTimer: null,
   undoSendVisible: false,
   attachments: [],
+  viewMode: "modal",
   fromEmail: null,
   lastSavedAt: null,
   isSaving: false,
@@ -97,6 +101,7 @@ export const useComposerStore = create<ComposerState>((set) => ({
       inReplyToMessageId: opts?.inReplyToMessageId ?? null,
       showCcBcc: (opts?.cc?.length ?? 0) > 0 || (opts?.bcc?.length ?? 0) > 0,
       draftId: opts?.draftId ?? null,
+      viewMode: "modal",
       fromEmail: null,
       attachments: [],
       lastSavedAt: null,
@@ -117,6 +122,7 @@ export const useComposerStore = create<ComposerState>((set) => ({
       inReplyToMessageId: null,
       showCcBcc: false,
       draftId: null,
+      viewMode: "modal",
       fromEmail: null,
       attachments: [],
       lastSavedAt: null,
@@ -143,6 +149,7 @@ export const useComposerStore = create<ComposerState>((set) => ({
   setLastSavedAt: (lastSavedAt) => set({ lastSavedAt }),
   setIsSaving: (isSaving) => set({ isSaving }),
   setFromEmail: (fromEmail) => set({ fromEmail }),
+  setViewMode: (viewMode) => set({ viewMode }),
   setSignatureHtml: (signatureHtml) => set({ signatureHtml }),
   setSignatureId: (signatureId) => set({ signatureId }),
 }));


### PR DESCRIPTION
## Summary
- Add full-page expand/collapse toggle to the composer (fills the viewport with wider max-width, no backdrop)
- Add pop-out button that opens the composer in a separate OS window via Tauri WebviewWindow
- New `ComposerWindow` entry point for pop-out windows with full theme/account initialization
- `viewMode` state in composerStore (`modal` | `fullpage`), reset on open/close

## Test plan
- [x] All 581 tests pass (`npm run test`)
- [x] Type-check passes (`npx tsc --noEmit`)
- [ ] Manual: open composer → expand button fills page → collapse returns to modal
- [ ] Manual: pop-out button opens new OS window with composer state preserved
- [ ] Manual: sending from pop-out window works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)