### PR TITLE
Harden repo: CODEOWNERS + manual release

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @avihaymenahem

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,8 +1,7 @@
 name: Build & Release
 
 on:
-  push:
-    branches: [main]
+  workflow_dispatch:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}


### PR DESCRIPTION
## Summary
- Add `.github/CODEOWNERS` — auto-requests @avihaymenahem as reviewer on all PRs
- Change release workflow trigger from `push to main` to `workflow_dispatch` (manual only)

## Test plan
- [x] Verify branch protection blocks direct pushes (confirmed — this PR exists because of it)
- [ ] Verify CODEOWNERS auto-assigns reviewer
- [ ] Verify release workflow shows "Run workflow" button in Actions tab

🤖 Generated with [Claude Code](https://claude.com/claude-code)