### PR TITLE
Fix AI provider badges overflow on mobile

### DIFF
--- a/landing/src/components/AiSection.tsx
+++ b/landing/src/components/AiSection.tsx
@@ -102,7 +102,7 @@ export function AiSection() {
 
         {/* AI Provider Badges */}
         <motion.div
-          className="flex items-center justify-center gap-4 mb-16"
+          className="flex items-center justify-center gap-3 md:gap-4 mb-16 flex-wrap"
           initial={{ opacity: 0, y: 15 }}
           whileInView={{ opacity: 1, y: 0 }}
           viewport={{ once: true }}


### PR DESCRIPTION
Add flex-wrap to the AI provider badges container so badges wrap
to the next line on narrow viewports instead of causing a horizontal
scrollbar. Also slightly reduce gap on mobile (gap-3 -> gap-4 at md).

https://claude.ai/code/session_01MyhNEAbuv1M57Pn2YdTYox