### PR TITLE
Add keyboard shortcut for Ask Inbox

### DIFF
--- a/src/constants/shortcuts.ts
+++ b/src/constants/shortcuts.ts
@@ -44,6 +44,7 @@ export const SHORTCUTS: ShortcutCategory[] = [
     { id: "app.commandPalette", keys: "/", desc: "Command palette" },
     { id: "app.toggleSidebar", keys: "Ctrl+Shift+E", desc: "Toggle sidebar" },
     { id: "app.send", keys: "Ctrl+Enter", desc: "Send email" },
+    { id: "app.askInbox", keys: "i", desc: "Ask AI about your inbox" },
     { id: "app.help", keys: "?", desc: "Show keyboard shortcuts" },
   ]},
 ];

--- a/src/hooks/useKeyboardShortcuts.test.ts
+++ b/src/hooks/useKeyboardShortcuts.test.ts
@@ -1,0 +1,124 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// Mock all external dependencies before importing the hook
+vi.mock("@/stores/uiStore", () => ({
+  useUIStore: { getState: () => ({ inboxViewMode: "unified", toggleSidebar: vi.fn() }) },
+}));
+vi.mock("@/stores/threadStore", () => ({
+  useThreadStore: {
+    getState: () => ({
+      threads: [],
+      selectedThreadIds: new Set(),
+      removeThread: vi.fn(),
+      removeThreads: vi.fn(),
+      updateThread: vi.fn(),
+      clearMultiSelect: vi.fn(),
+      selectAll: vi.fn(),
+      selectAllFromHere: vi.fn(),
+    }),
+  },
+}));
+vi.mock("@/stores/composerStore", () => ({
+  useComposerStore: { getState: () => ({ isOpen: false, openComposer: vi.fn(), closeComposer: vi.fn() }) },
+}));
+vi.mock("@/stores/accountStore", () => ({
+  useAccountStore: { getState: () => ({ activeAccountId: null }) },
+}));
+vi.mock("@/stores/shortcutStore", () => ({
+  useShortcutStore: {
+    getState: () => ({
+      keyMap: {
+        "app.askInbox": "i",
+        "app.commandPalette": "/",
+        "app.toggleSidebar": "Ctrl+Shift+E",
+        "app.help": "?",
+      },
+    }),
+  },
+}));
+vi.mock("@/stores/contextMenuStore", () => ({
+  useContextMenuStore: { getState: () => ({ menuType: null, closeMenu: vi.fn() }) },
+}));
+vi.mock("@/router/navigate", () => ({
+  navigateToLabel: vi.fn(),
+  navigateToThread: vi.fn(),
+  navigateBack: vi.fn(),
+  getActiveLabel: () => "inbox",
+  getSelectedThreadId: () => null,
+}));
+vi.mock("@/services/gmail/tokenManager", () => ({
+  getGmailClient: vi.fn(),
+}));
+vi.mock("@/services/db/threads", () => ({
+  deleteThread: vi.fn(),
+  pinThread: vi.fn(),
+  unpinThread: vi.fn(),
+  muteThread: vi.fn(),
+  unmuteThread: vi.fn(),
+}));
+vi.mock("@/services/gmail/draftDeletion", () => ({
+  deleteDraftsForThread: vi.fn(),
+}));
+vi.mock("@/services/db/messages", () => ({
+  getMessagesForThread: vi.fn(),
+}));
+vi.mock("@/components/email/MessageItem", () => ({
+  parseUnsubscribeUrl: vi.fn(),
+}));
+vi.mock("@tauri-apps/plugin-opener", () => ({
+  openUrl: vi.fn(),
+}));
+
+import { renderHook } from "@testing-library/react";
+import { useKeyboardShortcuts } from "./useKeyboardShortcuts";
+
+describe("useKeyboardShortcuts", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("dispatches velo-toggle-ask-inbox when 'i' is pressed", () => {
+    renderHook(() => useKeyboardShortcuts());
+
+    const listener = vi.fn();
+    window.addEventListener("velo-toggle-ask-inbox", listener);
+
+    window.dispatchEvent(
+      new KeyboardEvent("keydown", { key: "i", bubbles: true }),
+    );
+
+    expect(listener).toHaveBeenCalledTimes(1);
+
+    window.removeEventListener("velo-toggle-ask-inbox", listener);
+  });
+
+  it("dispatches velo-toggle-command-palette when '/' is pressed", () => {
+    renderHook(() => useKeyboardShortcuts());
+
+    const listener = vi.fn();
+    window.addEventListener("velo-toggle-command-palette", listener);
+
+    window.dispatchEvent(
+      new KeyboardEvent("keydown", { key: "/", bubbles: true }),
+    );
+
+    expect(listener).toHaveBeenCalledTimes(1);
+
+    window.removeEventListener("velo-toggle-command-palette", listener);
+  });
+
+  it("dispatches velo-toggle-shortcuts-help when '?' is pressed", () => {
+    renderHook(() => useKeyboardShortcuts());
+
+    const listener = vi.fn();
+    window.addEventListener("velo-toggle-shortcuts-help", listener);
+
+    window.dispatchEvent(
+      new KeyboardEvent("keydown", { key: "?", shiftKey: true, bubbles: true }),
+    );
+
+    expect(listener).toHaveBeenCalledTimes(1);
+
+    window.removeEventListener("velo-toggle-shortcuts-help", listener);
+  });
+});

--- a/src/hooks/useKeyboardShortcuts.ts
+++ b/src/hooks/useKeyboardShortcuts.ts
@@ -484,6 +484,9 @@ async function executeAction(actionId: string): Promise<void> {
     case "app.toggleSidebar":
       useUIStore.getState().toggleSidebar();
       break;
+    case "app.askInbox":
+      window.dispatchEvent(new Event("velo-toggle-ask-inbox"));
+      break;
     case "app.help":
       window.dispatchEvent(new Event("velo-toggle-shortcuts-help"));
       break;


### PR DESCRIPTION
## Summary
- Adds `i` keyboard shortcut to toggle the Ask Inbox AI panel
- Registers the shortcut in the shortcut definitions (`shortcuts.ts`) and the handler (`useKeyboardShortcuts.ts`)
- Includes unit tests for the new shortcut

## Test plan
- [x] Unit tests added for the Ask Inbox shortcut action
- [ ] Verify pressing `i` opens the Ask Inbox panel
- [ ] Verify the shortcut appears in the shortcuts help dialog (`?`)
- [ ] Verify the shortcut is customizable via settings

🤖 Generated with [Claude Code](https://claude.com/claude-code)