### PR TITLE
Fix client secret missing in OAuth token exchange

### DIFF
--- a/src/components/accounts/SetupClientId.test.tsx
+++ b/src/components/accounts/SetupClientId.test.tsx
@@ -1,0 +1,70 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { SetupClientId } from "./SetupClientId";
+
+vi.mock("@/services/db/settings", () => ({
+  setSetting: vi.fn().mockResolvedValue(undefined),
+  setSecureSetting: vi.fn().mockResolvedValue(undefined),
+}));
+
+describe("SetupClientId", () => {
+  it("disables Save button when both fields are empty", () => {
+    render(<SetupClientId onComplete={() => {}} onCancel={() => {}} />);
+    const saveButton = screen.getByText("Save & Continue");
+    expect(saveButton).toBeDisabled();
+  });
+
+  it("disables Save button when only client ID is provided", () => {
+    render(<SetupClientId onComplete={() => {}} onCancel={() => {}} />);
+    const inputs = screen.getAllByRole("textbox");
+    // Client ID is the text input; secret is password (not a textbox role)
+    const clientIdInput = screen.getByPlaceholderText(
+      "Paste your Client ID here...",
+    );
+    fireEvent.change(clientIdInput, { target: { value: "my-client-id" } });
+
+    const saveButton = screen.getByText("Save & Continue");
+    expect(saveButton).toBeDisabled();
+  });
+
+  it("disables Save button when only client secret is provided", () => {
+    render(<SetupClientId onComplete={() => {}} onCancel={() => {}} />);
+    const secretInput = screen.getByPlaceholderText(
+      "Paste your Client Secret here...",
+    );
+    fireEvent.change(secretInput, { target: { value: "my-secret" } });
+
+    const saveButton = screen.getByText("Save & Continue");
+    expect(saveButton).toBeDisabled();
+  });
+
+  it("enables Save button when both fields are filled", () => {
+    render(<SetupClientId onComplete={() => {}} onCancel={() => {}} />);
+    const clientIdInput = screen.getByPlaceholderText(
+      "Paste your Client ID here...",
+    );
+    const secretInput = screen.getByPlaceholderText(
+      "Paste your Client Secret here...",
+    );
+
+    fireEvent.change(clientIdInput, { target: { value: "my-client-id" } });
+    fireEvent.change(secretInput, { target: { value: "my-secret" } });
+
+    const saveButton = screen.getByText("Save & Continue");
+    expect(saveButton).not.toBeDisabled();
+  });
+
+  it("shows helper text about client secret being required", () => {
+    render(<SetupClientId onComplete={() => {}} onCancel={() => {}} />);
+    expect(
+      screen.getByText("Required for Web application credentials"),
+    ).toBeInTheDocument();
+  });
+
+  it("calls onCancel when Cancel button is clicked", () => {
+    const onCancel = vi.fn();
+    render(<SetupClientId onComplete={() => {}} onCancel={onCancel} />);
+    fireEvent.click(screen.getByText("Cancel"));
+    expect(onCancel).toHaveBeenCalled();
+  });
+});

--- a/src/components/accounts/SetupClientId.tsx
+++ b/src/components/accounts/SetupClientId.tsx
@@ -14,15 +14,13 @@ export function SetupClientId({ onComplete, onCancel }: SetupClientIdProps) {
 
   const handleSave = async () => {
     const trimmedId = clientId.trim();
-    if (!trimmedId) return;
+    const trimmedSecret = clientSecret.trim();
+    if (!trimmedId || !trimmedSecret) return;
 
     setSaving(true);
     try {
       await setSetting("google_client_id", trimmedId);
-      const trimmedSecret = clientSecret.trim();
-      if (trimmedSecret) {
-        await setSecureSetting("google_client_secret", trimmedSecret);
-      }
+      await setSecureSetting("google_client_secret", trimmedSecret);
       onComplete();
     } catch {
       setSaving(false);
@@ -66,8 +64,11 @@ export function SetupClientId({ onComplete, onCancel }: SetupClientIdProps) {
           value={clientSecret}
           onChange={(e) => setClientSecret(e.target.value)}
           placeholder="Paste your Client Secret here..."
-          className="w-full px-3 py-2 bg-bg-secondary border border-border-primary rounded-lg text-sm mb-4 outline-none focus:border-accent"
+          className="w-full px-3 py-2 bg-bg-secondary border border-border-primary rounded-lg text-sm mb-1 outline-none focus:border-accent"
         />
+        <p className="text-text-tertiary text-xs mb-4">
+          Required for Web application credentials
+        </p>
 
         <div className="flex gap-3 justify-end">
           <button
@@ -78,7 +79,7 @@ export function SetupClientId({ onComplete, onCancel }: SetupClientIdProps) {
           </button>
           <button
             onClick={handleSave}
-            disabled={!clientId.trim() || saving}
+            disabled={!clientId.trim() || !clientSecret.trim() || saving}
             className="px-4 py-2 text-sm bg-accent text-white rounded-lg hover:bg-accent-hover transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
           >
             {saving ? "Saving..." : "Save & Continue"}

--- a/src/services/gmail/auth.test.ts
+++ b/src/services/gmail/auth.test.ts
@@ -1,0 +1,16 @@
+import { describe, it, expect } from "vitest";
+import { startOAuthFlow } from "./auth";
+
+describe("startOAuthFlow", () => {
+  it("throws when client secret is undefined", async () => {
+    await expect(startOAuthFlow("client-id")).rejects.toThrow(
+      "Client Secret is not configured. Go to Settings → Google API to add it.",
+    );
+  });
+
+  it("throws when client secret is empty string", async () => {
+    await expect(startOAuthFlow("client-id", "")).rejects.toThrow(
+      "Client Secret is not configured",
+    );
+  });
+});

--- a/src/services/gmail/auth.ts
+++ b/src/services/gmail/auth.ts
@@ -71,6 +71,12 @@ export async function startOAuthFlow(
   clientId: string,
   clientSecret?: string,
 ): Promise<{ tokens: TokenResponse; userInfo: UserInfo }> {
+  if (!clientSecret) {
+    throw new Error(
+      "Client Secret is not configured. Go to Settings → Google API to add it.",
+    );
+  }
+
   const codeVerifier = generateCodeVerifier();
   const codeChallenge = await generateCodeChallenge(codeVerifier);
 


### PR DESCRIPTION
## Summary
- Make client secret **required** in `SetupClientId` — Save button is disabled until both Client ID and Client Secret are provided
- Add early validation in `startOAuthFlow()` that throws a clear error if client secret is missing
- Add tests for both the UI validation and the OAuth flow guard

Closes #24

## Test plan
- [x] All 975 existing tests pass, no regressions
- [x] New `SetupClientId.test.tsx` (6 tests) — verifies button disabled states and helper text
- [x] New `auth.test.ts` (2 tests) — verifies early throw for missing/empty client secret

🤖 Generated with [Claude Code](https://claude.com/claude-code)