### PR TITLE
Add optional IMAP/SMTP username field

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -161,9 +161,9 @@ Vitest + jsdom. Setup file: `src/test/setup.ts` (imports `@testing-library/jest-
 
 ## Database
 
-SQLite via Tauri SQL plugin. 14 migrations (version-tracked in `_migrations` table). Custom `splitStatements()` handles BEGIN...END blocks in triggers.
+SQLite via Tauri SQL plugin. 16 migrations (version-tracked in `_migrations` table). Custom `splitStatements()` handles BEGIN...END blocks in triggers.
 
-Key tables (31 total): `accounts` (with `provider` "gmail_api"|"imap", IMAP/SMTP host/port/security fields, `auth_method`, encrypted `imap_password`), `messages` (with FTS5 index `messages_fts`, `auth_results`, `message_id_header`, `references_header`, `in_reply_to_header`, `imap_uid`, `imap_folder`), `threads` (with `is_pinned`, `is_muted`), `thread_labels`, `labels` (with `imap_folder_path`, `imap_special_use`), `contacts` (frequency-ranked for autocomplete, with `first_contacted_at`), `attachments` (with `cached_at`, `cache_size`, `imap_part_id`), `filter_rules` (criteria/actions as JSON), `scheduled_emails` (status: pending/sent/failed), `templates` (with optional keyboard shortcut), `signatures`, `image_allowlist`, `settings` (key-value store), `ai_cache`, `thread_categories`, `calendar_events`, `follow_up_reminders`, `notification_vips`, `unsubscribe_actions`, `bundle_rules`, `bundled_threads`, `send_as_aliases`, `smart_folders`, `link_scan_results`, `phishing_allowlist`, `quick_steps`, `folder_sync_state` (IMAP UIDVALIDITY/last_uid/modseq tracking per folder), `_migrations`.
+Key tables (31 total): `accounts` (with `provider` "gmail_api"|"imap", IMAP/SMTP host/port/security fields, `auth_method`, encrypted `imap_password`, optional `imap_username`), `messages` (with FTS5 index `messages_fts`, `auth_results`, `message_id_header`, `references_header`, `in_reply_to_header`, `imap_uid`, `imap_folder`), `threads` (with `is_pinned`, `is_muted`), `thread_labels`, `labels` (with `imap_folder_path`, `imap_special_use`), `contacts` (frequency-ranked for autocomplete, with `first_contacted_at`), `attachments` (with `cached_at`, `cache_size`, `imap_part_id`), `filter_rules` (criteria/actions as JSON), `scheduled_emails` (status: pending/sent/failed), `templates` (with optional keyboard shortcut), `signatures`, `image_allowlist`, `settings` (key-value store), `ai_cache`, `thread_categories`, `calendar_events`, `follow_up_reminders`, `notification_vips`, `unsubscribe_actions`, `bundle_rules`, `bundled_threads`, `send_as_aliases`, `smart_folders`, `link_scan_results`, `phishing_allowlist`, `quick_steps`, `folder_sync_state` (IMAP UIDVALIDITY/last_uid/modseq tracking per folder), `_migrations`.
 
 ## Key Gotchas
 
@@ -181,6 +181,7 @@ Key tables (31 total): `accounts` (with `provider` "gmail_api"|"imap", IMAP/SMTP
 - **IMAP UIDVALIDITY**: If UIDVALIDITY changes on a folder, all cached UIDs are invalid — triggers full resync of that folder
 - **IMAP folders vs labels**: IMAP has no native labels; folders are mapped to Gmail-style labels via `folderMapper.ts` using special-use flags and well-known name matching
 - **IMAP passwords**: Encrypted with AES-256-GCM in SQLite (same crypto as OAuth tokens)
+- **IMAP username**: Optional `imap_username` column on accounts — when set, used as login username for IMAP/SMTP instead of email. Falls back to email when null
 - **IMAP auto-discovery**: Pre-configured for Outlook/Hotmail, Yahoo, iCloud, AOL, Zoho, FastMail, GMX; other providers require manual server entry
 - **Provider abstraction**: All sync/send operations go through `EmailProvider` interface — use `getEmailProvider(account)` from `providerFactory.ts`, never call Gmail or IMAP APIs directly from components
 - **CSP**: Allows connections to googleapis.com, anthropic.com, openai.com, generativelanguage.googleapis.com, gravatar.com, googleusercontent.com

--- a/src/components/accounts/AddImapAccount.tsx
+++ b/src/components/accounts/AddImapAccount.tsx
@@ -36,6 +36,7 @@ type AuthMode = "password" | "oauth2";
 interface FormState {
   email: string;
   displayName: string;
+  imapUsername: string;
   imapHost: string;
   imapPort: number;
   imapSecurity: SecurityType;
@@ -59,6 +60,7 @@ interface FormState {
 const initialFormState: FormState = {
   email: "",
   displayName: "",
+  imapUsername: "",
   imapHost: "",
   imapPort: 993,
   imapSecurity: "ssl",
@@ -286,7 +288,7 @@ export function AddImapAccount({
             host: form.imapHost,
             port: form.imapPort,
             security: mapSecurity(form.imapSecurity),
-            username: isOAuth ? (form.oauthEmail ?? form.email) : form.email,
+            username: form.imapUsername || (isOAuth ? (form.oauthEmail ?? form.email) : form.email),
             password: isOAuth ? (form.oauthAccessToken ?? "") : form.password,
             auth_method: isOAuth ? "oauth2" : "password",
           },
@@ -317,7 +319,7 @@ export function AddImapAccount({
             host: form.smtpHost,
             port: form.smtpPort,
             security: mapSecurity(form.smtpSecurity),
-            username: isOAuth ? (form.oauthEmail ?? form.email) : form.email,
+            username: form.imapUsername || (isOAuth ? (form.oauthEmail ?? form.email) : form.email),
             password: smtpPassword,
             auth_method: isOAuth ? "oauth2" : "password",
           },
@@ -344,6 +346,8 @@ export function AddImapAccount({
       const accountId = crypto.randomUUID();
       const email = (isOAuth ? form.oauthEmail : null) ?? form.email.trim();
 
+      const imapUsername = form.imapUsername.trim() || null;
+
       if (isOAuth) {
         await insertOAuthImapAccount({
           id: accountId,
@@ -362,6 +366,7 @@ export function AddImapAccount({
           oauthProvider: form.oauthProvider!,
           oauthClientId: form.oauthClientId.trim(),
           oauthClientSecret: form.oauthClientSecret.trim() || null,
+          imapUsername,
         });
       } else {
         await insertImapAccount({
@@ -377,6 +382,7 @@ export function AddImapAccount({
           smtpSecurity: form.smtpSecurity,
           authMethod: "password",
           password: form.samePassword ? form.password : form.password,
+          imapUsername,
         });
       }
 
@@ -588,6 +594,22 @@ export function AddImapAccount({
               placeholder="Your Name"
               className={inputClass}
             />
+          </div>
+          <div>
+            <label htmlFor="imap-username" className={labelClass}>
+              Username (optional)
+            </label>
+            <input
+              id="imap-username"
+              type="text"
+              value={form.imapUsername}
+              onChange={(e) => updateForm("imapUsername", e.target.value)}
+              placeholder="Leave blank to use your email address"
+              className={inputClass}
+            />
+            <p className="text-xs text-text-tertiary mt-1">
+              Only needed if your login username differs from your email address.
+            </p>
           </div>
           <div>
             <label htmlFor="imap-password" className={labelClass}>

--- a/src/services/db/accounts.test.ts
+++ b/src/services/db/accounts.test.ts
@@ -57,6 +57,7 @@ function makeGmailAccount(overrides: Partial<DbAccount> = {}): DbAccount {
     oauth_provider: null,
     oauth_client_id: null,
     oauth_client_secret: null,
+    imap_username: null,
     ...overrides,
   };
 }
@@ -87,6 +88,7 @@ function makeImapAccount(overrides: Partial<DbAccount> = {}): DbAccount {
     oauth_provider: null,
     oauth_client_id: null,
     oauth_client_secret: null,
+    imap_username: null,
     ...overrides,
   };
 }
@@ -230,7 +232,33 @@ describe("accounts", () => {
         "ssl",
         "password",
         "enc:my-app-password", // encrypted
+        null, // imap_username
       ]);
+    });
+
+    it("inserts IMAP account with custom username", async () => {
+      mockExecute.mockResolvedValue(undefined);
+
+      await insertImapAccount({
+        id: "new-imap-2",
+        email: "user@example.com",
+        displayName: null,
+        avatarUrl: null,
+        imapHost: "imap.example.com",
+        imapPort: 993,
+        imapSecurity: "ssl",
+        smtpHost: "smtp.example.com",
+        smtpPort: 465,
+        smtpSecurity: "ssl",
+        authMethod: "password",
+        password: "pass",
+        imapUsername: "custom-login-id",
+      });
+
+      expect(mockExecute).toHaveBeenCalledTimes(1);
+      const [sql, params] = mockExecute.mock.calls[0] as [string, unknown[]];
+      expect(sql).toContain("imap_username");
+      expect(params).toContain("custom-login-id");
     });
 
     it("sets access_token and refresh_token to NULL for IMAP accounts", async () => {

--- a/src/services/db/accounts.ts
+++ b/src/services/db/accounts.ts
@@ -26,6 +26,7 @@ export interface DbAccount {
   oauth_provider: string | null;
   oauth_client_id: string | null;
   oauth_client_secret: string | null;
+  imap_username: string | null;
 }
 
 async function decryptAccountTokens(account: DbAccount): Promise<DbAccount> {
@@ -178,12 +179,13 @@ export async function insertImapAccount(account: {
   smtpSecurity: string;
   authMethod: string;
   password: string;
+  imapUsername?: string | null;
 }): Promise<void> {
   const db = await getDb();
   const encPassword = await encryptValue(account.password);
   await db.execute(
-    `INSERT INTO accounts (id, email, display_name, avatar_url, access_token, refresh_token, provider, imap_host, imap_port, imap_security, smtp_host, smtp_port, smtp_security, auth_method, imap_password)
-     VALUES ($1, $2, $3, $4, NULL, NULL, 'imap', $5, $6, $7, $8, $9, $10, $11, $12)`,
+    `INSERT INTO accounts (id, email, display_name, avatar_url, access_token, refresh_token, provider, imap_host, imap_port, imap_security, smtp_host, smtp_port, smtp_security, auth_method, imap_password, imap_username)
+     VALUES ($1, $2, $3, $4, NULL, NULL, 'imap', $5, $6, $7, $8, $9, $10, $11, $12, $13)`,
     [
       account.id,
       account.email,
@@ -197,6 +199,7 @@ export async function insertImapAccount(account: {
       account.smtpSecurity,
       account.authMethod,
       encPassword,
+      account.imapUsername || null,
     ],
   );
 }
@@ -218,6 +221,7 @@ export async function insertOAuthImapAccount(account: {
   oauthProvider: string;
   oauthClientId: string;
   oauthClientSecret: string | null;
+  imapUsername?: string | null;
 }): Promise<void> {
   const db = await getDb();
   const encAccessToken = await encryptValue(account.accessToken);
@@ -226,8 +230,8 @@ export async function insertOAuthImapAccount(account: {
     ? await encryptValue(account.oauthClientSecret)
     : null;
   await db.execute(
-    `INSERT INTO accounts (id, email, display_name, avatar_url, access_token, refresh_token, token_expires_at, provider, imap_host, imap_port, imap_security, smtp_host, smtp_port, smtp_security, auth_method, imap_password, oauth_provider, oauth_client_id, oauth_client_secret)
-     VALUES ($1, $2, $3, $4, $5, $6, $7, 'imap', $8, $9, $10, $11, $12, $13, 'oauth2', NULL, $14, $15, $16)`,
+    `INSERT INTO accounts (id, email, display_name, avatar_url, access_token, refresh_token, token_expires_at, provider, imap_host, imap_port, imap_security, smtp_host, smtp_port, smtp_security, auth_method, imap_password, oauth_provider, oauth_client_id, oauth_client_secret, imap_username)
+     VALUES ($1, $2, $3, $4, $5, $6, $7, 'imap', $8, $9, $10, $11, $12, $13, 'oauth2', NULL, $14, $15, $16, $17)`,
     [
       account.id,
       account.email,
@@ -245,6 +249,7 @@ export async function insertOAuthImapAccount(account: {
       account.oauthProvider,
       account.oauthClientId,
       encClientSecret,
+      account.imapUsername || null,
     ],
   );
 }

--- a/src/services/db/migrations.ts
+++ b/src/services/db/migrations.ts
@@ -574,6 +574,11 @@ const MIGRATIONS = [
       ALTER TABLE accounts ADD COLUMN oauth_client_secret TEXT;
     `,
   },
+  {
+    version: 16,
+    description: "Optional IMAP/SMTP username override",
+    sql: `ALTER TABLE accounts ADD COLUMN imap_username TEXT;`,
+  },
 ];
 
 /**

--- a/src/services/imap/imapConfigBuilder.test.ts
+++ b/src/services/imap/imapConfigBuilder.test.ts
@@ -28,6 +28,7 @@ function makeAccount(overrides: Partial<DbAccount> = {}): DbAccount {
     oauth_provider: null,
     oauth_client_id: null,
     oauth_client_secret: null,
+    imap_username: null,
     ...overrides,
   };
 }
@@ -145,5 +146,31 @@ describe("buildSmtpConfig", () => {
     const config = buildSmtpConfig(account, "smtp-oauth-token");
     expect(config.password).toBe("smtp-oauth-token");
     expect(config.auth_method).toBe("oauth2");
+  });
+});
+
+describe("imap_username override", () => {
+  it("uses imap_username when set for IMAP config", () => {
+    const account = makeAccount({ imap_username: "custom-user" });
+    const config = buildImapConfig(account);
+    expect(config.username).toBe("custom-user");
+  });
+
+  it("uses imap_username when set for SMTP config", () => {
+    const account = makeAccount({ imap_username: "custom-user" });
+    const config = buildSmtpConfig(account);
+    expect(config.username).toBe("custom-user");
+  });
+
+  it("falls back to email when imap_username is null", () => {
+    const account = makeAccount({ imap_username: null });
+    const config = buildImapConfig(account);
+    expect(config.username).toBe("user@example.com");
+  });
+
+  it("falls back to email when imap_username is empty string", () => {
+    const account = makeAccount({ imap_username: "" as string | null });
+    const config = buildImapConfig(account);
+    expect(config.username).toBe("user@example.com");
   });
 });

--- a/src/services/imap/imapConfigBuilder.ts
+++ b/src/services/imap/imapConfigBuilder.ts
@@ -47,7 +47,7 @@ export function buildImapConfig(
     host: account.imap_host,
     port: account.imap_port ?? 993,
     security: mapSecurity(account.imap_security),
-    username: account.email,
+    username: account.imap_username || account.email,
     password,
     auth_method: authMethod,
   };
@@ -78,7 +78,7 @@ export function buildSmtpConfig(
     host: account.smtp_host,
     port: account.smtp_port ?? 587,
     security: mapSecurity(account.smtp_security),
-    username: account.email,
+    username: account.imap_username || account.email,
     password,
     auth_method: authMethod,
   };

--- a/src/services/oauth/oauthTokenManager.test.ts
+++ b/src/services/oauth/oauthTokenManager.test.ts
@@ -44,6 +44,7 @@ function makeAccount(overrides: Partial<DbAccount> = {}): DbAccount {
     oauth_provider: "microsoft",
     oauth_client_id: "client-id-123",
     oauth_client_secret: null,
+    imap_username: null,
     ...overrides,
   };
 }


### PR DESCRIPTION
## Summary
- Adds an optional `imap_username` column to accounts (migration 16) for IMAP providers where the login username differs from the email address
- When set, used as the IMAP/SMTP login; when null, falls back to email (backward compatible)
- Adds a "Username (optional)" input in the Add IMAP Account form with helper text

Resolves #26

## Test plan
- [x] `npx tsc --noEmit` — no type errors
- [x] `npm run test` — all 980 tests pass (81 test files)
- [x] Manual: Add IMAP account → verify username field appears in basic step
- [x] Manual: Leave username blank → verify email is used for login
- [x] Manual: Set custom username → verify it's used for IMAP/SMTP test connections
- [x] Manual: Existing accounts unaffected (null imap_username → email fallback)