### PR TITLE
Fix IMAP connection test showing no diagnostics

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "velo",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "velo",
-      "version": "0.3.2",
+      "version": "0.3.3",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.74.0",
         "@dnd-kit/core": "^6.3.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "velo",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "private": true,
   "type": "module",
   "scripts": {

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "velo"
-version = "0.3.2"
+version = "0.3.3"
 description = "Email at the speed of thought"
 authors = ["Avihay"]
 license = ""

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Velo",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "identifier": "com.velomail.app",
   "build": {
     "frontendDist": "../dist",


### PR DESCRIPTION
## Summary
- Fixed type mismatch in IMAP connection test: Rust returns `Result<String, String>` but UI expected `{success, message}` object
- `result.success` was always `undefined` (falsy), causing every test to show as failed with no error message
- Users now see proper success/failure messages and detailed error diagnostics (TCP failures, TLS errors, auth failures)
- Bumps version to 0.3.3

Resolves #26

## Test plan
- [ ] Add IMAP account with valid credentials — should show green success with folder count
- [ ] Add IMAP account with wrong password — should show red error with "Login failed" message
- [ ] Add IMAP account with wrong host — should show "TCP connect failed" error
- [ ] Add IMAP account with wrong port/security combo — should show TLS or connection error

🤖 Generated with [Claude Code](https://claude.com/claude-code)