### PR TITLE
refactor: consolidate duplicated test mocks

### DIFF
--- a/src/services/ai/providerManager.test.ts
+++ b/src/services/ai/providerManager.test.ts
@@ -8,27 +8,20 @@ vi.mock("@/services/db/settings", () => {
   };
 });
 
+import { createMockAiProvider } from "@/test/mocks";
+
 vi.mock("./providers/claudeProvider", () => ({
-  createClaudeProvider: vi.fn(() => ({
-    complete: vi.fn(() => Promise.resolve("claude response")),
-    testConnection: vi.fn(() => Promise.resolve(true)),
-  })),
+  createClaudeProvider: vi.fn(() => createMockAiProvider("claude response")),
   clearClaudeProvider: vi.fn(),
 }));
 
 vi.mock("./providers/openaiProvider", () => ({
-  createOpenAIProvider: vi.fn(() => ({
-    complete: vi.fn(() => Promise.resolve("openai response")),
-    testConnection: vi.fn(() => Promise.resolve(true)),
-  })),
+  createOpenAIProvider: vi.fn(() => createMockAiProvider("openai response")),
   clearOpenAIProvider: vi.fn(),
 }));
 
 vi.mock("./providers/geminiProvider", () => ({
-  createGeminiProvider: vi.fn(() => ({
-    complete: vi.fn(() => Promise.resolve("gemini response")),
-    testConnection: vi.fn(() => Promise.resolve(true)),
-  })),
+  createGeminiProvider: vi.fn(() => createMockAiProvider("gemini response")),
   clearGeminiProvider: vi.fn(),
 }));
 

--- a/src/services/attachments/preCacheManager.test.ts
+++ b/src/services/attachments/preCacheManager.test.ts
@@ -37,6 +37,7 @@ vi.mock("../backgroundCheckers", () => ({
 import { useUIStore } from "@/stores/uiStore";
 import { cacheAttachment } from "./cacheManager";
 import { startPreCacheManager, stopPreCacheManager } from "./preCacheManager";
+import { createMockUIStoreState } from "@/test/mocks";
 
 async function runPreCache() {
   startPreCacheManager();
@@ -47,13 +48,13 @@ describe("preCacheManager", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     stopPreCacheManager();
-    (useUIStore.getState as ReturnType<typeof vi.fn>).mockReturnValue({ isOnline: true });
+    (useUIStore.getState as ReturnType<typeof vi.fn>).mockReturnValue(createMockUIStoreState());
     mockSelect.mockReset();
     mockFetchAttachment.mockReset();
   });
 
   it("skips when offline", async () => {
-    (useUIStore.getState as ReturnType<typeof vi.fn>).mockReturnValue({ isOnline: false });
+    (useUIStore.getState as ReturnType<typeof vi.fn>).mockReturnValue(createMockUIStoreState({ isOnline: false }));
 
     await runPreCache();
 

--- a/src/services/composer/draftAutoSave.test.ts
+++ b/src/services/composer/draftAutoSave.test.ts
@@ -8,9 +8,11 @@ vi.mock("@/services/emailActions", () => ({
   updateDraft: vi.fn().mockResolvedValue({ success: true }),
 }));
 
+import { createMockAccountStoreState } from "@/test/mocks";
+
 vi.mock("@/stores/accountStore", () => ({
   useAccountStore: {
-    getState: () => ({
+    getState: () => createMockAccountStoreState({
       accounts: [{ id: "account-1", email: "test@example.com" }],
     }),
   },

--- a/src/services/db/accounts.test.ts
+++ b/src/services/db/accounts.test.ts
@@ -7,8 +7,8 @@ import {
   deleteAccount,
   updateAccountTokens,
   updateAccountSyncState,
-  type DbAccount,
 } from "./accounts";
+import { createMockGmailAccount, createMockImapAccount } from "@/test/mocks";
 
 const mockExecute = vi.fn();
 const mockSelect = vi.fn();
@@ -31,68 +31,6 @@ import { selectFirstBy } from "./connection";
 
 const mockSelectFirstBy = vi.mocked(selectFirstBy);
 
-function makeGmailAccount(overrides: Partial<DbAccount> = {}): DbAccount {
-  return {
-    id: "acc-gmail",
-    email: "user@gmail.com",
-    display_name: "Gmail User",
-    avatar_url: null,
-    access_token: "enc:access-token",
-    refresh_token: "enc:refresh-token",
-    token_expires_at: 9999999999,
-    history_id: "12345",
-    last_sync_at: 1700000000,
-    is_active: 1,
-    created_at: 1700000000,
-    updated_at: 1700000000,
-    provider: "gmail_api",
-    imap_host: null,
-    imap_port: null,
-    imap_security: null,
-    smtp_host: null,
-    smtp_port: null,
-    smtp_security: null,
-    auth_method: "oauth",
-    imap_password: null,
-    oauth_provider: null,
-    oauth_client_id: null,
-    oauth_client_secret: null,
-    imap_username: null,
-    ...overrides,
-  };
-}
-
-function makeImapAccount(overrides: Partial<DbAccount> = {}): DbAccount {
-  return {
-    id: "acc-imap",
-    email: "user@example.com",
-    display_name: "IMAP User",
-    avatar_url: null,
-    access_token: null,
-    refresh_token: null,
-    token_expires_at: null,
-    history_id: null,
-    last_sync_at: null,
-    is_active: 1,
-    created_at: 1700000000,
-    updated_at: 1700000000,
-    provider: "imap",
-    imap_host: "imap.example.com",
-    imap_port: 993,
-    imap_security: "tls",
-    smtp_host: "smtp.example.com",
-    smtp_port: 465,
-    smtp_security: "tls",
-    auth_method: "password",
-    imap_password: "enc:secret-password",
-    oauth_provider: null,
-    oauth_client_id: null,
-    oauth_client_secret: null,
-    imap_username: null,
-    ...overrides,
-  };
-}
-
 describe("accounts", () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -108,7 +46,7 @@ describe("accounts", () => {
     });
 
     it("returns a Gmail account with decrypted tokens", async () => {
-      mockSelectFirstBy.mockResolvedValue(makeGmailAccount());
+      mockSelectFirstBy.mockResolvedValue(createMockGmailAccount());
 
       const result = await getAccount("acc-gmail");
 
@@ -120,7 +58,7 @@ describe("accounts", () => {
     });
 
     it("returns an IMAP account with decrypted imap_password", async () => {
-      mockSelectFirstBy.mockResolvedValue(makeImapAccount());
+      mockSelectFirstBy.mockResolvedValue(createMockImapAccount());
 
       const result = await getAccount("acc-imap");
 
@@ -138,7 +76,7 @@ describe("accounts", () => {
 
     it("handles IMAP account with null imap_password gracefully", async () => {
       mockSelectFirstBy.mockResolvedValue(
-        makeImapAccount({ imap_password: null }),
+        createMockImapAccount({ imap_password: null }),
       );
 
       const result = await getAccount("acc-imap");
@@ -149,7 +87,7 @@ describe("accounts", () => {
 
   describe("getAccountByEmail", () => {
     it("returns account matching email", async () => {
-      mockSelectFirstBy.mockResolvedValue(makeImapAccount());
+      mockSelectFirstBy.mockResolvedValue(createMockImapAccount());
 
       const result = await getAccountByEmail("user@example.com");
 
@@ -168,7 +106,7 @@ describe("accounts", () => {
 
   describe("getAllAccounts", () => {
     it("returns all accounts with decrypted tokens", async () => {
-      mockSelect.mockResolvedValue([makeGmailAccount(), makeImapAccount()]);
+      mockSelect.mockResolvedValue([createMockGmailAccount(), createMockImapAccount()]);
 
       const result = await getAllAccounts();
 
@@ -188,7 +126,7 @@ describe("accounts", () => {
     });
 
     it("decrypts imap_password for IMAP accounts in the list", async () => {
-      mockSelect.mockResolvedValue([makeImapAccount()]);
+      mockSelect.mockResolvedValue([createMockImapAccount()]);
 
       const result = await getAllAccounts();
 

--- a/src/services/db/contacts.test.ts
+++ b/src/services/db/contacts.test.ts
@@ -14,11 +14,9 @@ import {
   updateContactNotes, getAttachmentsFromContact,
   getContactsFromSameDomain, getLatestAuthResult,
 } from "./contacts";
+import { createMockDb } from "@/test/mocks";
 
-const mockDb = {
-  select: vi.fn(() => Promise.resolve([])),
-  execute: vi.fn(() => Promise.resolve({ rowsAffected: 1 })),
-};
+const mockDb = createMockDb();
 
 describe("contacts service", () => {
   beforeEach(() => {

--- a/src/services/db/localDrafts.test.ts
+++ b/src/services/db/localDrafts.test.ts
@@ -16,11 +16,9 @@ import {
   markDraftSynced,
   deleteLocalDraft,
 } from "./localDrafts";
+import { createMockDb } from "@/test/mocks";
 
-const mockDb = {
-  select: vi.fn(() => Promise.resolve([])),
-  execute: vi.fn(() => Promise.resolve({ rowsAffected: 1 })),
-};
+const mockDb = createMockDb();
 
 describe("localDrafts DB service", () => {
   beforeEach(() => {

--- a/src/services/db/pendingOperations.test.ts
+++ b/src/services/db/pendingOperations.test.ts
@@ -22,11 +22,9 @@ import {
   clearFailedOperations,
   retryFailedOperations,
 } from "./pendingOperations";
+import { createMockDb } from "@/test/mocks";
 
-const mockDb = {
-  select: vi.fn(() => Promise.resolve([])),
-  execute: vi.fn(() => Promise.resolve({ rowsAffected: 1 })),
-};
+const mockDb = createMockDb();
 
 describe("pendingOperations DB service", () => {
   beforeEach(() => {

--- a/src/services/db/quickSteps.test.ts
+++ b/src/services/db/quickSteps.test.ts
@@ -18,11 +18,9 @@ import {
   deleteQuickStep,
   reorderQuickSteps,
 } from "./quickSteps";
+import { createMockDb } from "@/test/mocks";
 
-const mockDb = {
-  select: vi.fn(() => Promise.resolve([])),
-  execute: vi.fn(() => Promise.resolve({ rowsAffected: 1 })),
-};
+const mockDb = createMockDb();
 
 describe("quickSteps DB service", () => {
   beforeEach(() => {

--- a/src/services/db/sendAsAliases.test.ts
+++ b/src/services/db/sendAsAliases.test.ts
@@ -27,11 +27,9 @@ import {
   mapDbAlias,
   type DbSendAsAlias,
 } from "./sendAsAliases";
+import { createMockDb } from "@/test/mocks";
 
-const mockDb = {
-  select: vi.fn(() => Promise.resolve([])),
-  execute: vi.fn(() => Promise.resolve({ rowsAffected: 1 })),
-};
+const mockDb = createMockDb();
 
 describe("sendAsAliases service", () => {
   beforeEach(() => {

--- a/src/services/db/smartFolders.test.ts
+++ b/src/services/db/smartFolders.test.ts
@@ -27,11 +27,9 @@ import {
   deleteSmartFolder,
   updateSmartFolderSortOrder,
 } from "./smartFolders";
+import { createMockDb } from "@/test/mocks";
 
-const mockDb = {
-  select: vi.fn(() => Promise.resolve([])),
-  execute: vi.fn(() => Promise.resolve({ rowsAffected: 1 })),
-};
+const mockDb = createMockDb();
 
 describe("smartFolders service", () => {
   beforeEach(() => {

--- a/src/services/db/threads.test.ts
+++ b/src/services/db/threads.test.ts
@@ -10,11 +10,9 @@ vi.mock("@/services/db/connection", async (importOriginal) => {
 
 import { getDb } from "@/services/db/connection";
 import { muteThread, unmuteThread, getMutedThreadIds } from "./threads";
+import { createMockDb } from "@/test/mocks";
 
-const mockDb = {
-  select: vi.fn(() => Promise.resolve([])),
-  execute: vi.fn(() => Promise.resolve({ rowsAffected: 1 })),
-};
+const mockDb = createMockDb();
 
 describe("threads service - mute", () => {
   beforeEach(() => {

--- a/src/services/email/gmailProvider.test.ts
+++ b/src/services/email/gmailProvider.test.ts
@@ -1,35 +1,13 @@
 import { GmailApiProvider } from "./gmailProvider";
 import type { GmailClient } from "../gmail/client";
-
-function createMockClient(): GmailClient {
-  return {
-    listLabels: vi.fn(),
-    createLabel: vi.fn(),
-    deleteLabel: vi.fn(),
-    updateLabel: vi.fn(),
-    modifyThread: vi.fn(),
-    deleteThread: vi.fn(),
-    getMessage: vi.fn(),
-    getAttachment: vi.fn(),
-    sendMessage: vi.fn(),
-    createDraft: vi.fn(),
-    updateDraft: vi.fn(),
-    deleteDraft: vi.fn(),
-    getProfile: vi.fn(),
-    getHistory: vi.fn(),
-    getThread: vi.fn(),
-    listThreads: vi.fn(),
-    listDrafts: vi.fn(),
-    request: vi.fn(),
-  } as unknown as GmailClient;
-}
+import { createMockGmailClient } from "@/test/mocks";
 
 describe("GmailApiProvider", () => {
   let provider: GmailApiProvider;
   let mockClient: GmailClient;
 
   beforeEach(() => {
-    mockClient = createMockClient();
+    mockClient = createMockGmailClient();
     provider = new GmailApiProvider("account-1", mockClient);
   });
 

--- a/src/services/emailActions.test.ts
+++ b/src/services/emailActions.test.ts
@@ -45,22 +45,9 @@ import {
   spamThread,
   executeEmailAction,
 } from "./emailActions";
+import { createMockEmailProvider, createMockUIStoreState, createMockThreadStoreState } from "@/test/mocks";
 
-const mockProvider = {
-  archive: vi.fn(() => Promise.resolve()),
-  trash: vi.fn(() => Promise.resolve()),
-  permanentDelete: vi.fn(() => Promise.resolve()),
-  markRead: vi.fn(() => Promise.resolve()),
-  star: vi.fn(() => Promise.resolve()),
-  spam: vi.fn(() => Promise.resolve()),
-  moveToFolder: vi.fn(() => Promise.resolve()),
-  addLabel: vi.fn(() => Promise.resolve()),
-  removeLabel: vi.fn(() => Promise.resolve()),
-  sendMessage: vi.fn(() => Promise.resolve({ id: "msg-1" })),
-  createDraft: vi.fn(() => Promise.resolve({ draftId: "d-1" })),
-  updateDraft: vi.fn(() => Promise.resolve({ draftId: "d-1" })),
-  deleteDraft: vi.fn(() => Promise.resolve()),
-};
+const mockProvider = createMockEmailProvider();
 
 const mockUpdateThread = vi.fn();
 const mockRemoveThread = vi.fn();
@@ -69,11 +56,11 @@ describe("emailActions", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     vi.mocked(getEmailProvider).mockResolvedValue(mockProvider as never);
-    vi.mocked(useUIStore.getState).mockReturnValue({ isOnline: true } as never);
-    vi.mocked(useThreadStore.getState).mockReturnValue({
+    vi.mocked(useUIStore.getState).mockReturnValue(createMockUIStoreState() as never);
+    vi.mocked(useThreadStore.getState).mockReturnValue(createMockThreadStoreState({
       updateThread: mockUpdateThread,
       removeThread: mockRemoveThread,
-    } as never);
+    }) as never);
   });
 
   describe("online execution", () => {

--- a/src/services/filters/filterEngine.test.ts
+++ b/src/services/filters/filterEngine.test.ts
@@ -1,122 +1,95 @@
 import { describe, it, expect } from "vitest";
 import { messageMatchesFilter, computeFilterActions } from "./filterEngine";
 import type { FilterCriteria, FilterActions } from "../db/filters";
-import type { ParsedMessage } from "../gmail/messageParser";
-
-function makeMockMessage(overrides: Partial<ParsedMessage> = {}): ParsedMessage {
-  return {
-    id: "msg-1",
-    threadId: "thread-1",
-    fromAddress: "alice@example.com",
-    fromName: "Alice Smith",
-    toAddresses: "bob@example.com",
-    ccAddresses: null,
-    bccAddresses: null,
-    replyTo: null,
-    subject: "Project Update",
-    snippet: "Here is the latest update...",
-    date: Date.now(),
-    isRead: false,
-    isStarred: false,
-    bodyHtml: "<p>Hello from the project</p>",
-    bodyText: "Hello from the project",
-    rawSize: 1024,
-    internalDate: Date.now(),
-    labelIds: ["INBOX", "UNREAD"],
-    hasAttachments: false,
-    attachments: [],
-    listUnsubscribe: null,
-    ...overrides,
-  };
-}
+import { createMockParsedMessage } from "@/test/mocks";
 
 describe("messageMatchesFilter", () => {
   it("matches from criteria (case-insensitive)", () => {
-    const msg = makeMockMessage();
+    const msg = createMockParsedMessage();
     const criteria: FilterCriteria = { from: "alice" };
     expect(messageMatchesFilter(msg, criteria)).toBe(true);
   });
 
   it("matches from name", () => {
-    const msg = makeMockMessage();
+    const msg = createMockParsedMessage();
     const criteria: FilterCriteria = { from: "Smith" };
     expect(messageMatchesFilter(msg, criteria)).toBe(true);
   });
 
   it("does not match wrong from", () => {
-    const msg = makeMockMessage();
+    const msg = createMockParsedMessage();
     const criteria: FilterCriteria = { from: "charlie" };
     expect(messageMatchesFilter(msg, criteria)).toBe(false);
   });
 
   it("matches to criteria", () => {
-    const msg = makeMockMessage();
+    const msg = createMockParsedMessage();
     const criteria: FilterCriteria = { to: "bob" };
     expect(messageMatchesFilter(msg, criteria)).toBe(true);
   });
 
   it("does not match wrong to", () => {
-    const msg = makeMockMessage();
+    const msg = createMockParsedMessage();
     const criteria: FilterCriteria = { to: "charlie" };
     expect(messageMatchesFilter(msg, criteria)).toBe(false);
   });
 
   it("matches subject criteria", () => {
-    const msg = makeMockMessage();
+    const msg = createMockParsedMessage();
     const criteria: FilterCriteria = { subject: "project" };
     expect(messageMatchesFilter(msg, criteria)).toBe(true);
   });
 
   it("does not match wrong subject", () => {
-    const msg = makeMockMessage();
+    const msg = createMockParsedMessage();
     const criteria: FilterCriteria = { subject: "invoice" };
     expect(messageMatchesFilter(msg, criteria)).toBe(false);
   });
 
   it("matches body criteria in text", () => {
-    const msg = makeMockMessage();
+    const msg = createMockParsedMessage();
     const criteria: FilterCriteria = { body: "hello from" };
     expect(messageMatchesFilter(msg, criteria)).toBe(true);
   });
 
   it("matches hasAttachment criteria", () => {
-    const msg = makeMockMessage({ hasAttachments: true });
+    const msg = createMockParsedMessage({ hasAttachments: true });
     const criteria: FilterCriteria = { hasAttachment: true };
     expect(messageMatchesFilter(msg, criteria)).toBe(true);
   });
 
   it("does not match hasAttachment when no attachments", () => {
-    const msg = makeMockMessage({ hasAttachments: false });
+    const msg = createMockParsedMessage({ hasAttachments: false });
     const criteria: FilterCriteria = { hasAttachment: true };
     expect(messageMatchesFilter(msg, criteria)).toBe(false);
   });
 
   it("ANDs multiple criteria together", () => {
-    const msg = makeMockMessage();
+    const msg = createMockParsedMessage();
     const criteria: FilterCriteria = { from: "alice", subject: "project" };
     expect(messageMatchesFilter(msg, criteria)).toBe(true);
   });
 
   it("fails AND when one criterion misses", () => {
-    const msg = makeMockMessage();
+    const msg = createMockParsedMessage();
     const criteria: FilterCriteria = { from: "alice", subject: "invoice" };
     expect(messageMatchesFilter(msg, criteria)).toBe(false);
   });
 
   it("matches with empty criteria (matches everything)", () => {
-    const msg = makeMockMessage();
+    const msg = createMockParsedMessage();
     const criteria: FilterCriteria = {};
     expect(messageMatchesFilter(msg, criteria)).toBe(true);
   });
 
   it("handles null fromAddress gracefully", () => {
-    const msg = makeMockMessage({ fromAddress: null, fromName: null });
+    const msg = createMockParsedMessage({ fromAddress: null, fromName: null });
     const criteria: FilterCriteria = { from: "alice" };
     expect(messageMatchesFilter(msg, criteria)).toBe(false);
   });
 
   it("handles null toAddresses gracefully", () => {
-    const msg = makeMockMessage({ toAddresses: null });
+    const msg = createMockParsedMessage({ toAddresses: null });
     const criteria: FilterCriteria = { to: "bob" };
     expect(messageMatchesFilter(msg, criteria)).toBe(false);
   });

--- a/src/services/gmail/messageParser.test.ts
+++ b/src/services/gmail/messageParser.test.ts
@@ -1,54 +1,10 @@
 import { describe, it, expect } from "vitest";
 import { parseGmailMessage } from "./messageParser";
-import type { GmailMessage } from "./client";
-
-function makeMessage(overrides: Partial<GmailMessage> = {}): GmailMessage {
-  return {
-    id: "msg-1",
-    threadId: "thread-1",
-    labelIds: ["INBOX", "UNREAD"],
-    snippet: "Hello this is a test",
-    historyId: "12345",
-    internalDate: "1700000000000",
-    sizeEstimate: 1024,
-    payload: {
-      partId: "",
-      mimeType: "multipart/alternative",
-      filename: "",
-      headers: [
-        { name: "From", value: "John Doe <john@example.com>" },
-        { name: "To", value: "me@example.com" },
-        { name: "Subject", value: "Test Subject" },
-        { name: "Cc", value: "" },
-      ],
-      body: { size: 0 },
-      parts: [
-        {
-          partId: "0",
-          mimeType: "text/plain",
-          filename: "",
-          headers: [],
-          body: { size: 11, data: "SGVsbG8gV29ybGQ" }, // "Hello World" in base64url
-        },
-        {
-          partId: "1",
-          mimeType: "text/html",
-          filename: "",
-          headers: [],
-          body: {
-            size: 28,
-            data: "PGI-SGVsbG8gV29ybGQ8L2I-", // "<b>Hello World</b>" in base64url
-          },
-        },
-      ],
-    },
-    ...overrides,
-  };
-}
+import { createMockGmailMessage } from "@/test/mocks";
 
 describe("parseGmailMessage", () => {
   it("should parse basic message metadata", () => {
-    const parsed = parseGmailMessage(makeMessage());
+    const parsed = parseGmailMessage(createMockGmailMessage());
 
     expect(parsed.id).toBe("msg-1");
     expect(parsed.threadId).toBe("thread-1");
@@ -61,28 +17,28 @@ describe("parseGmailMessage", () => {
 
   it("should detect unread status from UNREAD label", () => {
     const unread = parseGmailMessage(
-      makeMessage({ labelIds: ["INBOX", "UNREAD"] }),
+      createMockGmailMessage({ labelIds: ["INBOX", "UNREAD"] }),
     );
     expect(unread.isRead).toBe(false);
 
-    const read = parseGmailMessage(makeMessage({ labelIds: ["INBOX"] }));
+    const read = parseGmailMessage(createMockGmailMessage({ labelIds: ["INBOX"] }));
     expect(read.isRead).toBe(true);
   });
 
   it("should detect starred status from STARRED label", () => {
     const starred = parseGmailMessage(
-      makeMessage({ labelIds: ["INBOX", "STARRED"] }),
+      createMockGmailMessage({ labelIds: ["INBOX", "STARRED"] }),
     );
     expect(starred.isStarred).toBe(true);
 
     const notStarred = parseGmailMessage(
-      makeMessage({ labelIds: ["INBOX"] }),
+      createMockGmailMessage({ labelIds: ["INBOX"] }),
     );
     expect(notStarred.isStarred).toBe(false);
   });
 
   it("should detect attachments", () => {
-    const withAttachment = makeMessage();
+    const withAttachment = createMockGmailMessage();
     withAttachment.payload.parts!.push({
       partId: "2",
       mimeType: "application/pdf",
@@ -96,7 +52,7 @@ describe("parseGmailMessage", () => {
   });
 
   it("should handle plain email address without name", () => {
-    const msg = makeMessage();
+    const msg = createMockGmailMessage();
     msg.payload.headers = [
       { name: "From", value: "noreply@example.com" },
       { name: "To", value: "me@example.com" },
@@ -110,7 +66,7 @@ describe("parseGmailMessage", () => {
 
   it("should preserve label IDs", () => {
     const parsed = parseGmailMessage(
-      makeMessage({
+      createMockGmailMessage({
         labelIds: ["INBOX", "UNREAD", "IMPORTANT", "Label_123"],
       }),
     );

--- a/src/services/imap/folderMapper.test.ts
+++ b/src/services/imap/folderMapper.test.ts
@@ -1,82 +1,70 @@
 import { describe, it, expect } from "vitest";
 import { mapFolderToLabel, getLabelsForMessage, getSyncableFolders } from "./folderMapper";
-import type { ImapFolder } from "./tauriCommands";
-
-function makeFolder(overrides: Partial<ImapFolder> = {}): ImapFolder {
-  return {
-    path: "INBOX",
-    name: "INBOX",
-    delimiter: "/",
-    special_use: null,
-    exists: 100,
-    unseen: 10,
-    ...overrides,
-  };
-}
+import { createMockImapFolder } from "@/test/mocks";
 
 describe("mapFolderToLabel", () => {
   it("maps special_use \\Inbox to INBOX label", () => {
-    const folder = makeFolder({ special_use: "\\Inbox" });
+    const folder = createMockImapFolder({ special_use: "\\Inbox" });
     const result = mapFolderToLabel(folder);
     expect(result).toEqual({ labelId: "INBOX", labelName: "Inbox", type: "system" });
   });
 
   it("maps special_use \\Sent to SENT label", () => {
-    const folder = makeFolder({ path: "Sent", name: "Sent", special_use: "\\Sent" });
+    const folder = createMockImapFolder({ path: "Sent", name: "Sent", special_use: "\\Sent" });
     const result = mapFolderToLabel(folder);
     expect(result).toEqual({ labelId: "SENT", labelName: "Sent", type: "system" });
   });
 
   it("maps special_use \\Drafts to DRAFT label", () => {
-    const folder = makeFolder({ path: "Drafts", name: "Drafts", special_use: "\\Drafts" });
+    const folder = createMockImapFolder({ path: "Drafts", name: "Drafts", special_use: "\\Drafts" });
     const result = mapFolderToLabel(folder);
     expect(result).toEqual({ labelId: "DRAFT", labelName: "Drafts", type: "system" });
   });
 
   it("maps special_use \\Trash to TRASH label", () => {
-    const folder = makeFolder({ path: "Trash", name: "Trash", special_use: "\\Trash" });
+    const folder = createMockImapFolder({ path: "Trash", name: "Trash", special_use: "\\Trash" });
     const result = mapFolderToLabel(folder);
     expect(result).toEqual({ labelId: "TRASH", labelName: "Trash", type: "system" });
   });
 
   it("maps special_use \\Junk to SPAM label", () => {
-    const folder = makeFolder({ path: "Junk", name: "Junk", special_use: "\\Junk" });
+    const folder = createMockImapFolder({ path: "Junk", name: "Junk", special_use: "\\Junk" });
     const result = mapFolderToLabel(folder);
     expect(result).toEqual({ labelId: "SPAM", labelName: "Spam", type: "system" });
   });
 
   it("maps special_use \\Archive to archive label", () => {
-    const folder = makeFolder({ path: "Archive", name: "Archive", special_use: "\\Archive" });
+    const folder = createMockImapFolder({ path: "Archive", name: "Archive", special_use: "\\Archive" });
     const result = mapFolderToLabel(folder);
     expect(result).toEqual({ labelId: "archive", labelName: "Archive", type: "system" });
   });
 
   it("falls back to folder name when no special_use", () => {
-    const folder = makeFolder({ path: "INBOX", name: "INBOX", special_use: null });
+    const folder = createMockImapFolder({ path: "INBOX", name: "INBOX", special_use: null });
     const result = mapFolderToLabel(folder);
     expect(result).toEqual({ labelId: "INBOX", labelName: "Inbox", type: "system" });
   });
 
   it("falls back to name-based detection for Sent Items", () => {
-    const folder = makeFolder({ path: "Sent Items", name: "Sent Items", special_use: null });
+    const folder = createMockImapFolder({ path: "Sent Items", name: "Sent Items", special_use: null });
     const result = mapFolderToLabel(folder);
     expect(result).toEqual({ labelId: "SENT", labelName: "Sent", type: "system" });
   });
 
   it("falls back to name-based detection for Deleted Items", () => {
-    const folder = makeFolder({ path: "Deleted Items", name: "Deleted Items", special_use: null });
+    const folder = createMockImapFolder({ path: "Deleted Items", name: "Deleted Items", special_use: null });
     const result = mapFolderToLabel(folder);
     expect(result).toEqual({ labelId: "TRASH", labelName: "Trash", type: "system" });
   });
 
   it("maps [Gmail]/Sent Mail correctly", () => {
-    const folder = makeFolder({ path: "[Gmail]/Sent Mail", name: "Sent Mail", special_use: null });
+    const folder = createMockImapFolder({ path: "[Gmail]/Sent Mail", name: "Sent Mail", special_use: null });
     const result = mapFolderToLabel(folder);
     expect(result).toEqual({ labelId: "SENT", labelName: "Sent", type: "system" });
   });
 
   it("creates user folder label for unrecognized folders", () => {
-    const folder = makeFolder({ path: "My Folder", name: "My Folder", special_use: null });
+    const folder = createMockImapFolder({ path: "My Folder", name: "My Folder", special_use: null });
     const result = mapFolderToLabel(folder);
     expect(result).toEqual({
       labelId: "folder-My Folder",
@@ -86,7 +74,7 @@ describe("mapFolderToLabel", () => {
   });
 
   it("creates user folder label for nested folders", () => {
-    const folder = makeFolder({ path: "Work/Projects", name: "Projects", special_use: null });
+    const folder = createMockImapFolder({ path: "Work/Projects", name: "Projects", special_use: null });
     const result = mapFolderToLabel(folder);
     expect(result).toEqual({
       labelId: "folder-Work/Projects",
@@ -133,9 +121,9 @@ describe("getLabelsForMessage", () => {
 describe("getSyncableFolders", () => {
   it("filters out [Gmail] parent folder", () => {
     const folders: ImapFolder[] = [
-      makeFolder({ path: "INBOX", name: "INBOX" }),
-      makeFolder({ path: "[Gmail]", name: "[Gmail]" }),
-      makeFolder({ path: "[Gmail]/Sent Mail", name: "Sent Mail" }),
+      createMockImapFolder({ path: "INBOX", name: "INBOX" }),
+      createMockImapFolder({ path: "[Gmail]", name: "[Gmail]" }),
+      createMockImapFolder({ path: "[Gmail]/Sent Mail", name: "Sent Mail" }),
     ];
     const result = getSyncableFolders(folders);
     expect(result).toHaveLength(2);
@@ -144,8 +132,8 @@ describe("getSyncableFolders", () => {
 
   it("filters out [Google Mail] parent folder", () => {
     const folders: ImapFolder[] = [
-      makeFolder({ path: "INBOX", name: "INBOX" }),
-      makeFolder({ path: "[Google Mail]", name: "[Google Mail]" }),
+      createMockImapFolder({ path: "INBOX", name: "INBOX" }),
+      createMockImapFolder({ path: "[Google Mail]", name: "[Google Mail]" }),
     ];
     const result = getSyncableFolders(folders);
     expect(result).toHaveLength(1);
@@ -153,9 +141,9 @@ describe("getSyncableFolders", () => {
 
   it("keeps all normal folders", () => {
     const folders: ImapFolder[] = [
-      makeFolder({ path: "INBOX", name: "INBOX" }),
-      makeFolder({ path: "Sent", name: "Sent" }),
-      makeFolder({ path: "Work", name: "Work" }),
+      createMockImapFolder({ path: "INBOX", name: "INBOX" }),
+      createMockImapFolder({ path: "Sent", name: "Sent" }),
+      createMockImapFolder({ path: "Work", name: "Work" }),
     ];
     const result = getSyncableFolders(folders);
     expect(result).toHaveLength(3);

--- a/src/services/imap/imapConfigBuilder.test.ts
+++ b/src/services/imap/imapConfigBuilder.test.ts
@@ -1,41 +1,10 @@
 import { describe, it, expect } from "vitest";
 import { buildImapConfig, buildSmtpConfig } from "./imapConfigBuilder";
-import type { DbAccount } from "../db/accounts";
-
-function makeAccount(overrides: Partial<DbAccount> = {}): DbAccount {
-  return {
-    id: "acc-1",
-    email: "user@example.com",
-    display_name: "Test User",
-    avatar_url: null,
-    access_token: null,
-    refresh_token: null,
-    token_expires_at: null,
-    history_id: null,
-    last_sync_at: null,
-    is_active: 1,
-    created_at: 1700000000,
-    updated_at: 1700000000,
-    provider: "imap",
-    imap_host: "imap.example.com",
-    imap_port: 993,
-    imap_security: "ssl",
-    smtp_host: "smtp.example.com",
-    smtp_port: 587,
-    smtp_security: "starttls",
-    auth_method: "password",
-    imap_password: "secret123",
-    oauth_provider: null,
-    oauth_client_id: null,
-    oauth_client_secret: null,
-    imap_username: null,
-    ...overrides,
-  };
-}
+import { createMockDbAccount } from "@/test/mocks";
 
 describe("buildImapConfig", () => {
   it("builds config from account with ssl security mapped to tls", () => {
-    const account = makeAccount();
+    const account = createMockDbAccount();
     const config = buildImapConfig(account);
 
     expect(config).toEqual({
@@ -49,61 +18,61 @@ describe("buildImapConfig", () => {
   });
 
   it("maps tls security to tls", () => {
-    const account = makeAccount({ imap_security: "tls" });
+    const account = createMockDbAccount({ imap_security: "tls" });
     const config = buildImapConfig(account);
     expect(config.security).toBe("tls");
   });
 
   it("maps starttls security to starttls", () => {
-    const account = makeAccount({ imap_security: "starttls" });
+    const account = createMockDbAccount({ imap_security: "starttls" });
     const config = buildImapConfig(account);
     expect(config.security).toBe("starttls");
   });
 
   it("maps none security to none", () => {
-    const account = makeAccount({ imap_security: "none" });
+    const account = createMockDbAccount({ imap_security: "none" });
     const config = buildImapConfig(account);
     expect(config.security).toBe("none");
   });
 
   it("defaults to tls when security is null", () => {
-    const account = makeAccount({ imap_security: null });
+    const account = createMockDbAccount({ imap_security: null });
     const config = buildImapConfig(account);
     expect(config.security).toBe("tls");
   });
 
   it("defaults port to 993 when null", () => {
-    const account = makeAccount({ imap_port: null });
+    const account = createMockDbAccount({ imap_port: null });
     const config = buildImapConfig(account);
     expect(config.port).toBe(993);
   });
 
   it("handles oauth2 auth method", () => {
-    const account = makeAccount({ auth_method: "oauth2" });
+    const account = createMockDbAccount({ auth_method: "oauth2" });
     const config = buildImapConfig(account);
     expect(config.auth_method).toBe("oauth2");
   });
 
   it("uses accessToken override for oauth2 accounts", () => {
-    const account = makeAccount({ auth_method: "oauth2", imap_password: "old" });
+    const account = createMockDbAccount({ auth_method: "oauth2", imap_password: "old" });
     const config = buildImapConfig(account, "fresh-token");
     expect(config.password).toBe("fresh-token");
     expect(config.auth_method).toBe("oauth2");
   });
 
   it("ignores accessToken override for password accounts", () => {
-    const account = makeAccount({ auth_method: "password" });
+    const account = createMockDbAccount({ auth_method: "password" });
     const config = buildImapConfig(account, "should-not-use");
     expect(config.password).toBe("secret123");
   });
 
   it("throws when imap_host is missing", () => {
-    const account = makeAccount({ imap_host: null });
+    const account = createMockDbAccount({ imap_host: null });
     expect(() => buildImapConfig(account)).toThrow("no IMAP host configured");
   });
 
   it("handles empty password gracefully", () => {
-    const account = makeAccount({ imap_password: null });
+    const account = createMockDbAccount({ imap_password: null });
     const config = buildImapConfig(account);
     expect(config.password).toBe("");
   });
@@ -111,7 +80,7 @@ describe("buildImapConfig", () => {
 
 describe("buildSmtpConfig", () => {
   it("builds config from account SMTP fields", () => {
-    const account = makeAccount();
+    const account = createMockDbAccount();
     const config = buildSmtpConfig(account);
 
     expect(config).toEqual({
@@ -125,24 +94,24 @@ describe("buildSmtpConfig", () => {
   });
 
   it("defaults port to 587 when null", () => {
-    const account = makeAccount({ smtp_port: null });
+    const account = createMockDbAccount({ smtp_port: null });
     const config = buildSmtpConfig(account);
     expect(config.port).toBe(587);
   });
 
   it("throws when smtp_host is missing", () => {
-    const account = makeAccount({ smtp_host: null });
+    const account = createMockDbAccount({ smtp_host: null });
     expect(() => buildSmtpConfig(account)).toThrow("no SMTP host configured");
   });
 
   it("maps ssl security to tls for SMTP", () => {
-    const account = makeAccount({ smtp_security: "ssl" });
+    const account = createMockDbAccount({ smtp_security: "ssl" });
     const config = buildSmtpConfig(account);
     expect(config.security).toBe("tls");
   });
 
   it("uses accessToken override for oauth2 SMTP", () => {
-    const account = makeAccount({ auth_method: "oauth2" });
+    const account = createMockDbAccount({ auth_method: "oauth2" });
     const config = buildSmtpConfig(account, "smtp-oauth-token");
     expect(config.password).toBe("smtp-oauth-token");
     expect(config.auth_method).toBe("oauth2");
@@ -151,25 +120,25 @@ describe("buildSmtpConfig", () => {
 
 describe("imap_username override", () => {
   it("uses imap_username when set for IMAP config", () => {
-    const account = makeAccount({ imap_username: "custom-user" });
+    const account = createMockDbAccount({ imap_username: "custom-user" });
     const config = buildImapConfig(account);
     expect(config.username).toBe("custom-user");
   });
 
   it("uses imap_username when set for SMTP config", () => {
-    const account = makeAccount({ imap_username: "custom-user" });
+    const account = createMockDbAccount({ imap_username: "custom-user" });
     const config = buildSmtpConfig(account);
     expect(config.username).toBe("custom-user");
   });
 
   it("falls back to email when imap_username is null", () => {
-    const account = makeAccount({ imap_username: null });
+    const account = createMockDbAccount({ imap_username: null });
     const config = buildImapConfig(account);
     expect(config.username).toBe("user@example.com");
   });
 
   it("falls back to email when imap_username is empty string", () => {
-    const account = makeAccount({ imap_username: "" as string | null });
+    const account = createMockDbAccount({ imap_username: "" as string | null });
     const config = buildImapConfig(account);
     expect(config.username).toBe("user@example.com");
   });

--- a/src/services/queue/queueProcessor.test.ts
+++ b/src/services/queue/queueProcessor.test.ts
@@ -45,24 +45,24 @@ import {
 import { executeQueuedAction } from "../emailActions";
 import { classifyError } from "@/utils/networkErrors";
 import { startQueueProcessor, stopQueueProcessor, triggerQueueFlush } from "./queueProcessor";
+import { createMockUIStoreState } from "@/test/mocks";
 
 const mockSetPendingOpsCount = vi.fn();
 
 describe("queueProcessor", () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    vi.mocked(useUIStore.getState).mockReturnValue({
-      isOnline: true,
+    vi.mocked(useUIStore.getState).mockReturnValue(createMockUIStoreState({
       setPendingOpsCount: mockSetPendingOpsCount,
-    } as never);
+    }) as never);
     vi.mocked(getPendingOperations).mockResolvedValue([]);
   });
 
   it("skips processing when offline", async () => {
-    vi.mocked(useUIStore.getState).mockReturnValue({
+    vi.mocked(useUIStore.getState).mockReturnValue(createMockUIStoreState({
       isOnline: false,
       setPendingOpsCount: mockSetPendingOpsCount,
-    } as never);
+    }) as never);
     await triggerQueueFlush();
     expect(getPendingOperations).not.toHaveBeenCalled();
   });

--- a/src/services/quickSteps/executor.test.ts
+++ b/src/services/quickSteps/executor.test.ts
@@ -53,24 +53,7 @@ import { setThreadCategory } from "@/services/db/threadCategories";
 import { snoozeThread } from "@/services/snooze/snoozeManager";
 import { useThreadStore } from "@/stores/threadStore";
 import { executeQuickStep } from "./executor";
-import type { QuickStep } from "./types";
-
-function makeQuickStep(overrides: Partial<QuickStep> = {}): QuickStep {
-  return {
-    id: "qs-1",
-    accountId: "acct-1",
-    name: "Test Quick Step",
-    description: null,
-    shortcut: null,
-    actions: [],
-    icon: null,
-    isEnabled: true,
-    continueOnError: false,
-    sortOrder: 0,
-    createdAt: Date.now(),
-    ...overrides,
-  };
-}
+import { createMockQuickStep } from "@/test/mocks";
 
 describe("executeQuickStep", () => {
   beforeEach(() => {
@@ -78,7 +61,7 @@ describe("executeQuickStep", () => {
   });
 
   it("executes a single archive action", async () => {
-    const step = makeQuickStep({
+    const step = createMockQuickStep({
       actions: [{ type: "archive" }],
     });
 
@@ -93,7 +76,7 @@ describe("executeQuickStep", () => {
   });
 
   it("executes a multi-action chain (markRead + archive)", async () => {
-    const step = makeQuickStep({
+    const step = createMockQuickStep({
       actions: [{ type: "markRead" }, { type: "archive" }],
     });
 
@@ -117,7 +100,7 @@ describe("executeQuickStep", () => {
     // Make the archive action fail
     mockArchiveThread.mockRejectedValueOnce(new Error("API Error"));
 
-    const step = makeQuickStep({
+    const step = createMockQuickStep({
       actions: [{ type: "archive" }, { type: "markRead" }],
     });
 
@@ -137,7 +120,7 @@ describe("executeQuickStep", () => {
     // Make the archive action fail
     mockArchiveThread.mockRejectedValueOnce(new Error("API Error"));
 
-    const step = makeQuickStep({
+    const step = createMockQuickStep({
       continueOnError: true,
       actions: [{ type: "archive" }, { type: "markRead" }],
     });
@@ -156,7 +139,7 @@ describe("executeQuickStep", () => {
   });
 
   it("defers thread removal until chain completes", async () => {
-    const step = makeQuickStep({
+    const step = createMockQuickStep({
       actions: [{ type: "star" }, { type: "archive" }],
     });
 
@@ -178,7 +161,7 @@ describe("executeQuickStep", () => {
   it("dispatches event for reply action and does not remove from view", async () => {
     const dispatchSpy = vi.spyOn(window, "dispatchEvent");
 
-    const step = makeQuickStep({
+    const step = createMockQuickStep({
       actions: [{ type: "reply" }],
     });
 
@@ -197,7 +180,7 @@ describe("executeQuickStep", () => {
   });
 
   it("executes pin and unpin actions", async () => {
-    const step = makeQuickStep({
+    const step = createMockQuickStep({
       actions: [{ type: "pin" }],
     });
 
@@ -209,7 +192,7 @@ describe("executeQuickStep", () => {
 
     vi.clearAllMocks();
 
-    const step2 = makeQuickStep({ actions: [{ type: "unpin" }] });
+    const step2 = createMockQuickStep({ actions: [{ type: "unpin" }] });
     await executeQuickStep(step2, ["t1"], "acct-1");
     expect(unpinThread).toHaveBeenCalledWith("acct-1", "t1");
     expect(useThreadStore.getState().updateThread).toHaveBeenCalledWith("t1", { isPinned: false });
@@ -219,7 +202,7 @@ describe("executeQuickStep", () => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date("2024-01-01T00:00:00Z"));
 
-    const step = makeQuickStep({
+    const step = createMockQuickStep({
       actions: [{ type: "snooze", params: { snoozeDuration: 3600000 } }],
     });
 
@@ -234,7 +217,7 @@ describe("executeQuickStep", () => {
   it("executes moveToCategory action", async () => {
     const dispatchSpy = vi.spyOn(window, "dispatchEvent");
 
-    const step = makeQuickStep({
+    const step = createMockQuickStep({
       actions: [{ type: "moveToCategory", params: { category: "Promotions" } }],
     });
 
@@ -248,7 +231,7 @@ describe("executeQuickStep", () => {
   });
 
   it("executes spam action", async () => {
-    const step = makeQuickStep({
+    const step = createMockQuickStep({
       actions: [{ type: "spam" }],
     });
 
@@ -260,7 +243,7 @@ describe("executeQuickStep", () => {
   });
 
   it("handles multiple threads", async () => {
-    const step = makeQuickStep({
+    const step = createMockQuickStep({
       actions: [{ type: "markRead" }],
     });
 
@@ -273,7 +256,7 @@ describe("executeQuickStep", () => {
   });
 
   it("returns correct result for empty action list", async () => {
-    const step = makeQuickStep({ actions: [] });
+    const step = createMockQuickStep({ actions: [] });
 
     const result = await executeQuickStep(step, ["t1"], "acct-1");
 

--- a/src/stores/labelStore.test.ts
+++ b/src/stores/labelStore.test.ts
@@ -20,14 +20,7 @@ const mockDbDeleteLabel = vi.mocked(dbDeleteLabel);
 const mockUpdateSortOrder = vi.mocked(updateLabelSortOrder);
 const mockUpsertLabel = vi.mocked(upsertLabel);
 const mockGetGmailClient = vi.mocked(getGmailClient);
-
-function makeMockClient() {
-  return {
-    createLabel: vi.fn(),
-    updateLabel: vi.fn(),
-    deleteLabel: vi.fn(),
-  };
-}
+import { createMockGmailClient } from "@/test/mocks";
 
 describe("labelStore", () => {
   beforeEach(() => {
@@ -97,7 +90,7 @@ describe("labelStore", () => {
   });
 
   it("should create a label via Gmail API and update DB", async () => {
-    const mockClient = makeMockClient();
+    const mockClient = createMockGmailClient();
     mockClient.createLabel.mockResolvedValue({
       id: "Label_new",
       name: "New Label",
@@ -124,7 +117,7 @@ describe("labelStore", () => {
   });
 
   it("should update a label via Gmail API and update DB", async () => {
-    const mockClient = makeMockClient();
+    const mockClient = createMockGmailClient();
     mockClient.updateLabel.mockResolvedValue({
       id: "Label_1",
       name: "Renamed",
@@ -149,7 +142,7 @@ describe("labelStore", () => {
   });
 
   it("should delete a label via Gmail API and DB", async () => {
-    const mockClient = makeMockClient();
+    const mockClient = createMockGmailClient();
     mockClient.deleteLabel.mockResolvedValue(undefined);
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     mockGetGmailClient.mockResolvedValue(mockClient as any);

--- a/src/test/mocks/db.mock.ts
+++ b/src/test/mocks/db.mock.ts
@@ -1,0 +1,6 @@
+export function createMockDb() {
+  return {
+    select: vi.fn(() => Promise.resolve([])),
+    execute: vi.fn(() => Promise.resolve({ rowsAffected: 1 })),
+  };
+}

--- a/src/test/mocks/entities.mock.ts
+++ b/src/test/mocks/entities.mock.ts
@@ -1,0 +1,264 @@
+import type { ParsedMessage } from "@/services/gmail/messageParser";
+import type { GmailMessage } from "@/services/gmail/client";
+import type { DbAccount } from "@/services/db/accounts";
+import type { ImapMessage } from "@/services/imap/tauriCommands";
+import type { ImapFolder } from "@/services/imap/tauriCommands";
+import type { QuickStep } from "@/services/quickSteps/types";
+import type { SendAsAlias } from "@/services/db/sendAsAliases";
+
+export function createMockParsedMessage(
+  overrides: Partial<ParsedMessage> = {},
+): ParsedMessage {
+  return {
+    id: "msg-1",
+    threadId: "thread-1",
+    fromAddress: "alice@example.com",
+    fromName: "Alice Smith",
+    toAddresses: "bob@example.com",
+    ccAddresses: null,
+    bccAddresses: null,
+    replyTo: null,
+    subject: "Project Update",
+    snippet: "Here is the latest update...",
+    date: Date.now(),
+    isRead: false,
+    isStarred: false,
+    bodyHtml: "<p>Hello from the project</p>",
+    bodyText: "Hello from the project",
+    rawSize: 1024,
+    internalDate: Date.now(),
+    labelIds: ["INBOX", "UNREAD"],
+    hasAttachments: false,
+    attachments: [],
+    listUnsubscribe: null,
+    ...overrides,
+  };
+}
+
+export function createMockGmailMessage(
+  overrides: Partial<GmailMessage> = {},
+): GmailMessage {
+  return {
+    id: "msg-1",
+    threadId: "thread-1",
+    labelIds: ["INBOX", "UNREAD"],
+    snippet: "Hello this is a test",
+    historyId: "12345",
+    internalDate: "1700000000000",
+    sizeEstimate: 1024,
+    payload: {
+      partId: "",
+      mimeType: "multipart/alternative",
+      filename: "",
+      headers: [
+        { name: "From", value: "John Doe <john@example.com>" },
+        { name: "To", value: "me@example.com" },
+        { name: "Subject", value: "Test Subject" },
+        { name: "Cc", value: "" },
+      ],
+      body: { size: 0 },
+      parts: [
+        {
+          partId: "0",
+          mimeType: "text/plain",
+          filename: "",
+          headers: [],
+          body: { size: 11, data: "SGVsbG8gV29ybGQ" },
+        },
+        {
+          partId: "1",
+          mimeType: "text/html",
+          filename: "",
+          headers: [],
+          body: {
+            size: 28,
+            data: "PGI-SGVsbG8gV29ybGQ8L2I-",
+          },
+        },
+      ],
+    },
+    ...overrides,
+  };
+}
+
+export function createMockGmailAccount(
+  overrides: Partial<DbAccount> = {},
+): DbAccount {
+  return {
+    id: "acc-gmail",
+    email: "user@gmail.com",
+    display_name: "Gmail User",
+    avatar_url: null,
+    access_token: "enc:access-token",
+    refresh_token: "enc:refresh-token",
+    token_expires_at: 9999999999,
+    history_id: "12345",
+    last_sync_at: 1700000000,
+    is_active: 1,
+    created_at: 1700000000,
+    updated_at: 1700000000,
+    provider: "gmail_api",
+    imap_host: null,
+    imap_port: null,
+    imap_security: null,
+    smtp_host: null,
+    smtp_port: null,
+    smtp_security: null,
+    auth_method: "oauth",
+    imap_password: null,
+    oauth_provider: null,
+    oauth_client_id: null,
+    oauth_client_secret: null,
+    imap_username: null,
+    ...overrides,
+  };
+}
+
+export function createMockImapAccount(
+  overrides: Partial<DbAccount> = {},
+): DbAccount {
+  return {
+    id: "acc-imap",
+    email: "user@example.com",
+    display_name: "IMAP User",
+    avatar_url: null,
+    access_token: null,
+    refresh_token: null,
+    token_expires_at: null,
+    history_id: null,
+    last_sync_at: null,
+    is_active: 1,
+    created_at: 1700000000,
+    updated_at: 1700000000,
+    provider: "imap",
+    imap_host: "imap.example.com",
+    imap_port: 993,
+    imap_security: "tls",
+    smtp_host: "smtp.example.com",
+    smtp_port: 465,
+    smtp_security: "tls",
+    auth_method: "password",
+    imap_password: "enc:secret-password",
+    oauth_provider: null,
+    oauth_client_id: null,
+    oauth_client_secret: null,
+    imap_username: null,
+    ...overrides,
+  };
+}
+
+export function createMockDbAccount(
+  overrides: Partial<DbAccount> = {},
+): DbAccount {
+  return {
+    id: "acc-1",
+    email: "user@example.com",
+    display_name: "Test User",
+    avatar_url: null,
+    access_token: null,
+    refresh_token: null,
+    token_expires_at: null,
+    history_id: null,
+    last_sync_at: null,
+    is_active: 1,
+    created_at: 1700000000,
+    updated_at: 1700000000,
+    provider: "imap",
+    imap_host: "imap.example.com",
+    imap_port: 993,
+    imap_security: "ssl",
+    smtp_host: "smtp.example.com",
+    smtp_port: 587,
+    smtp_security: "starttls",
+    auth_method: "password",
+    imap_password: "secret123",
+    oauth_provider: null,
+    oauth_client_id: null,
+    oauth_client_secret: null,
+    imap_username: null,
+    ...overrides,
+  };
+}
+
+export function createMockImapMessage(
+  overrides: Partial<ImapMessage> = {},
+): ImapMessage {
+  return {
+    uid: 42,
+    folder: "INBOX",
+    message_id: "<test-123@example.com>",
+    in_reply_to: null,
+    references: null,
+    from_address: "sender@example.com",
+    from_name: "Sender Name",
+    to_addresses: "recipient@example.com",
+    cc_addresses: null,
+    bcc_addresses: null,
+    reply_to: null,
+    subject: "Test Subject",
+    date: 1700000000,
+    is_read: false,
+    is_starred: false,
+    is_draft: false,
+    body_html: "<p>Hello</p>",
+    body_text: "Hello",
+    snippet: "Hello",
+    raw_size: 1024,
+    list_unsubscribe: null,
+    list_unsubscribe_post: null,
+    auth_results: null,
+    attachments: [],
+    ...overrides,
+  };
+}
+
+export function createMockImapFolder(
+  overrides: Partial<ImapFolder> = {},
+): ImapFolder {
+  return {
+    path: "INBOX",
+    name: "INBOX",
+    delimiter: "/",
+    special_use: null,
+    exists: 100,
+    unseen: 10,
+    ...overrides,
+  };
+}
+
+export function createMockQuickStep(
+  overrides: Partial<QuickStep> = {},
+): QuickStep {
+  return {
+    id: "qs-1",
+    accountId: "acct-1",
+    name: "Test Quick Step",
+    description: null,
+    shortcut: null,
+    actions: [],
+    icon: null,
+    isEnabled: true,
+    continueOnError: false,
+    sortOrder: 0,
+    createdAt: Date.now(),
+    ...overrides,
+  };
+}
+
+export function createMockSendAsAlias(
+  overrides: Partial<SendAsAlias> = {},
+): SendAsAlias {
+  return {
+    id: "alias-1",
+    accountId: "acc-1",
+    email: "primary@example.com",
+    displayName: null,
+    replyToAddress: null,
+    signatureId: null,
+    isPrimary: false,
+    isDefault: false,
+    treatAsAlias: true,
+    verificationStatus: "accepted",
+    ...overrides,
+  };
+}

--- a/src/test/mocks/index.ts
+++ b/src/test/mocks/index.ts
@@ -1,0 +1,22 @@
+export { createMockDb } from "./db.mock";
+export {
+  createMockParsedMessage,
+  createMockGmailMessage,
+  createMockGmailAccount,
+  createMockImapAccount,
+  createMockDbAccount,
+  createMockImapMessage,
+  createMockImapFolder,
+  createMockQuickStep,
+  createMockSendAsAlias,
+} from "./entities.mock";
+export {
+  createMockGmailClient,
+  createMockEmailProvider,
+  createMockAiProvider,
+} from "./services.mock";
+export {
+  createMockUIStoreState,
+  createMockThreadStoreState,
+  createMockAccountStoreState,
+} from "./stores.mock";

--- a/src/test/mocks/services.mock.ts
+++ b/src/test/mocks/services.mock.ts
@@ -1,0 +1,55 @@
+import type { GmailClient } from "@/services/gmail/client";
+
+export function createMockGmailClient(
+  overrides: Record<string, unknown> = {},
+): GmailClient {
+  return {
+    listLabels: vi.fn(),
+    createLabel: vi.fn(),
+    deleteLabel: vi.fn(),
+    updateLabel: vi.fn(),
+    modifyThread: vi.fn(),
+    deleteThread: vi.fn(),
+    getMessage: vi.fn(),
+    getAttachment: vi.fn(),
+    sendMessage: vi.fn(),
+    createDraft: vi.fn(),
+    updateDraft: vi.fn(),
+    deleteDraft: vi.fn(),
+    getProfile: vi.fn(),
+    getHistory: vi.fn(),
+    getThread: vi.fn(),
+    listThreads: vi.fn(),
+    listDrafts: vi.fn(),
+    request: vi.fn(),
+    ...overrides,
+  } as unknown as GmailClient;
+}
+
+export function createMockEmailProvider(
+  overrides: Record<string, unknown> = {},
+) {
+  return {
+    archive: vi.fn(() => Promise.resolve()),
+    trash: vi.fn(() => Promise.resolve()),
+    permanentDelete: vi.fn(() => Promise.resolve()),
+    markRead: vi.fn(() => Promise.resolve()),
+    star: vi.fn(() => Promise.resolve()),
+    spam: vi.fn(() => Promise.resolve()),
+    moveToFolder: vi.fn(() => Promise.resolve()),
+    addLabel: vi.fn(() => Promise.resolve()),
+    removeLabel: vi.fn(() => Promise.resolve()),
+    sendMessage: vi.fn(() => Promise.resolve({ id: "msg-1" })),
+    createDraft: vi.fn(() => Promise.resolve({ draftId: "d-1" })),
+    updateDraft: vi.fn(() => Promise.resolve({ draftId: "d-1" })),
+    deleteDraft: vi.fn(() => Promise.resolve()),
+    ...overrides,
+  };
+}
+
+export function createMockAiProvider(response = "ai response") {
+  return {
+    complete: vi.fn(() => Promise.resolve(response)),
+    testConnection: vi.fn(() => Promise.resolve(true)),
+  };
+}

--- a/src/test/mocks/stores.mock.ts
+++ b/src/test/mocks/stores.mock.ts
@@ -1,0 +1,29 @@
+export function createMockUIStoreState(overrides: Record<string, unknown> = {}) {
+  return {
+    isOnline: true,
+    setPendingOpsCount: vi.fn(),
+    ...overrides,
+  };
+}
+
+export function createMockThreadStoreState(
+  overrides: Record<string, unknown> = {},
+) {
+  return {
+    threads: [],
+    updateThread: vi.fn(),
+    removeThread: vi.fn(),
+    removeThreads: vi.fn(),
+    ...overrides,
+  };
+}
+
+export function createMockAccountStoreState(
+  overrides: Record<string, unknown> = {},
+) {
+  return {
+    accounts: [],
+    activeAccountId: null,
+    ...overrides,
+  };
+}

--- a/src/utils/resolveFromAddress.test.ts
+++ b/src/utils/resolveFromAddress.test.ts
@@ -1,22 +1,6 @@
 import { describe, it, expect } from "vitest";
 import { resolveFromAddress } from "./resolveFromAddress";
-import type { SendAsAlias } from "@/services/db/sendAsAliases";
-
-function makeAlias(overrides: Partial<SendAsAlias> = {}): SendAsAlias {
-  return {
-    id: "alias-1",
-    accountId: "acc-1",
-    email: "primary@example.com",
-    displayName: null,
-    replyToAddress: null,
-    signatureId: null,
-    isPrimary: false,
-    isDefault: false,
-    treatAsAlias: true,
-    verificationStatus: "accepted",
-    ...overrides,
-  };
-}
+import { createMockSendAsAlias } from "@/test/mocks";
 
 describe("resolveFromAddress", () => {
   it("returns null for empty aliases", () => {
@@ -26,8 +10,8 @@ describe("resolveFromAddress", () => {
 
   it("resolves matching alias from To field", () => {
     const aliases = [
-      makeAlias({ id: "a1", email: "primary@example.com", isPrimary: true }),
-      makeAlias({ id: "a2", email: "alias@example.com" }),
+      createMockSendAsAlias({ id: "a1", email: "primary@example.com", isPrimary: true }),
+      createMockSendAsAlias({ id: "a2", email: "alias@example.com" }),
     ];
 
     const result = resolveFromAddress(aliases, "alias@example.com, other@test.com", null);
@@ -37,8 +21,8 @@ describe("resolveFromAddress", () => {
 
   it("resolves matching alias from CC field", () => {
     const aliases = [
-      makeAlias({ id: "a1", email: "primary@example.com", isPrimary: true }),
-      makeAlias({ id: "a2", email: "work@example.com" }),
+      createMockSendAsAlias({ id: "a1", email: "primary@example.com", isPrimary: true }),
+      createMockSendAsAlias({ id: "a2", email: "work@example.com" }),
     ];
 
     const result = resolveFromAddress(aliases, "someone@test.com", "work@example.com");
@@ -48,7 +32,7 @@ describe("resolveFromAddress", () => {
 
   it("is case-insensitive when matching addresses", () => {
     const aliases = [
-      makeAlias({ id: "a1", email: "User@Example.COM", isPrimary: true }),
+      createMockSendAsAlias({ id: "a1", email: "User@Example.COM", isPrimary: true }),
     ];
 
     const result = resolveFromAddress(aliases, "user@example.com", null);
@@ -57,8 +41,8 @@ describe("resolveFromAddress", () => {
 
   it("falls back to default when no match", () => {
     const aliases = [
-      makeAlias({ id: "a1", email: "primary@example.com", isPrimary: true }),
-      makeAlias({ id: "a2", email: "default@example.com", isDefault: true }),
+      createMockSendAsAlias({ id: "a1", email: "primary@example.com", isPrimary: true }),
+      createMockSendAsAlias({ id: "a2", email: "default@example.com", isDefault: true }),
     ];
 
     const result = resolveFromAddress(aliases, "unknown@test.com", null);
@@ -67,8 +51,8 @@ describe("resolveFromAddress", () => {
 
   it("falls back to primary when no default and no match", () => {
     const aliases = [
-      makeAlias({ id: "a1", email: "secondary@example.com" }),
-      makeAlias({ id: "a2", email: "primary@example.com", isPrimary: true }),
+      createMockSendAsAlias({ id: "a1", email: "secondary@example.com" }),
+      createMockSendAsAlias({ id: "a2", email: "primary@example.com", isPrimary: true }),
     ];
 
     const result = resolveFromAddress(aliases, "unknown@test.com", null);
@@ -77,8 +61,8 @@ describe("resolveFromAddress", () => {
 
   it("falls back to first alias when no default, no primary, no match", () => {
     const aliases = [
-      makeAlias({ id: "a1", email: "first@example.com" }),
-      makeAlias({ id: "a2", email: "second@example.com" }),
+      createMockSendAsAlias({ id: "a1", email: "first@example.com" }),
+      createMockSendAsAlias({ id: "a2", email: "second@example.com" }),
     ];
 
     const result = resolveFromAddress(aliases, "unknown@test.com", null);
@@ -87,8 +71,8 @@ describe("resolveFromAddress", () => {
 
   it("handles null toAddresses and ccAddresses", () => {
     const aliases = [
-      makeAlias({ id: "a1", email: "primary@example.com", isPrimary: true }),
-      makeAlias({ id: "a2", email: "default@example.com", isDefault: true }),
+      createMockSendAsAlias({ id: "a1", email: "primary@example.com", isPrimary: true }),
+      createMockSendAsAlias({ id: "a2", email: "default@example.com", isDefault: true }),
     ];
 
     const result = resolveFromAddress(aliases, null, null);
@@ -97,7 +81,7 @@ describe("resolveFromAddress", () => {
 
   it("handles empty string addresses", () => {
     const aliases = [
-      makeAlias({ id: "a1", email: "primary@example.com", isPrimary: true }),
+      createMockSendAsAlias({ id: "a1", email: "primary@example.com", isPrimary: true }),
     ];
 
     const result = resolveFromAddress(aliases, "", "");
@@ -106,8 +90,8 @@ describe("resolveFromAddress", () => {
 
   it("prefers To match over default alias", () => {
     const aliases = [
-      makeAlias({ id: "a1", email: "default@example.com", isDefault: true }),
-      makeAlias({ id: "a2", email: "match@example.com" }),
+      createMockSendAsAlias({ id: "a1", email: "default@example.com", isDefault: true }),
+      createMockSendAsAlias({ id: "a2", email: "match@example.com" }),
     ];
 
     const result = resolveFromAddress(aliases, "match@example.com", null);


### PR DESCRIPTION
## Summary
- Create shared mock infrastructure under `src/test/mocks/` with 5 files:
  - `entities.mock.ts` — 9 entity factories (ParsedMessage, GmailMessage, DbAccount variants, ImapMessage, ImapFolder, QuickStep, SendAsAlias)
  - `db.mock.ts` — `createMockDb()` factory for the `{ select, execute }` pattern
  - `services.mock.ts` — `createMockGmailClient()`, `createMockEmailProvider()`, `createMockAiProvider()`
  - `stores.mock.ts` — `createMockUIStoreState()`, `createMockThreadStoreState()`, `createMockAccountStoreState()`
  - `index.ts` — barrel re-export
- Migrate 23 test files to use shared factories, removing ~400 lines of duplicated mock definitions

## Test plan
- [x] All 87 test files pass (1046 tests)
- [x] No test behavior changed — only mock definitions were extracted