### PR TITLE
fix: resolve console warnings, TipTap duplicates, FS scope, and CI errors

### DIFF
--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -37,6 +37,7 @@
     {
       "identifier": "fs:scope",
       "allow": [
+        { "path": "$APPDATA" },
         { "path": "$APPDATA/**" }
       ]
     },

--- a/src/components/composer/Composer.tsx
+++ b/src/components/composer/Composer.tsx
@@ -2,8 +2,6 @@ import { useCallback, useEffect, useRef, useState } from "react";
 import { CSSTransition } from "react-transition-group";
 import { useEditor, EditorContent } from "@tiptap/react";
 import StarterKit from "@tiptap/starter-kit";
-import Link from "@tiptap/extension-link";
-import Underline from "@tiptap/extension-underline";
 import Placeholder from "@tiptap/extension-placeholder";
 import Image from "@tiptap/extension-image";
 import { Clock, Maximize2, Minimize2, ExternalLink } from "lucide-react";
@@ -84,9 +82,8 @@ export function Composer() {
     extensions: [
       StarterKit.configure({
         heading: { levels: [1, 2, 3] },
+        link: { openOnClick: false },
       }),
-      Link.configure({ openOnClick: false }),
-      Underline,
       Placeholder.configure({
         placeholder: "Write your message...",
       }),

--- a/src/components/email/InlineReply.tsx
+++ b/src/components/email/InlineReply.tsx
@@ -1,8 +1,6 @@
 import { useState, useCallback, useEffect, useRef } from "react";
 import { useEditor, EditorContent } from "@tiptap/react";
 import StarterKit from "@tiptap/starter-kit";
-import Link from "@tiptap/extension-link";
-import Underline from "@tiptap/extension-underline";
 import Placeholder from "@tiptap/extension-placeholder";
 import { Reply, ReplyAll, Forward, Send, Maximize2 } from "lucide-react";
 import { useAccountStore } from "@/stores/accountStore";
@@ -40,9 +38,7 @@ export function InlineReply({ thread, messages, accountId, noReply, onSent }: In
 
   const editor = useEditor({
     extensions: [
-      StarterKit.configure({ heading: false }),
-      Link.configure({ openOnClick: false }),
-      Underline,
+      StarterKit.configure({ heading: false, link: { openOnClick: false } }),
       Placeholder.configure({
         placeholder: "Write your reply...",
       }),

--- a/src/components/layout/Sidebar.tsx
+++ b/src/components/layout/Sidebar.tsx
@@ -162,14 +162,16 @@ function DroppableLabelItem({
             <Tag size={14} className="shrink-0" />
           )}
           <span className="flex-1 truncate">{label.name}</span>
-          <button
-            type="button"
+          <span
+            role="button"
+            tabIndex={0}
             onClick={(e) => { e.stopPropagation(); onEditClick(); }}
+            onKeyDown={(e) => { if (e.key === "Enter" || e.key === " ") { e.preventDefault(); e.stopPropagation(); onEditClick(); } }}
             className="opacity-0 group-hover:opacity-100 p-0.5 text-sidebar-text/40 hover:text-sidebar-text transition-opacity"
             title="Edit label"
           >
             <Pencil size={12} />
-          </button>
+          </span>
         </>
       )}
     </button>
@@ -330,10 +332,19 @@ export function Sidebar({ collapsed, onAddAccount }: SidebarProps) {
                       <span className="flex-1 truncate">{item.label}</span>
                     )}
                     {isInbox && !collapsed && (
-                      <button
+                      <span
+                        role="button"
+                        tabIndex={0}
                         onClick={(e) => {
                           e.stopPropagation();
                           setInboxViewMode(inboxViewMode === "split" ? "unified" : "split");
+                        }}
+                        onKeyDown={(e) => {
+                          if (e.key === "Enter" || e.key === " ") {
+                            e.preventDefault();
+                            e.stopPropagation();
+                            setInboxViewMode(inboxViewMode === "split" ? "unified" : "split");
+                          }
                         }}
                         title={inboxViewMode === "split" ? "Switch to unified inbox" : "Switch to split inbox"}
                         className={`p-1 rounded transition-colors ${
@@ -343,7 +354,7 @@ export function Sidebar({ collapsed, onAddAccount }: SidebarProps) {
                         }`}
                       >
                         <Columns2 size={14} />
-                      </button>
+                      </span>
                     )}
                   </>
                 )}

--- a/src/components/settings/SignatureEditor.tsx
+++ b/src/components/settings/SignatureEditor.tsx
@@ -1,8 +1,6 @@
 import { useState, useEffect, useCallback } from "react";
 import { useEditor, EditorContent } from "@tiptap/react";
 import StarterKit from "@tiptap/starter-kit";
-import Link from "@tiptap/extension-link";
-import Underline from "@tiptap/extension-underline";
 import Placeholder from "@tiptap/extension-placeholder";
 import Image from "@tiptap/extension-image";
 import { Trash2, Pencil } from "lucide-react";
@@ -27,9 +25,7 @@ export function SignatureEditor() {
 
   const editor = useEditor({
     extensions: [
-      StarterKit.configure({ heading: { levels: [1, 2, 3] } }),
-      Link.configure({ openOnClick: false }),
-      Underline,
+      StarterKit.configure({ heading: { levels: [1, 2, 3] }, link: { openOnClick: false } }),
       Image.configure({ inline: true, allowBase64: true }),
       Placeholder.configure({ placeholder: "Write your signature..." }),
     ],

--- a/src/components/settings/TemplateEditor.tsx
+++ b/src/components/settings/TemplateEditor.tsx
@@ -1,8 +1,6 @@
 import { useState, useEffect, useCallback } from "react";
 import { useEditor, EditorContent } from "@tiptap/react";
 import StarterKit from "@tiptap/starter-kit";
-import Link from "@tiptap/extension-link";
-import Underline from "@tiptap/extension-underline";
 import Placeholder from "@tiptap/extension-placeholder";
 import Image from "@tiptap/extension-image";
 import { Trash2, Pencil, ChevronDown } from "lucide-react";
@@ -28,9 +26,7 @@ export function TemplateEditor() {
 
   const editor = useEditor({
     extensions: [
-      StarterKit.configure({ heading: { levels: [1, 2, 3] } }),
-      Link.configure({ openOnClick: false }),
-      Underline,
+      StarterKit.configure({ heading: { levels: [1, 2, 3] }, link: { openOnClick: false } }),
       Image.configure({ inline: true, allowBase64: true }),
       Placeholder.configure({ placeholder: "Write your template..." }),
     ],

--- a/src/test/mocks/db.mock.ts
+++ b/src/test/mocks/db.mock.ts
@@ -1,3 +1,5 @@
+import { vi } from "vitest";
+
 export function createMockDb() {
   return {
     select: vi.fn(() => Promise.resolve([])),

--- a/src/test/mocks/entities.mock.ts
+++ b/src/test/mocks/entities.mock.ts
@@ -31,6 +31,8 @@ export function createMockParsedMessage(
     hasAttachments: false,
     attachments: [],
     listUnsubscribe: null,
+    listUnsubscribePost: null,
+    authResults: null,
     ...overrides,
   };
 }

--- a/src/test/mocks/services.mock.ts
+++ b/src/test/mocks/services.mock.ts
@@ -1,3 +1,4 @@
+import { vi } from "vitest";
 import type { GmailClient } from "@/services/gmail/client";
 
 export function createMockGmailClient(

--- a/src/test/mocks/stores.mock.ts
+++ b/src/test/mocks/stores.mock.ts
@@ -1,3 +1,5 @@
+import { vi } from "vitest";
+
 export function createMockUIStoreState(overrides: Record<string, unknown> = {}) {
   return {
     isOnline: true,


### PR DESCRIPTION
## Summary
- Replace nested `<button>` elements in Sidebar with `<span role="button">` to fix HTML validation warning
- Remove duplicate Link/Underline TipTap extensions from all 4 editors — TipTap v3 StarterKit includes both natively
- Add `$APPDATA` root to Tauri FS scope so `exists()` on the app data directory is permitted
- Add missing `vi` imports and entity fields in test mocks to fix CI type-check errors

## Test plan
- [x] All 1046 tests passing
- [x] `tsc --noEmit` passes clean
- [ ] Verify no console warnings for nested buttons in sidebar
- [ ] Verify TipTap editors (composer, inline reply, signatures, templates) still work correctly