### PR TITLE
fix: use baseDir for Tauri FS operations to resolve scope errors

### DIFF
--- a/src/services/attachments/cacheManager.test.ts
+++ b/src/services/attachments/cacheManager.test.ts
@@ -1,0 +1,150 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { createMockTauriFs, createMockTauriPath } from "@/test/mocks";
+
+const tauriFs = createMockTauriFs();
+const tauriPath = createMockTauriPath();
+
+vi.mock("@tauri-apps/plugin-fs", () => tauriFs.mock);
+vi.mock("@tauri-apps/api/path", () => tauriPath);
+
+const mockExecute = vi.fn();
+const mockSelect = vi.fn();
+vi.mock("@/services/db/connection", () => ({
+  getDb: vi.fn(() => Promise.resolve({ execute: mockExecute, select: mockSelect })),
+}));
+
+vi.mock("@/services/db/settings", () => ({
+  getSetting: vi.fn(() => Promise.resolve("500")),
+}));
+
+import {
+  cacheAttachment,
+  loadCachedAttachment,
+  getCacheSize,
+  evictOldestCached,
+  clearAllCache,
+} from "./cacheManager";
+
+describe("cacheManager", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    tauriFs.mock.mkdir.mockResolvedValue(undefined);
+    tauriFs.mock.writeFile.mockResolvedValue(undefined);
+    tauriFs.mock.readFile.mockResolvedValue(new Uint8Array([1, 2, 3]));
+    tauriFs.mock.remove.mockResolvedValue(undefined);
+    mockExecute.mockResolvedValue(undefined);
+  });
+
+  describe("cacheAttachment", () => {
+    it("creates cache dir with baseDir option", async () => {
+      const data = new Uint8Array([10, 20, 30]);
+      await cacheAttachment("att-1", data);
+
+      expect(tauriFs.mock.mkdir).toHaveBeenCalledWith("attachment_cache", {
+        baseDir: 26,
+        recursive: true,
+      });
+    });
+
+    it("writes file with baseDir option", async () => {
+      const data = new Uint8Array([10, 20, 30]);
+      await cacheAttachment("att-1", data);
+
+      expect(tauriFs.mock.writeFile).toHaveBeenCalledWith(
+        expect.stringContaining("attachment_cache/"),
+        data,
+        { baseDir: 26 },
+      );
+    });
+
+    it("returns relative path", async () => {
+      const result = await cacheAttachment("att-1", new Uint8Array([1]));
+      expect(result).toMatch(/^attachment_cache\//);
+    });
+
+    it("updates DB with relative path", async () => {
+      const data = new Uint8Array([10, 20]);
+      await cacheAttachment("att-1", data);
+
+      expect(mockExecute).toHaveBeenCalledWith(
+        expect.stringContaining("UPDATE attachments SET local_path"),
+        [expect.stringContaining("attachment_cache/"), 2, "att-1"],
+      );
+    });
+  });
+
+  describe("loadCachedAttachment", () => {
+    it("reads file with baseDir option", async () => {
+      const result = await loadCachedAttachment("attachment_cache/abc");
+
+      expect(tauriFs.mock.readFile).toHaveBeenCalledWith("attachment_cache/abc", { baseDir: 26 });
+      expect(result).toEqual(new Uint8Array([1, 2, 3]));
+    });
+
+    it("returns null on read error", async () => {
+      tauriFs.mock.readFile.mockRejectedValueOnce(new Error("not found"));
+      const result = await loadCachedAttachment("attachment_cache/missing");
+      expect(result).toBeNull();
+    });
+  });
+
+  describe("getCacheSize", () => {
+    it("returns total cache size from DB", async () => {
+      mockSelect.mockResolvedValueOnce([{ total: 1024 }]);
+      const size = await getCacheSize();
+      expect(size).toBe(1024);
+    });
+
+    it("returns 0 when no cached attachments", async () => {
+      mockSelect.mockResolvedValueOnce([{ total: 0 }]);
+      const size = await getCacheSize();
+      expect(size).toBe(0);
+    });
+  });
+
+  describe("evictOldestCached", () => {
+    it("removes files with baseDir option when over limit", async () => {
+      const maxBytes = 500 * 1024 * 1024;
+      mockSelect
+        .mockResolvedValueOnce([{ total: maxBytes + 1000 }])
+        .mockResolvedValueOnce([
+          { id: "att-old", local_path: "attachment_cache/old", cache_size: 2000 },
+        ]);
+
+      await evictOldestCached();
+
+      expect(tauriFs.mock.remove).toHaveBeenCalledWith("attachment_cache/old", { baseDir: 26 });
+      expect(mockExecute).toHaveBeenCalledWith(
+        expect.stringContaining("UPDATE attachments SET local_path = NULL"),
+        ["att-old"],
+      );
+    });
+
+    it("does nothing when under limit", async () => {
+      mockSelect.mockResolvedValueOnce([{ total: 100 }]);
+
+      await evictOldestCached();
+
+      expect(tauriFs.mock.remove).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("clearAllCache", () => {
+    it("removes cache dir with baseDir option", async () => {
+      await clearAllCache();
+
+      expect(tauriFs.mock.remove).toHaveBeenCalledWith("attachment_cache", {
+        baseDir: 26,
+        recursive: true,
+      });
+    });
+
+    it("clears cached_at in DB", async () => {
+      await clearAllCache();
+
+      expect(mockExecute).toHaveBeenCalledWith(
+        expect.stringContaining("UPDATE attachments SET local_path = NULL"),
+      );
+    });
+  });
+});

--- a/src/test/mocks/index.ts
+++ b/src/test/mocks/index.ts
@@ -20,3 +20,4 @@ export {
   createMockThreadStoreState,
   createMockAccountStoreState,
 } from "./stores.mock";
+export { createMockTauriFs, createMockTauriPath } from "./tauri.mock";

--- a/src/test/mocks/tauri.mock.ts
+++ b/src/test/mocks/tauri.mock.ts
@@ -1,0 +1,35 @@
+import { vi } from "vitest";
+
+/**
+ * Creates a mock for @tauri-apps/plugin-fs that simulates file operations
+ * using an in-memory Map store. All operations use baseDir option (not absolute paths).
+ */
+export function createMockTauriFs() {
+  const store = new Map<string, string>();
+
+  return {
+    store,
+    mock: {
+      exists: vi.fn(async (path: string) => store.has(path)),
+      readTextFile: vi.fn(async (path: string) => store.get(path) ?? ""),
+      writeTextFile: vi.fn(async (path: string, content: string) => {
+        store.set(path, content);
+      }),
+      writeFile: vi.fn(),
+      readFile: vi.fn(async () => new Uint8Array([1, 2, 3])),
+      mkdir: vi.fn(async () => {}),
+      remove: vi.fn(async () => {}),
+      BaseDirectory: { AppData: 26 },
+    },
+  };
+}
+
+/**
+ * Creates a mock for @tauri-apps/api/path with simple join behavior.
+ */
+export function createMockTauriPath() {
+  return {
+    join: vi.fn(async (...parts: string[]) => parts.join("/")),
+    appDataDir: vi.fn(async () => "/mock/app/data/"),
+  };
+}


### PR DESCRIPTION
## Summary
- Switches `crypto.ts` and `cacheManager.ts` from using absolute paths (via `appDataDir()`) to `BaseDirectory.AppData` with relative paths for all Tauri FS operations (`exists`, `readTextFile`, `writeTextFile`, `mkdir`, `readFile`, `writeFile`, `remove`)
- This resolves the "forbidden path" error where Tauri's FS scope check rejected the resolved `$APPDATA` absolute path for `allow-exists` and other FS permissions
- Adds central Tauri FS mock factory (`createMockTauriFs`, `createMockTauriPath`) in `src/test/mocks/tauri.mock.ts`
- Adds comprehensive test coverage for `cacheManager.ts` (12 tests) and updates `crypto.test.ts` (9 tests) to verify `baseDir` usage

Fixes #39

## Test plan
- [x] All 1060 existing tests pass
- [x] New `cacheManager.test.ts` tests verify `baseDir` option on all FS calls
- [x] Updated `crypto.test.ts` tests verify `baseDir` option on exists/read/write
- [x] Manual verification: app starts without FS scope errors on Windows