### PR TITLE
fix: add appdata FS permissions for baseDir operations

### DIFF
--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -30,10 +30,13 @@
     "dialog:default",
     "dialog:allow-save",
     "fs:default",
+    "fs:allow-appdata-read-recursive",
+    "fs:allow-appdata-write-recursive",
     "fs:allow-read-file",
     "fs:allow-write-file",
     "fs:allow-exists",
     "fs:allow-mkdir",
+    "fs:allow-remove",
     {
       "identifier": "fs:scope",
       "allow": [


### PR DESCRIPTION
## Summary
- Adds `fs:allow-appdata-read-recursive` and `fs:allow-appdata-write-recursive` permissions to the Tauri capabilities file
- Adds `fs:allow-remove` for attachment cache cleanup operations
- The previous PR switched FS operations to use `baseDir: BaseDirectory.AppData` but Tauri v2 requires these directory-specific permissions when using `baseDir` — the generic `fs:allow-write-file` / `fs:allow-read-file` alone are not sufficient

Fixes #39

## Root cause
Tauri v2's FS plugin has two permission models:
1. **Generic** (`fs:allow-write-file` + `fs:scope`) — for absolute paths
2. **Directory-specific** (`fs:allow-appdata-write-recursive`) — for `baseDir` option

Our code now uses `baseDir: BaseDirectory.AppData` but only had generic permissions, causing `fs.write_text_file not allowed`.

## Test plan
- [x] `cargo check` passes with new permissions
- [x] All 1060 Vitest tests pass
- [x] Manual: add IMAP account without FS permission error