### PR TITLE
fix: decode IMAP folder names from modified UTF-7 and use real UIDs for sync

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -342,6 +342,12 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "base64"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
+
+[[package]]
+name = "base64"
 version = "0.21.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
@@ -6214,6 +6220,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09cc8ee72d2a9becf2f2febe0205bbed8fc6615b7cb429ad062dc7b7ddd036a9"
 
 [[package]]
+name = "utf7-imap"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e326365261fc2761f0809dfb6032810534a0427bbd8f0edf546f6afeef89f5d"
+dependencies = [
+ "base64 0.13.1",
+ "encoding_rs",
+ "regex",
+]
+
+[[package]]
 name = "utf8-width"
 version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6251,7 +6268,7 @@ checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "velo"
-version = "0.2.0"
+version = "0.3.3"
 dependencies = [
  "async-imap",
  "base64 0.22.1",
@@ -6277,6 +6294,7 @@ dependencies = [
  "tauri-plugin-sql",
  "tokio",
  "tokio-native-tls",
+ "utf7-imap",
  "windows 0.58.0",
 ]
 

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -40,6 +40,7 @@ native-tls = "0.2"
 mail-parser = "0.9"
 lettre = { version = "0.11", default-features = false, features = ["smtp-transport", "tokio1-native-tls", "builder"] }
 base64 = "0.22"
+utf7-imap = "0.3"
 
 [target.'cfg(windows)'.dependencies]
 windows = { version = "0.58", features = ["Win32_UI_Shell"] }

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -55,6 +55,17 @@ pub async fn imap_fetch_new_uids(
 }
 
 #[tauri::command]
+pub async fn imap_search_all_uids(
+    config: ImapConfig,
+    folder: String,
+) -> Result<Vec<u32>, String> {
+    let mut session = imap_client::connect(&config).await?;
+    let uids = imap_client::search_all_uids(&mut session, &folder).await?;
+    let _ = session.logout().await;
+    Ok(uids)
+}
+
+#[tauri::command]
 pub async fn imap_fetch_message_body(
     config: ImapConfig,
     folder: String,

--- a/src-tauri/src/imap/types.rs
+++ b/src-tauri/src/imap/types.rs
@@ -12,8 +12,9 @@ pub struct ImapConfig {
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ImapFolder {
-    pub path: String,
-    pub name: String,
+    pub path: String,      // decoded UTF-8 display name
+    pub raw_path: String,  // original modified UTF-7 path for IMAP commands
+    pub name: String,      // decoded display name (last segment)
     pub delimiter: String,
     pub special_use: Option<String>, // "\Sent", "\Trash", "\Drafts", "\Junk", "\Archive", "\All"
     pub exists: u32,

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -81,6 +81,7 @@ pub fn run() {
             commands::imap_list_folders,
             commands::imap_fetch_messages,
             commands::imap_fetch_new_uids,
+            commands::imap_search_all_uids,
             commands::imap_fetch_message_body,
             commands::imap_set_flags,
             commands::imap_move_messages,

--- a/src/services/imap/folderMapper.ts
+++ b/src/services/imap/folderMapper.ts
@@ -130,7 +130,7 @@ export async function syncFoldersToLabels(
       accountId,
       name: mapping.labelName,
       type: mapping.type,
-      imapFolderPath: folder.path,
+      imapFolderPath: folder.raw_path,
       imapSpecialUse: folder.special_use,
     });
   }

--- a/src/services/imap/tauriCommands.ts
+++ b/src/services/imap/tauriCommands.ts
@@ -12,8 +12,9 @@ export interface ImapConfig {
 }
 
 export interface ImapFolder {
-  path: string;
-  name: string;
+  path: string;       // decoded UTF-8 display name
+  raw_path: string;   // original modified UTF-7 path for IMAP commands
+  name: string;       // decoded display name (last segment)
   delimiter: string;
   special_use: string | null;
   exists: number;
@@ -123,6 +124,17 @@ export async function imapFetchNewUids(
   sinceUid: number
 ): Promise<number[]> {
   return invoke<number[]>('imap_fetch_new_uids', { config, folder, sinceUid });
+}
+
+/**
+ * Search for all UIDs in a folder using UID SEARCH ALL.
+ * Returns real UIDs — avoids the sparse UID gap problem with generateUidRange.
+ */
+export async function imapSearchAllUids(
+  config: ImapConfig,
+  folder: string
+): Promise<number[]> {
+  return invoke<number[]>('imap_search_all_uids', { config, folder });
 }
 
 /**

--- a/src/test/mocks/entities.mock.ts
+++ b/src/test/mocks/entities.mock.ts
@@ -217,8 +217,10 @@ export function createMockImapMessage(
 export function createMockImapFolder(
   overrides: Partial<ImapFolder> = {},
 ): ImapFolder {
+  const path = overrides.path ?? "INBOX";
   return {
-    path: "INBOX",
+    path,
+    raw_path: path,
     name: "INBOX",
     delimiter: "/",
     special_use: null,


### PR DESCRIPTION
## Summary

- **Folder name encoding**: IMAP uses modified UTF-7 (RFC 3501 §5.1.3) for non-ASCII folder names. `async-imap`'s `Name::name()` returns the raw encoded string (e.g. `Be&AOk-rkezett` instead of `Beérkezett`). Added `utf7-imap` crate to decode folder names to UTF-8 for display, while preserving the raw encoded path for IMAP protocol commands.
- **Messages not syncing**: `generateUidRange(uidnext, exists)` assumed UIDs are dense near `uidnext`, but IMAP UIDs are often sparse after deletions — generating UIDs that don't exist. Replaced with `UID SEARCH ALL` which returns real UIDs from the server.
- Added `raw_path` field to `ImapFolder` struct — `path` is decoded UTF-8 for display/DB, `raw_path` is the original modified UTF-7 for IMAP commands (SELECT, STATUS, FETCH).

## Test plan

- [x] `cargo build` — Rust compiles
- [x] `npx tsc --noEmit` — TypeScript passes
- [x] `npm run test` — all 88 test files, 1060 tests passing
- [ ] Manual: add IMAP account with non-ASCII folder names → folders display correctly
- [ ] Manual: IMAP sync fetches messages → emails appear in folders