### PR TITLE
fix: IMAP messages downloaded but not stored in database

### DIFF
--- a/src/services/imap/imapSync.test.ts
+++ b/src/services/imap/imapSync.test.ts
@@ -153,4 +153,16 @@ describe("imapMessageToParsedMessage", () => {
     const { parsed } = imapMessageToParsedMessage(msg, "acc-1", "INBOX");
     expect(parsed.authResults).toBe('{"spf":"pass","dkim":"pass"}');
   });
+
+  it("handles date=0 (unparseable Date header) without crashing", () => {
+    const msg = createMockImapMessage({ date: 0 });
+    const { parsed, threadable } = imapMessageToParsedMessage(msg, "acc-1", "INBOX");
+
+    // date=0 is passed through — the caller (imapInitialSync) applies the fallback
+    expect(parsed.date).toBe(0);
+    expect(threadable.date).toBe(0);
+    // Message should still be valid
+    expect(parsed.id).toBe("imap-acc-1-INBOX-42");
+    expect(parsed.fromAddress).toBe("sender@example.com");
+  });
 });


### PR DESCRIPTION
## Summary
- **Rust parser**: Use `INTERNALDATE` from IMAP server as date fallback when `mail_parser` can't parse the `Date` header (previously defaulted to `0`, causing all such messages to be silently dropped by the date cutoff filter)
- **TypeScript date filter**: Messages with `date=0` that still slip through now get current time as fallback instead of being filtered out
- **Sync completion guard**: No longer marks initial sync as complete when messages were found on server but zero were stored — prevents permanently switching to delta mode which would never retry the missed messages
- **Diagnostic logging**: Added `console.log`/`warn` throughout the IMAP sync flow for folder counts, fetch/filter stats, threading results, and storage outcomes

## Root Cause
Three compounding bugs: (1) non-standard date headers → `date=0` in Rust, (2) `date=0 < cutoffDate` → all messages filtered out in TS, (3) sync marked complete unconditionally → delta sync never retries.

## Test plan
- [x] All 1061 existing tests pass (88 test files)
- [x] Rust compiles cleanly (`cargo check`)
- [x] New test added for `date=0` handling in `imapMessageToParsedMessage`
- [ ] Manual test: connect IMAP account and verify messages appear in DB

Closes #39