### PR TITLE
fix: starred threads not appearing in Starred folder

### DIFF
--- a/src/services/emailActions.ts
+++ b/src/services/emailActions.ts
@@ -138,6 +138,17 @@ async function applyLocalDbUpdate(
         "UPDATE threads SET is_starred = $1 WHERE account_id = $2 AND id = $3",
         [action.starred ? 1 : 0, accountId, action.threadId],
       );
+      if (action.starred) {
+        await db.execute(
+          "INSERT OR IGNORE INTO thread_labels (account_id, thread_id, label_id) VALUES ($1, $2, 'STARRED')",
+          [accountId, action.threadId],
+        );
+      } else {
+        await db.execute(
+          "DELETE FROM thread_labels WHERE account_id = $1 AND thread_id = $2 AND label_id = 'STARRED'",
+          [accountId, action.threadId],
+        );
+      }
       break;
     case "archive":
       await db.execute(


### PR DESCRIPTION
The star action only updated the threads.is_starred column but did not insert/delete rows in thread_labels for the STARRED label. Since the Starred folder view queries via INNER JOIN on thread_labels, it returned no results. Now syncs thread_labels alongside the is_starred flag.