### PR TITLE
feat: add View Source option to message context menu

### DIFF
--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -86,6 +86,18 @@ pub async fn imap_fetch_message_body(
 }
 
 #[tauri::command]
+pub async fn imap_fetch_raw_message(
+    config: ImapConfig,
+    folder: String,
+    uid: u32,
+) -> Result<String, String> {
+    let mut session = imap_client::connect(&config).await?;
+    let raw = imap_client::fetch_raw_message(&mut session, &folder, uid).await?;
+    let _ = session.logout().await;
+    Ok(raw)
+}
+
+#[tauri::command]
 pub async fn imap_set_flags(
     config: ImapConfig,
     folder: String,

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -83,6 +83,7 @@ pub fn run() {
             commands::imap_fetch_new_uids,
             commands::imap_search_all_uids,
             commands::imap_fetch_message_body,
+            commands::imap_fetch_raw_message,
             commands::imap_set_flags,
             commands::imap_move_messages,
             commands::imap_delete_messages,

--- a/src/components/email/RawMessageModal.test.tsx
+++ b/src/components/email/RawMessageModal.test.tsx
@@ -1,0 +1,155 @@
+import { render, screen, waitFor, fireEvent } from "@testing-library/react";
+import { RawMessageModal } from "./RawMessageModal";
+
+vi.mock("@/services/email/providerFactory", () => ({
+  getEmailProvider: vi.fn(),
+}));
+
+import { getEmailProvider } from "@/services/email/providerFactory";
+
+describe("RawMessageModal", () => {
+  const mockFetchRawMessage = vi.fn();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(getEmailProvider).mockResolvedValue({
+      fetchRawMessage: mockFetchRawMessage,
+    } as never);
+  });
+
+  it("shows loading state initially", () => {
+    mockFetchRawMessage.mockReturnValue(new Promise(() => {})); // never resolves
+    render(
+      <RawMessageModal
+        isOpen={true}
+        onClose={vi.fn()}
+        messageId="msg-1"
+        accountId="acc-1"
+      />,
+    );
+
+    expect(screen.getByText("Loading message source...")).toBeInTheDocument();
+  });
+
+  it("displays raw message content after loading", async () => {
+    const rawSource = "From: test@example.com\r\nSubject: Hello\r\n\r\nBody text";
+    mockFetchRawMessage.mockResolvedValue(rawSource);
+
+    render(
+      <RawMessageModal
+        isOpen={true}
+        onClose={vi.fn()}
+        messageId="msg-1"
+        accountId="acc-1"
+      />,
+    );
+
+    await waitFor(() => {
+      const pre = document.querySelector("pre");
+      expect(pre).not.toBeNull();
+      expect(pre!.textContent).toBe(rawSource);
+    });
+  });
+
+  it("displays error state on failure", async () => {
+    mockFetchRawMessage.mockRejectedValue(new Error("Network error"));
+
+    render(
+      <RawMessageModal
+        isOpen={true}
+        onClose={vi.fn()}
+        messageId="msg-1"
+        accountId="acc-1"
+      />,
+    );
+
+    await waitFor(() => {
+      expect(
+        screen.getByText(/Failed to load message source: Network error/),
+      ).toBeInTheDocument();
+    });
+  });
+
+  it("shows copy button after content loads", async () => {
+    mockFetchRawMessage.mockResolvedValue("raw content");
+
+    render(
+      <RawMessageModal
+        isOpen={true}
+        onClose={vi.fn()}
+        messageId="msg-1"
+        accountId="acc-1"
+      />,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText("Copy")).toBeInTheDocument();
+    });
+  });
+
+  it("copies content to clipboard on button click", async () => {
+    const rawSource = "raw email content";
+    mockFetchRawMessage.mockResolvedValue(rawSource);
+
+    const writeTextMock = vi.fn().mockResolvedValue(undefined);
+    Object.assign(navigator, {
+      clipboard: { writeText: writeTextMock },
+    });
+
+    render(
+      <RawMessageModal
+        isOpen={true}
+        onClose={vi.fn()}
+        messageId="msg-1"
+        accountId="acc-1"
+      />,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText("Copy")).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByText("Copy"));
+
+    expect(writeTextMock).toHaveBeenCalledWith(rawSource);
+    await waitFor(() => {
+      expect(screen.getByText("Copied")).toBeInTheDocument();
+    });
+  });
+
+  it("does not render content when closed", () => {
+    render(
+      <RawMessageModal
+        isOpen={false}
+        onClose={vi.fn()}
+        messageId="msg-1"
+        accountId="acc-1"
+      />,
+    );
+
+    expect(screen.queryByText("Message Source")).not.toBeInTheDocument();
+    expect(mockFetchRawMessage).not.toHaveBeenCalled();
+  });
+
+  it("calls onClose when close button is clicked", async () => {
+    mockFetchRawMessage.mockResolvedValue("content");
+    const onClose = vi.fn();
+
+    render(
+      <RawMessageModal
+        isOpen={true}
+        onClose={onClose}
+        messageId="msg-1"
+        accountId="acc-1"
+      />,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText("content")).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByText("\u00d7"));
+
+    expect(onClose).toHaveBeenCalled();
+  });
+});

--- a/src/components/email/RawMessageModal.tsx
+++ b/src/components/email/RawMessageModal.tsx
@@ -1,0 +1,119 @@
+import { useState, useEffect, useCallback } from "react";
+import { Modal } from "@/components/ui/Modal";
+import { getEmailProvider } from "@/services/email/providerFactory";
+import { Copy, Check } from "lucide-react";
+
+interface RawMessageModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  messageId: string;
+  accountId: string;
+}
+
+export function RawMessageModal({
+  isOpen,
+  onClose,
+  messageId,
+  accountId,
+}: RawMessageModalProps) {
+  const [raw, setRaw] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [copied, setCopied] = useState(false);
+
+  useEffect(() => {
+    if (!isOpen) {
+      setRaw(null);
+      setError(null);
+      setLoading(false);
+      setCopied(false);
+      return;
+    }
+
+    let cancelled = false;
+    setLoading(true);
+    setError(null);
+
+    getEmailProvider(accountId)
+      .then((provider) => provider.fetchRawMessage(messageId))
+      .then((source) => {
+        if (!cancelled) {
+          setRaw(source);
+          setLoading(false);
+        }
+      })
+      .catch((err) => {
+        if (!cancelled) {
+          setError(err instanceof Error ? err.message : String(err));
+          setLoading(false);
+        }
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [isOpen, messageId, accountId]);
+
+  const handleCopy = useCallback(async () => {
+    if (!raw) return;
+    try {
+      await navigator.clipboard.writeText(raw);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    } catch {
+      // Fallback: no-op in non-secure contexts
+    }
+  }, [raw]);
+
+  return (
+    <Modal
+      isOpen={isOpen}
+      onClose={onClose}
+      title="Message Source"
+      width="w-[720px] max-w-[90vw]"
+      renderHeader={
+        <div className="px-4 py-3 border-b border-border-primary flex items-center justify-between">
+          <h3 className="text-sm font-semibold text-text-primary">
+            Message Source
+          </h3>
+          <div className="flex items-center gap-2">
+            {raw && (
+              <button
+                onClick={handleCopy}
+                className="flex items-center gap-1 text-xs text-text-secondary hover:text-text-primary px-2 py-1 rounded hover:bg-bg-hover transition-colors"
+                title="Copy to clipboard"
+              >
+                {copied ? <Check size={14} /> : <Copy size={14} />}
+                {copied ? "Copied" : "Copy"}
+              </button>
+            )}
+            <button
+              onClick={onClose}
+              className="text-text-tertiary hover:text-text-primary text-lg leading-none"
+            >
+              &times;
+            </button>
+          </div>
+        </div>
+      }
+    >
+      <div className="max-h-[70vh] overflow-y-auto p-4">
+        {loading && (
+          <div className="flex items-center justify-center py-12 text-text-tertiary text-sm">
+            Loading message source...
+          </div>
+        )}
+        {error && (
+          <div className="text-danger text-sm py-4">
+            Failed to load message source: {error}
+          </div>
+        )}
+        {raw && (
+          <pre className="text-xs font-mono text-text-secondary whitespace-pre-wrap break-all select-text">
+            {raw}
+          </pre>
+        )}
+      </div>
+    </Modal>
+  );
+}

--- a/src/components/ui/ContextMenuPortal.tsx
+++ b/src/components/ui/ContextMenuPortal.tsx
@@ -35,6 +35,7 @@ import {
   Layers,
   VolumeX,
   Zap,
+  Code,
 } from "lucide-react";
 import { setThreadCategory, ALL_CATEGORIES } from "@/services/db/threadCategories";
 
@@ -547,6 +548,7 @@ function MessageMenu({
 
   const messageId = data["messageId"] as string;
   const threadId = data["threadId"] as string;
+  const accountId = data["accountId"] as string | null;
   const fromAddress = data["fromAddress"] as string | null;
   const fromName = data["fromName"] as string | null;
   const replyTo = data["replyTo"] as string | null;
@@ -642,6 +644,23 @@ function MessageMenu({
       icon: Copy,
       action: handleCopy,
     },
+    ...(accountId
+      ? [
+          { id: "sep-2", label: "", separator: true },
+          {
+            id: "view-source",
+            label: "View Source",
+            icon: Code,
+            action: () => {
+              window.dispatchEvent(
+                new CustomEvent("velo-view-raw-message", {
+                  detail: { messageId, accountId },
+                }),
+              );
+            },
+          },
+        ]
+      : []),
   ];
 
   return <ContextMenu items={items} position={position} onClose={onClose} />;

--- a/src/services/email/gmailProvider.test.ts
+++ b/src/services/email/gmailProvider.test.ts
@@ -427,6 +427,22 @@ describe("GmailApiProvider", () => {
     });
   });
 
+  describe("fetchRawMessage", () => {
+    it("fetches raw format and decodes base64url to string", async () => {
+      // "Hello World" in base64url
+      const base64url = btoa("From: test@example.com\r\nSubject: Hi\r\n\r\nHello")
+        .replace(/\+/g, "-")
+        .replace(/\//g, "_")
+        .replace(/=+$/, "");
+      vi.mocked(mockClient.getMessage).mockResolvedValue({ raw: base64url } as never);
+
+      const result = await provider.fetchRawMessage("msg-1");
+
+      expect(mockClient.getMessage).toHaveBeenCalledWith("msg-1", "raw");
+      expect(result).toBe("From: test@example.com\r\nSubject: Hi\r\n\r\nHello");
+    });
+  });
+
   describe("fetchAttachment", () => {
     it("delegates to client.getAttachment", async () => {
       vi.mocked(mockClient.getAttachment).mockResolvedValue({

--- a/src/services/email/gmailProvider.ts
+++ b/src/services/email/gmailProvider.ts
@@ -137,6 +137,13 @@ export class GmailApiProvider implements EmailProvider {
     return { data: resp.data, size: resp.size };
   }
 
+  async fetchRawMessage(messageId: string): Promise<string> {
+    // Gmail API with format=raw returns a { raw: string } field (base64url-encoded RFC822)
+    const resp = await this.client.getMessage(messageId, "raw") as unknown as { raw: string };
+    const base64 = resp.raw.replace(/-/g, "+").replace(/_/g, "/");
+    return atob(base64);
+  }
+
   async archive(threadId: string, _messageIds: string[]): Promise<void> {
     await this.client.modifyThread(threadId, undefined, ["INBOX"]);
   }

--- a/src/services/email/imapSmtpProvider.test.ts
+++ b/src/services/email/imapSmtpProvider.test.ts
@@ -29,6 +29,7 @@ vi.mock("../imap/tauriCommands", () => ({
   imapDeleteMessages: vi.fn(),
   imapFetchMessageBody: vi.fn(),
   imapFetchAttachment: vi.fn(),
+  imapFetchRawMessage: vi.fn(),
   imapTestConnection: vi.fn(),
   imapAppendMessage: vi.fn(),
   smtpSendEmail: vi.fn(),
@@ -178,6 +179,26 @@ describe("ImapSmtpProvider", () => {
     it("throws an informative error", async () => {
       await expect(provider.renameFolder("old", "new")).rejects.toThrow(
         "not supported",
+      );
+    });
+  });
+
+  // ---------- Raw message ----------
+
+  describe("fetchRawMessage", () => {
+    it("parses IMAP message ID and calls imapFetchRawMessage", async () => {
+      const { imapFetchRawMessage } = await import("../imap/tauriCommands");
+      vi.mocked(imapFetchRawMessage).mockResolvedValue("From: test@example.com\r\nSubject: Hello\r\n\r\nBody");
+
+      const result = await provider.fetchRawMessage("imap-acc-1-INBOX-42");
+
+      expect(imapFetchRawMessage).toHaveBeenCalledWith(mockImapConfig, "INBOX", 42);
+      expect(result).toBe("From: test@example.com\r\nSubject: Hello\r\n\r\nBody");
+    });
+
+    it("throws for invalid message ID format", async () => {
+      await expect(provider.fetchRawMessage("invalid-id")).rejects.toThrow(
+        "Invalid IMAP message ID format",
       );
     });
   });

--- a/src/services/email/imapSmtpProvider.ts
+++ b/src/services/email/imapSmtpProvider.ts
@@ -10,6 +10,7 @@ import {
   imapDeleteMessages,
   imapFetchMessageBody,
   imapFetchAttachment,
+  imapFetchRawMessage,
   imapTestConnection,
   imapAppendMessage,
   smtpSendEmail,
@@ -173,6 +174,17 @@ export class ImapSmtpProvider implements EmailProvider {
     const config = await this.getImapConfig();
     const data = await imapFetchAttachment(config, folder, uid, attachmentId);
     return { data, size: data.length };
+  }
+
+  async fetchRawMessage(messageId: string): Promise<string> {
+    const { folder, uid } = this.parseImapMessageId(messageId);
+
+    if (uid === null || !folder) {
+      throw new Error(`Invalid IMAP message ID format: ${messageId}`);
+    }
+
+    const config = await this.getImapConfig();
+    return imapFetchRawMessage(config, folder, uid);
   }
 
   // ---- Actions ----

--- a/src/services/email/types.ts
+++ b/src/services/email/types.ts
@@ -46,6 +46,7 @@ export interface EmailProvider {
     messageId: string,
     attachmentId: string,
   ): Promise<{ data: string; size: number }>;
+  fetchRawMessage(messageId: string): Promise<string>;
 
   // Actions (operate on thread/message level)
   archive(threadId: string, messageIds: string[]): Promise<void>;

--- a/src/services/imap/tauriCommands.ts
+++ b/src/services/imap/tauriCommands.ts
@@ -225,6 +225,18 @@ export async function imapFetchAttachment(
 }
 
 /**
+ * Fetch the raw RFC822 source of a single message by UID.
+ * Returns the full message as a UTF-8 string.
+ */
+export async function imapFetchRawMessage(
+  config: ImapConfig,
+  folder: string,
+  uid: number
+): Promise<string> {
+  return invoke<string>('imap_fetch_raw_message', { config, folder, uid });
+}
+
+/**
  * Raw IMAP diagnostic: bypasses async-imap to show raw server responses.
  */
 export async function imapRawFetchDiagnostic(

--- a/src/test/mocks/services.mock.ts
+++ b/src/test/mocks/services.mock.ts
@@ -44,6 +44,7 @@ export function createMockEmailProvider(
     createDraft: vi.fn(() => Promise.resolve({ draftId: "d-1" })),
     updateDraft: vi.fn(() => Promise.resolve({ draftId: "d-1" })),
     deleteDraft: vi.fn(() => Promise.resolve()),
+    fetchRawMessage: vi.fn(() => Promise.resolve("")),
     ...overrides,
   };
 }


### PR DESCRIPTION
## Summary
- Add "View Source" option to message right-click context menu that fetches and displays the full RFC822 raw message source
- Works for both Gmail API accounts (base64url-decoded raw format) and IMAP accounts (via new Rust `fetch_raw_message` command)
- New `RawMessageModal` component with loading/error states, monospace display, and copy-to-clipboard button

## Changes
- **Rust backend**: `fetch_raw_message()` in `client.rs`, `imap_fetch_raw_message` command, registered in `lib.rs`
- **Service layer**: `fetchRawMessage()` added to `EmailProvider` interface, implemented in `GmailApiProvider` and `ImapSmtpProvider`, TypeScript Tauri wrapper in `tauriCommands.ts`
- **UI**: `RawMessageModal.tsx` (new), "View Source" menu item in `ContextMenuPortal.tsx`, event wiring in `ThreadView.tsx`
- **Tests**: 7 new modal tests, provider tests for both Gmail and IMAP (all 1072 tests passing)

## Test plan
- [ ] Right-click a message in a Gmail account → "View Source" → modal shows full RFC822 headers + body
- [ ] Right-click a message in an IMAP account → "View Source" → modal shows full RFC822 source
- [ ] Copy button copies raw source to clipboard
- [ ] Modal shows loading spinner while fetching
- [ ] Modal shows error message on network failure
- [ ] Escape / close button dismisses modal