### PR TITLE
feat: optimize IMAP delta sync with single-connection batch check

### DIFF
--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -1,5 +1,8 @@
 use crate::imap::client as imap_client;
-use crate::imap::types::{ImapConfig, ImapFetchResult, ImapFolder, ImapFolderStatus, ImapMessage};
+use crate::imap::types::{
+    DeltaCheckRequest, DeltaCheckResult, ImapConfig, ImapFetchResult, ImapFolder, ImapFolderStatus,
+    ImapMessage,
+};
 use crate::smtp::client as smtp_client;
 use crate::smtp::types::{SmtpConfig, SmtpSendResult};
 
@@ -245,6 +248,17 @@ pub async fn imap_raw_fetch_diagnostic(
     uid_range: String,
 ) -> Result<String, String> {
     imap_client::raw_fetch_diagnostic(&config, &folder, &uid_range).await
+}
+
+#[tauri::command]
+pub async fn imap_delta_check(
+    config: ImapConfig,
+    folders: Vec<DeltaCheckRequest>,
+) -> Result<Vec<DeltaCheckResult>, String> {
+    let mut session = imap_client::connect(&config).await?;
+    let results = imap_client::delta_check_folders(&mut session, &folders).await?;
+    let _ = session.logout().await;
+    Ok(results)
 }
 
 // ---------- SMTP commands ----------

--- a/src-tauri/src/imap/types.rs
+++ b/src-tauri/src/imap/types.rs
@@ -73,3 +73,18 @@ pub struct ImapFetchResult {
     pub messages: Vec<ImapMessage>,
     pub folder_status: ImapFolderStatus,
 }
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct DeltaCheckRequest {
+    pub folder: String,
+    pub last_uid: u32,
+    pub uidvalidity: u32,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct DeltaCheckResult {
+    pub folder: String,
+    pub uidvalidity: u32,
+    pub new_uids: Vec<u32>,
+    pub uidvalidity_changed: bool,
+}

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -91,6 +91,7 @@ pub fn run() {
             commands::imap_fetch_attachment,
             commands::imap_append_message,
             commands::imap_raw_fetch_diagnostic,
+            commands::imap_delta_check,
             commands::smtp_send_email,
             commands::smtp_test_connection,
         ])

--- a/src/services/imap/tauriCommands.ts
+++ b/src/services/imap/tauriCommands.ts
@@ -70,6 +70,21 @@ export interface ImapFetchResult {
   folder_status: ImapFolderStatus;
 }
 
+// ---------- Delta check types ----------
+
+export interface DeltaCheckRequest {
+  folder: string;
+  last_uid: number;
+  uidvalidity: number;
+}
+
+export interface DeltaCheckResult {
+  folder: string;
+  uidvalidity: number;
+  new_uids: number[];
+  uidvalidity_changed: boolean;
+}
+
 // ---------- SMTP types ----------
 
 export interface SmtpConfig {
@@ -234,6 +249,17 @@ export async function imapFetchRawMessage(
   uid: number
 ): Promise<string> {
   return invoke<string>('imap_fetch_raw_message', { config, folder, uid });
+}
+
+/**
+ * Check multiple folders for new UIDs in a single IMAP connection.
+ * Replaces N separate imapGetFolderStatus + imapFetchNewUids calls with one round-trip.
+ */
+export async function imapDeltaCheck(
+  config: ImapConfig,
+  folders: DeltaCheckRequest[]
+): Promise<DeltaCheckResult[]> {
+  return invoke<DeltaCheckResult[]>('imap_delta_check', { config, folders });
 }
 
 /**


### PR DESCRIPTION
## Summary
- Adds a new Rust `imap_delta_check` command that checks all IMAP folders for new messages in a **single TCP+TLS+AUTH connection**, replacing N*2 separate connections per sync cycle
- For ~10 folders, this reduces delta sync from 20+ connections to 1 for the check phase
- Falls back to the old per-folder approach (`imapGetFolderStatus` + `imapFetchNewUids`) if the batch command fails

## Changes
- **Rust**: `DeltaCheckRequest`/`DeltaCheckResult` types, `delta_check_folders()` in client.rs, `imap_delta_check` Tauri command
- **TypeScript**: `imapDeltaCheck()` wrapper in tauriCommands.ts, rewritten delta sync hot path in imapSync.ts with fallback

## Test plan
- [x] `cargo build` compiles
- [x] `npx tsc --noEmit` passes
- [x] All 1076 tests pass (`npm run test`)
- [ ] Manual: send email to IMAP account, verify it appears within ~15s
- [ ] Check dev console for `[imapSync] Batch delta check: N/N folders checked` log

Closes #56 