### PR TITLE
docs: add CONTRIBUTING.md and SECURITY.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,109 @@
+# Contributing to Velo
+
+Thank you for your interest in contributing to Velo! This guide will help you get started.
+
+## Getting Started
+
+### Prerequisites
+
+- [Node.js](https://nodejs.org/) v18+
+- [Rust](https://www.rust-lang.org/tools/install)
+- [Tauri v2 prerequisites](https://v2.tauri.app/start/prerequisites/)
+
+### Setup
+
+```bash
+git clone https://github.com/avihaymenahem/velo.git
+cd velo
+npm install
+npm run tauri dev
+```
+
+## Development Workflow
+
+1. **Fork** the repository and create a branch from `main`
+2. **Make your changes** -- see the sections below for guidelines
+3. **Run tests** before submitting: `npm run test`
+4. **Type-check** your code: `npx tsc --noEmit`
+5. **Open a pull request** against `main`
+
+## Project Structure
+
+| Directory | Purpose |
+|-----------|---------|
+| `src-tauri/` | Rust backend (Tauri commands, plugins, system tray) |
+| `src/components/` | React UI components (12 groups) |
+| `src/stores/` | Zustand state stores |
+| `src/services/` | Business logic (email, AI, sync, DB) |
+| `src/services/db/` | SQLite query functions and migrations |
+| `src/hooks/` | Custom React hooks |
+| `src/constants/` | Static data (shortcuts, themes, help content) |
+| `src/utils/` | Shared utility functions |
+
+For detailed architecture, see [docs/architecture.md](docs/architecture.md).
+
+## Code Guidelines
+
+### TypeScript / React
+
+- **Strict mode** is enabled (`noUnusedLocals`, `noUnusedParameters`, `noUncheckedIndexedAccess`)
+- **Avoid `useEffect`** where possible -- prefer derived state, event handlers, `useMemo`, or refs
+- **Tailwind CSS v4** for all styling -- use semantic color tokens (`bg-bg-primary`, `text-text-primary`, etc.)
+- **Icons** from `lucide-react`
+- **Path alias**: use `@/` to import from `src/`
+
+### Rust
+
+- Backend code lives in `src-tauri/src/`
+- New Tauri commands must be registered in `src-tauri/src/lib.rs`
+- New plugins need permissions added to `src-tauri/capabilities/default.json`
+
+### Database
+
+- Migrations go in `src/services/db/migrations.ts` -- always add to the end of the array
+- Never modify existing migrations; only append new ones
+- Query functions go in `src/services/db/` as separate files
+
+### Testing
+
+- Write tests for new code -- tests are colocated with source files (e.g., `foo.test.ts` next to `foo.ts`)
+- Run the full suite with `npm run test`
+- Run a single file with `npx vitest run <path>`
+- We use **Vitest** with `globals: true` (no need to import `describe`, `it`, `expect`)
+
+### Commit Messages
+
+We use [Conventional Commits](https://www.conventionalcommits.org/) for automatic versioning:
+
+```
+feat: add snooze presets to context menu
+fix: prevent duplicate sync on reconnect
+docs: update keyboard shortcuts reference
+refactor: extract email parser into separate module
+test: add coverage for filter engine AND logic
+chore: bump tauri to v2.10
+```
+
+## Pull Requests
+
+- Fill out the [PR template](.github/pull_request_template.md)
+- Keep PRs focused -- one feature or fix per PR
+- Include screenshots for UI changes
+- Ensure all tests pass and there are no type errors
+
+## Reporting Bugs
+
+Use the [bug report template](https://github.com/avihaymenahem/velo/issues/new?template=bug_report.yml) on GitHub Issues. Include:
+
+- Steps to reproduce
+- Expected vs. actual behavior
+- OS and Velo version
+- Screenshots or logs if applicable
+
+## Feature Requests
+
+Use the [feature request template](https://github.com/avihaymenahem/velo/issues/new?template=feature_request.yml) on GitHub Issues.
+
+## License
+
+By contributing, you agree that your contributions will be licensed under the [Apache-2.0 License](LICENSE).

--- a/README.md
+++ b/README.md
@@ -18,7 +18,8 @@
   <a href="#getting-started">Getting Started</a>&nbsp;&nbsp;&bull;&nbsp;&nbsp;
   <a href="docs/keyboard-shortcuts.md">Shortcuts</a>&nbsp;&nbsp;&bull;&nbsp;&nbsp;
   <a href="docs/architecture.md">Architecture</a>&nbsp;&nbsp;&bull;&nbsp;&nbsp;
-  <a href="docs/development.md">Development</a>
+  <a href="docs/development.md">Development</a>&nbsp;&nbsp;&bull;&nbsp;&nbsp;
+  <a href="CONTRIBUTING.md">Contributing</a>
 </p>
 
 ---
@@ -144,7 +145,7 @@ See [Development Guide](docs/development.md) for all commands, testing, and buil
 | **State** | Zustand 5 (8 stores) |
 | **Editor** | TipTap v3 |
 | **Email** | Gmail API, IMAP/SMTP (via async-imap + lettre in Rust) |
-| **Database** | SQLite + FTS5 (31 tables) |
+| **Database** | SQLite + FTS5 (33 tables) |
 | **AI** | Claude, GPT, Gemini |
 | **Testing** | Vitest + Testing Library |
 
@@ -164,7 +165,7 @@ npm run tauri build
 
 ## License
 
-[MIT License](LICENSE)
+[Apache-2.0](LICENSE)
 
 ---
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,79 @@
+# Security Policy
+
+## Supported Versions
+
+| Version | Supported |
+|---------|-----------|
+| Latest release | Yes |
+| Older releases | No |
+
+We only provide security fixes for the latest release. Please keep Velo up to date.
+
+## Reporting a Vulnerability
+
+**Please do not report security vulnerabilities through public GitHub issues.**
+
+Instead, please report them via email to **security@velomail.app** (or by opening a [private security advisory](https://github.com/avihaymenahem/velo/security/advisories/new) on GitHub).
+
+Include as much of the following as possible:
+
+- Description of the vulnerability
+- Steps to reproduce
+- Potential impact
+- Suggested fix (if any)
+
+You should receive an acknowledgment within **48 hours**. We will work with you to understand the issue and coordinate a fix before any public disclosure.
+
+## Security Model
+
+### Local-First Architecture
+
+Velo is a desktop application. Your emails, tokens, and settings are stored locally in a SQLite database on your machine. There are no Velo-operated backend servers.
+
+### Authentication & Credentials
+
+- **Gmail**: OAuth 2.0 with PKCE -- no client secret stored. Tokens are encrypted with AES-256-GCM before being saved to the local database.
+- **IMAP/SMTP**: Passwords and app passwords are encrypted with AES-256-GCM in the local SQLite database.
+- **AI API keys**: Stored in the local SQLite settings table. Keys are sent directly to the respective provider (Anthropic, OpenAI, Google) over HTTPS -- never to any Velo server.
+
+### Email Rendering
+
+- HTML emails are sanitized with **DOMPurify** and rendered in a **sandboxed iframe** (`allow-same-origin` only -- no scripts)
+- Remote images are **blocked by default** and replaced with placeholders. Users can allowlist specific senders.
+- Phishing detection uses 10 heuristic rules to flag suspicious links before you click them
+
+### Network
+
+- All API connections use HTTPS
+- Content Security Policy restricts network requests to known domains (googleapis.com, anthropic.com, openai.com, generativelanguage.googleapis.com, gravatar.com, googleusercontent.com)
+- No telemetry, analytics, or tracking
+
+### Dependencies
+
+- Frontend: React, Tailwind CSS, TipTap, Zustand, DOMPurify, lucide-react
+- Backend: Tauri v2 (Rust), async-imap, lettre, mail-parser
+- We monitor dependencies for known vulnerabilities and update regularly
+
+## Scope
+
+The following are **in scope** for security reports:
+
+- Authentication bypass or token leakage
+- Credential exposure (OAuth tokens, IMAP passwords, API keys)
+- Cross-site scripting (XSS) via email content escaping the sandbox
+- Remote code execution
+- SQL injection in the local SQLite database
+- Insecure data storage or encryption weaknesses
+- Phishing detection bypasses
+
+The following are **out of scope**:
+
+- Vulnerabilities requiring physical access to the user's machine (local SQLite is not encrypted at rest by design -- the OS protects user files)
+- Denial of service against the local application
+- Issues in third-party dependencies with no demonstrated impact on Velo
+- Social engineering attacks
+
+## Disclosure Policy
+
+- We follow coordinated disclosure. Please allow us reasonable time (typically 90 days) to address the issue before public disclosure.
+- We will credit reporters in release notes unless anonymity is requested.


### PR DESCRIPTION
## Summary
- Add `CONTRIBUTING.md` with setup instructions, code guidelines, testing conventions, and commit format
- Add `SECURITY.md` with vulnerability reporting process, security model overview, and disclosure policy
- Fix README: correct license (MIT → Apache-2.0), update table count (31 → 33), add Contributing nav link

## Type of Change
- [x] Documentation

## Testing
- [x] No code changes — documentation only