### PR TITLE
fix: handle missing router context in pop-out thread windows

### DIFF
--- a/src/hooks/useRouteNavigation.ts
+++ b/src/hooks/useRouteNavigation.ts
@@ -1,11 +1,23 @@
 import { useMatches } from "@tanstack/react-router";
 
 /**
+ * Safely call useMatches — returns [] when no router context is available
+ * (e.g. in pop-out ThreadWindow which has no RouterProvider).
+ */
+function useMatchesSafe() {
+  try {
+    return useMatches();
+  } catch {
+    return [];
+  }
+}
+
+/**
  * Derive the active label from the current route.
  * Returns the same string format as the old uiStore.activeLabel.
  */
 export function useActiveLabel(): string {
-  const matches = useMatches();
+  const matches = useMatchesSafe();
   for (const match of matches) {
     if (match.routeId === "/mail/$label" || match.routeId === "/mail/$label/thread/$threadId") {
       return (match.params as { label: string }).label;
@@ -33,7 +45,7 @@ export function useActiveLabel(): string {
  * Get the selected thread ID from route params, or null if no thread is selected.
  */
 export function useSelectedThreadId(): string | null {
-  const matches = useMatches();
+  const matches = useMatchesSafe();
   for (const match of matches) {
     const params = match.params as Record<string, string>;
     if (params["threadId"]) {
@@ -47,7 +59,7 @@ export function useSelectedThreadId(): string | null {
  * Get the active category from search params (only relevant on inbox in split mode).
  */
 export function useActiveCategory(): string {
-  const matches = useMatches();
+  const matches = useMatchesSafe();
   for (const match of matches) {
     const search = (match as { search?: Record<string, unknown> }).search;
     if (search && typeof search["category"] === "string") {
@@ -61,7 +73,7 @@ export function useActiveCategory(): string {
  * Get the search query from search params.
  */
 export function useSearchQuery(): string {
-  const matches = useMatches();
+  const matches = useMatchesSafe();
   for (const match of matches) {
     const search = (match as { search?: Record<string, unknown> }).search;
     if (search && typeof search["q"] === "string") {


### PR DESCRIPTION
## Summary
- Pop-out thread windows (`ThreadWindow`) don't have a `RouterProvider`, so `useMatches()` from TanStack Router throws, crashing the `ActionBar` component
- Added a `useMatchesSafe()` wrapper that catches the error and returns `[]`, letting all route hooks fall through to their defaults gracefully
- 
Closes #73 

## Test plan
- [x] Existing 20 tests in `useRouteNavigation.test.ts` pass
- [ ] Open a thread in a new window — no more console error
- [ ] Verify ActionBar buttons work correctly in the pop-out window