### PR TITLE
ci: auto-trigger build on release-please release

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -20,3 +20,9 @@ jobs:
         id: release
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
+
+  build-and-release:
+    needs: release-please
+    if: needs.release-please.outputs.release_created == 'true'
+    uses: ./.github/workflows/release.yml
+    secrets: inherit

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,8 +1,7 @@
 name: Build & Release
 
 on:
-  release:
-    types: [published]
+  workflow_call:
   workflow_dispatch:
 
 concurrency:
@@ -184,7 +183,7 @@ jobs:
 
   update-homebrew:
     needs: build-macos
-    if: github.event_name == 'release' || github.event_name == 'workflow_dispatch'
+    if: always() && needs.build-macos.result == 'success'
     runs-on: macos-latest
     steps:
       - name: Get version from tag


### PR DESCRIPTION
## Summary
- Chain Build & Release workflow directly from release-please via `workflow_call`, so builds start automatically when a release is created
- Remove the dead `release: types: [published]` trigger (never fired due to `GITHUB_TOKEN` not triggering downstream workflows)
- Fix homebrew update job condition to work with `workflow_call` event

## Before
1. Merge PR → release-please creates Release PR
2. Merge Release PR → release created (nothing happens)
3. Manually go to Actions → Build & Release → Run workflow

## After
1. Merge PR → release-please creates Release PR
2. Merge Release PR → release created → **build starts automatically**

Manual `workflow_dispatch` trigger still available as fallback.