### PR TITLE
fix: create placeholder thread before message insert during IMAP sync

### DIFF
--- a/src/services/imap/imapSync.ts
+++ b/src/services/imap/imapSync.ts
@@ -412,8 +412,21 @@ export async function imapInitialSync(
             folderMapping.labelId,
           );
 
-          // Store message to DB immediately with placeholder threadId
+          // Store message to DB immediately with placeholder threadId.
+          // Create a placeholder thread first to satisfy the FK constraint.
           parsed.threadId = parsed.id;
+          await upsertThread({
+            id: parsed.id,
+            accountId,
+            subject: parsed.subject,
+            snippet: parsed.snippet,
+            lastMessageAt: parsed.date,
+            messageCount: 1,
+            isRead: parsed.isRead,
+            isStarred: parsed.isStarred,
+            isImportant: false,
+            hasAttachments: parsed.hasAttachments,
+          });
           await upsertMessage({
             id: parsed.id,
             accountId,


### PR DESCRIPTION
## Summary
- IMAP initial sync was failing with `FOREIGN KEY constraint failed` because messages were inserted with a placeholder `threadId` before any thread record existed
- Added a placeholder `upsertThread` call before each `upsertMessage` in Phase 2, satisfying the FK constraint (`messages.thread_id → threads.id`)
- Phase 4 upserts the final thread records which naturally update the placeholders via `ON CONFLICT DO UPDATE`

Fixes #89

## Test plan
- [x] Added test verifying placeholder threads are created before messages (call order assertion)
- [x] Updated existing test for correct `upsertThread` call count (2 instead of 1)
- [x] All 21 IMAP sync tests passing
- [x] Full test suite passing (1198/1199 — 1 pre-existing unrelated failure in help content count)