### PR TITLE
feat(ui): highlight spam threads with dimmed red background

### DIFF
--- a/src/components/email/MessageItem.test.tsx
+++ b/src/components/email/MessageItem.test.tsx
@@ -1,0 +1,91 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { MessageItem } from "./MessageItem";
+import type { DbMessage } from "@/services/db/messages";
+
+vi.mock("./EmailRenderer", () => ({
+  EmailRenderer: () => <div data-testid="email-renderer" />,
+}));
+
+vi.mock("./InlineAttachmentPreview", () => ({
+  InlineAttachmentPreview: () => null,
+}));
+
+vi.mock("./AttachmentList", () => ({
+  AttachmentList: () => null,
+  getAttachmentsForMessage: vi.fn().mockResolvedValue([]),
+}));
+
+vi.mock("./AuthBadge", () => ({
+  AuthBadge: () => null,
+}));
+
+vi.mock("./AuthWarningBanner", () => ({
+  AuthWarningBanner: () => null,
+}));
+
+function makeMessage(overrides: Partial<DbMessage> = {}): DbMessage {
+  return {
+    id: "m1",
+    account_id: "a1",
+    thread_id: "t1",
+    from_address: "bob@example.com",
+    from_name: "Bob",
+    to_addresses: "alice@example.com",
+    cc_addresses: null,
+    bcc_addresses: null,
+    reply_to: null,
+    subject: "Test subject",
+    snippet: "Test snippet",
+    date: Date.now(),
+    is_read: 0,
+    is_starred: 0,
+    body_html: "<p>Hello</p>",
+    body_text: "Hello",
+    body_cached: 1,
+    raw_size: 100,
+    internal_date: null,
+    list_unsubscribe: null,
+    list_unsubscribe_post: null,
+    auth_results: null,
+    message_id_header: null,
+    references_header: null,
+    in_reply_to_header: null,
+    ...overrides,
+  };
+}
+
+describe("MessageItem", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("renders sender name", () => {
+    render(<MessageItem message={makeMessage()} isLast={true} blockImages={false} />);
+    expect(screen.getByText("Bob")).toBeInTheDocument();
+  });
+
+  it("applies red background when isSpam is true", () => {
+    const { container } = render(
+      <MessageItem message={makeMessage()} isLast={true} blockImages={false} isSpam={true} />,
+    );
+    const wrapper = container.firstElementChild!;
+    expect(wrapper.className).toContain("bg-red-500/8");
+  });
+
+  it("does not apply red background when isSpam is false", () => {
+    const { container } = render(
+      <MessageItem message={makeMessage()} isLast={true} blockImages={false} isSpam={false} />,
+    );
+    const wrapper = container.firstElementChild!;
+    expect(wrapper.className).not.toContain("bg-red-500");
+  });
+
+  it("does not apply red background when isSpam is undefined", () => {
+    const { container } = render(
+      <MessageItem message={makeMessage()} isLast={true} blockImages={false} />,
+    );
+    const wrapper = container.firstElementChild!;
+    expect(wrapper.className).not.toContain("bg-red-500");
+  });
+});

--- a/src/components/email/MessageItem.tsx
+++ b/src/components/email/MessageItem.tsx
@@ -16,10 +16,11 @@ interface MessageItemProps {
   senderAllowlisted?: boolean;
   accountId?: string;
   threadId?: string;
+  isSpam?: boolean;
   onContextMenu?: (e: React.MouseEvent) => void;
 }
 
-export const MessageItem = memo(function MessageItem({ message, isLast, blockImages, senderAllowlisted, accountId, threadId, onContextMenu }: MessageItemProps) {
+export const MessageItem = memo(function MessageItem({ message, isLast, blockImages, senderAllowlisted, accountId, threadId, isSpam, onContextMenu }: MessageItemProps) {
   const [expanded, setExpanded] = useState(isLast);
   const [attachments, setAttachments] = useState<DbAttachment[]>([]);
   const [, setPreviewAttachment] = useState<DbAttachment | null>(null);
@@ -55,7 +56,7 @@ export const MessageItem = memo(function MessageItem({ message, isLast, blockIma
   const fromDisplay = message.from_name ?? message.from_address ?? "Unknown";
 
   return (
-    <div className="border-b border-border-secondary last:border-b-0" onContextMenu={onContextMenu}>
+    <div className={`border-b border-border-secondary last:border-b-0 ${isSpam ? "bg-red-500/8 dark:bg-red-500/10" : ""}`} onContextMenu={onContextMenu}>
       {/* Header — always visible, click to expand/collapse */}
       <button
         onClick={handleToggle}

--- a/src/components/email/ThreadCard.test.tsx
+++ b/src/components/email/ThreadCard.test.tsx
@@ -1,0 +1,104 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { ThreadCard } from "./ThreadCard";
+import type { Thread } from "@/stores/threadStore";
+
+vi.mock("@dnd-kit/core", () => ({
+  useDraggable: () => ({
+    attributes: {},
+    listeners: {},
+    setNodeRef: vi.fn(),
+    isDragging: false,
+  }),
+}));
+
+vi.mock("@/stores/threadStore", () => ({
+  useThreadStore: Object.assign(
+    (selector: (s: Record<string, unknown>) => unknown) =>
+      selector({
+        selectedThreadIds: new Set(),
+        toggleThreadSelection: vi.fn(),
+        selectThreadRange: vi.fn(),
+      }),
+    { getState: () => ({ selectedThreadIds: new Set() }) },
+  ),
+}));
+
+vi.mock("@/stores/uiStore", () => ({
+  useUIStore: (selector: (s: Record<string, unknown>) => unknown) =>
+    selector({ emailDensity: "default" }),
+}));
+
+vi.mock("@/hooks/useRouteNavigation", () => ({
+  useActiveLabel: () => "inbox",
+}));
+
+function makeThread(overrides: Partial<Thread> = {}): Thread {
+  return {
+    id: "t1",
+    accountId: "a1",
+    subject: "Test subject",
+    snippet: "Test snippet",
+    lastMessageAt: Date.now(),
+    messageCount: 1,
+    isRead: false,
+    isStarred: false,
+    isPinned: false,
+    isMuted: false,
+    hasAttachments: false,
+    labelIds: ["INBOX"],
+    fromName: "Alice",
+    fromAddress: "alice@example.com",
+    ...overrides,
+  };
+}
+
+describe("ThreadCard", () => {
+  const onClick = vi.fn();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("renders sender name and subject", () => {
+    render(<ThreadCard thread={makeThread()} isSelected={false} onClick={onClick} />);
+    expect(screen.getByText("Alice")).toBeInTheDocument();
+    expect(screen.getByText("Test subject")).toBeInTheDocument();
+  });
+
+  it("applies red background for spam threads", () => {
+    const { container } = render(
+      <ThreadCard
+        thread={makeThread({ labelIds: ["SPAM"] })}
+        isSelected={false}
+        onClick={onClick}
+      />,
+    );
+    const button = container.querySelector("button")!;
+    expect(button.className).toContain("bg-red-500/8");
+  });
+
+  it("does not apply red background for non-spam threads", () => {
+    const { container } = render(
+      <ThreadCard
+        thread={makeThread({ labelIds: ["INBOX"] })}
+        isSelected={false}
+        onClick={onClick}
+      />,
+    );
+    const button = container.querySelector("button")!;
+    expect(button.className).not.toContain("bg-red-500");
+  });
+
+  it("applies red background for spam even when thread has other labels", () => {
+    const { container } = render(
+      <ThreadCard
+        thread={makeThread({ labelIds: ["INBOX", "SPAM", "IMPORTANT"] })}
+        isSelected={false}
+        onClick={onClick}
+      />,
+    );
+    const button = container.querySelector("button")!;
+    expect(button.className).toContain("bg-red-500/8");
+  });
+});

--- a/src/components/email/ThreadCard.tsx
+++ b/src/components/email/ThreadCard.tsx
@@ -32,6 +32,7 @@ export const ThreadCard = memo(function ThreadCard({ thread, isSelected, onClick
   const selectThreadRange = useThreadStore((s) => s.selectThreadRange);
   const activeLabel = useActiveLabel();
   const emailDensity = useUIStore((s) => s.emailDensity);
+  const isSpam = thread.labelIds.includes("SPAM");
 
   // Read selectedThreadIds lazily for drag — avoids subscribing all cards to the Set reference
   const dragData: DragData = useMemo(() => ({
@@ -88,7 +89,7 @@ export const ThreadCard = memo(function ThreadCard({ thread, isSelected, onClick
             : isSelected
               ? "bg-bg-selected"
               : "hover:bg-bg-hover"
-      }`}
+      } ${isSpam ? "bg-red-500/8 dark:bg-red-500/10" : ""}`}
     >
       <div className="flex items-start gap-3">
         {/* Avatar */}

--- a/src/components/email/ThreadView.tsx
+++ b/src/components/email/ThreadView.tsx
@@ -381,6 +381,7 @@ export function ThreadView({ thread }: ThreadViewProps) {
                 isLast={i === messages.length - 1}
                 blockImages={blockImages}
                 senderAllowlisted={msg.from_address ? allowlistedSenders.has(msg.from_address) : false}
+                isSpam={thread.labelIds.includes("SPAM")}
                 onContextMenu={(e) => handleMessageContextMenu(e, msg)}
               />
             ))}


### PR DESCRIPTION
## Summary
- Spam threads now display a subtle red tinted background (`bg-red-500/8`) in both the email list (ThreadCard) and reading pane (MessageItem)
- Detection is based on `thread.labelIds` containing `"SPAM"`, so it works regardless of which view/label the user is navigating
- ThreadView passes `isSpam` prop down to each MessageItem

## Test plan
- [x] Added `ThreadCard.test.tsx` (4 tests): verifies red bg for spam, no red bg for non-spam, spam with mixed labels
- [x] Added `MessageItem.test.tsx` (4 tests): verifies red bg when `isSpam=true`, no red bg when false/undefined
- [x] All 8 new tests passing
- [x] All existing tests passing
- [ ] Visual QA: navigate to Spam label and verify red tint on thread cards
- [ ] Visual QA: open a spam thread and verify red tint on messages in reading pane
- [ ] Visual QA: verify non-spam threads remain unaffected