### PR TITLE
feat(signatures): add HTML source editor toggle

### DIFF
--- a/src/components/composer/Composer.tsx
+++ b/src/components/composer/Composer.tsx
@@ -30,6 +30,7 @@ import { startAutoSave, stopAutoSave } from "@/services/composer/draftAutoSave";
 import { getTemplatesForAccount, type DbTemplate } from "@/services/db/templates";
 import { readFileAsBase64 } from "@/utils/fileUtils";
 import { interpolateVariables } from "@/utils/templateVariables";
+import { sanitizeHtml } from "@/utils/sanitize";
 
 export function Composer() {
   // Individual selectors — only re-render when each specific value changes
@@ -229,7 +230,7 @@ export function Composer() {
   const getFullHtml = useCallback(() => {
     const editorHtml = editor?.getHTML() ?? "";
     if (!signatureHtml) return editorHtml;
-    return `${editorHtml}<div style="margin-top:16px;border-top:1px solid #e5e5e5;padding-top:12px">${signatureHtml}</div>`;
+    return `${editorHtml}<div style="margin-top:16px;border-top:1px solid #e5e5e5;padding-top:12px">${sanitizeHtml(signatureHtml)}</div>`;
   }, [editor, signatureHtml]);
 
   const handleSend = useCallback(async () => {
@@ -541,7 +542,7 @@ export function Composer() {
           {signatureHtml && (
             <div
               className="px-4 py-2 border-t border-border-secondary text-xs text-text-tertiary"
-              dangerouslySetInnerHTML={{ __html: signatureHtml }}
+              dangerouslySetInnerHTML={{ __html: sanitizeHtml(signatureHtml) }}
             />
           )}
         </div>

--- a/src/components/settings/SignatureEditor.test.tsx
+++ b/src/components/settings/SignatureEditor.test.tsx
@@ -1,0 +1,189 @@
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { vi, describe, it, expect, beforeEach } from "vitest";
+
+const mockSetContent = vi.fn();
+const mockGetHTML = vi.fn(() => "<p>editor html</p>");
+
+vi.mock("@tiptap/react", () => ({
+  useEditor: vi.fn(() => ({
+    commands: { setContent: mockSetContent },
+    getHTML: mockGetHTML,
+    isActive: vi.fn(() => false),
+    chain: vi.fn(() => ({
+      focus: vi.fn().mockReturnThis(),
+      toggleBold: vi.fn().mockReturnThis(),
+      run: vi.fn(),
+    })),
+    can: vi.fn(() => ({
+      chain: vi.fn(() => ({
+        focus: vi.fn().mockReturnThis(),
+        undo: vi.fn().mockReturnThis(),
+        run: vi.fn(() => true),
+      })),
+    })),
+  })),
+  EditorContent: vi.fn(() => <div data-testid="editor-content">Editor</div>),
+}));
+
+vi.mock("@tiptap/starter-kit", () => ({
+  default: { configure: vi.fn(() => ({})) },
+}));
+
+vi.mock("@tiptap/extension-placeholder", () => ({
+  default: { configure: vi.fn(() => ({})) },
+}));
+
+vi.mock("@tiptap/extension-image", () => ({
+  default: { configure: vi.fn(() => ({})) },
+}));
+
+vi.mock("@/components/composer/EditorToolbar", () => ({
+  EditorToolbar: vi.fn(() => <div data-testid="editor-toolbar">Toolbar</div>),
+}));
+
+vi.mock("@/components/ui/TextField", () => ({
+  TextField: vi.fn((props: React.InputHTMLAttributes<HTMLInputElement>) => (
+    <input {...props} />
+  )),
+}));
+
+const mockGetSignatures = vi.fn<() => Promise<import("@/services/db/signatures").DbSignature[]>>().mockResolvedValue([]);
+const mockInsertSignature = vi.fn().mockResolvedValue(undefined);
+const mockUpdateSignature = vi.fn().mockResolvedValue(undefined);
+const mockDeleteSignature = vi.fn().mockResolvedValue(undefined);
+
+vi.mock("@/services/db/signatures", () => ({
+  getSignaturesForAccount: (...args: unknown[]) => mockGetSignatures(...(args as [])),
+  insertSignature: (...args: unknown[]) => mockInsertSignature(...(args as [])),
+  updateSignature: (...args: unknown[]) => mockUpdateSignature(...(args as [])),
+  deleteSignature: (...args: unknown[]) => mockDeleteSignature(...(args as [])),
+}));
+
+import { useAccountStore } from "@/stores/accountStore";
+import { SignatureEditor } from "./SignatureEditor";
+
+describe("SignatureEditor", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetSignatures.mockResolvedValue([]);
+    mockGetHTML.mockReturnValue("<p>editor html</p>");
+    useAccountStore.setState({ activeAccountId: "acc-1" });
+  });
+
+  it("renders WYSIWYG mode by default with toggle button visible", () => {
+    render(<SignatureEditor />);
+
+    // Click "Add signature" to show the form
+    fireEvent.click(screen.getByText("+ Add signature"));
+
+    expect(screen.getByTestId("editor-content")).toBeInTheDocument();
+    expect(screen.getByTestId("editor-toolbar")).toBeInTheDocument();
+    expect(screen.getByTitle("Edit HTML source")).toBeInTheDocument();
+  });
+
+  it("switches to HTML textarea when toggle is clicked", () => {
+    render(<SignatureEditor />);
+    fireEvent.click(screen.getByText("+ Add signature"));
+
+    // Click the toggle to switch to HTML mode
+    fireEvent.click(screen.getByTitle("Edit HTML source"));
+
+    // Should show textarea, not editor
+    expect(screen.queryByTestId("editor-content")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("editor-toolbar")).not.toBeInTheDocument();
+    expect(screen.getByText("HTML source")).toBeInTheDocument();
+    expect(screen.getByTitle("Switch to visual editor")).toBeInTheDocument();
+
+    // Textarea should have the editor's HTML content
+    const textarea = document.querySelector("textarea")!;
+    expect(textarea).toBeInTheDocument();
+    expect(textarea.value).toBe("<p>editor html</p>");
+  });
+
+  it("switches back to WYSIWYG when toggled again", () => {
+    render(<SignatureEditor />);
+    fireEvent.click(screen.getByText("+ Add signature"));
+
+    // Toggle to HTML mode
+    fireEvent.click(screen.getByTitle("Edit HTML source"));
+
+    // Edit the raw HTML
+    const textarea = document.querySelector("textarea")!;
+    fireEvent.change(textarea, { target: { value: "<b>custom html</b>" } });
+
+    // Toggle back to WYSIWYG
+    fireEvent.click(screen.getByTitle("Switch to visual editor"));
+
+    expect(screen.getByTestId("editor-content")).toBeInTheDocument();
+    expect(screen.getByTestId("editor-toolbar")).toBeInTheDocument();
+    expect(mockSetContent).toHaveBeenCalledWith("<b>custom html</b>");
+  });
+
+  it("saves using textarea content when in HTML mode", async () => {
+    render(<SignatureEditor />);
+    fireEvent.click(screen.getByText("+ Add signature"));
+
+    // Fill in the name
+    fireEvent.change(screen.getByPlaceholderText("Signature name"), {
+      target: { value: "My Sig" },
+    });
+
+    // Toggle to HTML mode
+    fireEvent.click(screen.getByTitle("Edit HTML source"));
+
+    // Edit the raw HTML
+    const textarea = document.querySelector("textarea")!;
+    fireEvent.change(textarea, { target: { value: "<table><tr><td>Sig</td></tr></table>" } });
+
+    // Save
+    fireEvent.click(screen.getByText("Save"));
+
+    await waitFor(() => {
+      expect(mockInsertSignature).toHaveBeenCalledWith({
+        accountId: "acc-1",
+        name: "My Sig",
+        bodyHtml: "<table><tr><td>Sig</td></tr></table>",
+        isDefault: false,
+      });
+    });
+  });
+
+  it("saves using editor.getHTML() when in WYSIWYG mode", async () => {
+    mockGetHTML.mockReturnValue("<p>wysiwyg content</p>");
+
+    render(<SignatureEditor />);
+    fireEvent.click(screen.getByText("+ Add signature"));
+
+    fireEvent.change(screen.getByPlaceholderText("Signature name"), {
+      target: { value: "My Sig" },
+    });
+
+    fireEvent.click(screen.getByText("Save"));
+
+    await waitFor(() => {
+      expect(mockInsertSignature).toHaveBeenCalledWith({
+        accountId: "acc-1",
+        name: "My Sig",
+        bodyHtml: "<p>wysiwyg content</p>",
+        isDefault: false,
+      });
+    });
+  });
+
+  it("resets HTML mode state when cancel is clicked", () => {
+    render(<SignatureEditor />);
+    fireEvent.click(screen.getByText("+ Add signature"));
+
+    // Toggle to HTML mode
+    fireEvent.click(screen.getByTitle("Edit HTML source"));
+    expect(document.querySelector("textarea")).toBeInTheDocument();
+
+    // Cancel
+    fireEvent.click(screen.getByText("Cancel"));
+
+    // Re-open form — should be in WYSIWYG mode
+    fireEvent.click(screen.getByText("+ Add signature"));
+    expect(screen.getByTestId("editor-content")).toBeInTheDocument();
+    expect(document.querySelector("textarea")).not.toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary
- Add a raw HTML code editor toggle (`<>` button) to the signature editor so users can paste complex HTML signatures (tables, custom layouts) from other email clients like Gmail and Outlook
- Sanitize signature HTML via DOMPurify in the composer (both preview and send path) for defense-in-depth
- Add 6 unit tests for the new HTML mode toggle behavior

Closes https://github.com/avihaymenahem/velo/issues/99

## Test plan
- [x] `npx vitest run src/components/settings/SignatureEditor.test.tsx` — 6 new tests pass
- [x] `npm run test` — all 1218 existing tests pass (109 files)
- [x] `npx tsc --noEmit` — no type errors
- [x] Manual: open Settings → Signatures → Add signature, toggle HTML mode, paste an HTML table signature, toggle back to WYSIWYG, verify it renders
- [x] Manual: compose an email with an HTML signature, verify it appears sanitized in preview and sent email