### PR TITLE
fix(ci): fix Homebrew cask 404 and deprecation warning

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -194,7 +194,7 @@ jobs:
           VERSION="${GITHUB_REF_NAME#v}"
           echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
 
-      - name: Download DMG and compute SHA256
+      - name: Wait for DMG and compute SHA256
         id: sha
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -203,7 +203,20 @@ jobs:
           DMG_URL="https://github.com/${{ github.repository }}/releases/download/v${VERSION}/Velo_${VERSION}_universal.dmg"
 
           echo "Downloading DMG from: ${DMG_URL}"
-          curl -sL -o Velo.dmg "$DMG_URL"
+          for i in 1 2 3 4 5; do
+            HTTP_CODE=$(curl -sL -o Velo.dmg -w "%{http_code}" "$DMG_URL")
+            if [ "$HTTP_CODE" = "200" ]; then
+              echo "Download succeeded (attempt $i)"
+              break
+            fi
+            echo "Attempt $i failed (HTTP $HTTP_CODE), retrying in 60s..."
+            rm -f Velo.dmg
+            if [ "$i" = "5" ]; then
+              echo "::error::DMG not available after 5 attempts"
+              exit 1
+            fi
+            sleep 60
+          done
 
           SHA256=$(shasum -a 256 Velo.dmg | awk '{print $1}')
           echo "SHA256: ${SHA256}"

--- a/.github/workflows/update-homebrew.yml
+++ b/.github/workflows/update-homebrew.yml
@@ -29,14 +29,27 @@ jobs:
           echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
           echo "Using version: ${VERSION}"
 
-      - name: Download DMG and compute SHA256
+      - name: Wait for DMG and compute SHA256
         id: sha
         run: |
           VERSION="${{ steps.version.outputs.version }}"
           DMG_URL="https://github.com/${{ github.repository }}/releases/download/v${VERSION}/Velo_${VERSION}_universal.dmg"
 
           echo "Downloading DMG from: ${DMG_URL}"
-          curl -sL -o Velo.dmg "$DMG_URL"
+          for i in 1 2 3 4 5; do
+            HTTP_CODE=$(curl -sL -o Velo.dmg -w "%{http_code}" "$DMG_URL")
+            if [ "$HTTP_CODE" = "200" ]; then
+              echo "Download succeeded (attempt $i)"
+              break
+            fi
+            echo "Attempt $i failed (HTTP $HTTP_CODE), retrying in 60s..."
+            rm -f Velo.dmg
+            if [ "$i" = "5" ]; then
+              echo "::error::DMG not available after 5 attempts"
+              exit 1
+            fi
+            sleep 60
+          done
 
           SHA256=$(shasum -a 256 Velo.dmg | awk '{print $1}')
           echo "SHA256: ${SHA256}"


### PR DESCRIPTION
## Summary
- Guard `update-homebrew` job to only run on `release` events — prevents `GITHUB_REF_NAME` resolving to `main` and producing invalid `vmain` download URLs (404)
- Remove deprecated `depends_on macos: ">= :high_sierra"` from both `release.yml` and `update-homebrew.yml` cask templates

## Note
The existing tap (`homebrew-velo`) still has the broken cask. After merging, run the **Update Homebrew Tap** workflow dispatch with the latest version (e.g., `0.4.2`) to push a corrected cask.

Closes #59