### PR TITLE
docs: fix stale counts, add missing shortcuts and help cards

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -67,7 +67,7 @@ Tauri v2 desktop app: Rust backend + React 19 frontend communicating via Tauri I
 
 ### Component organization
 
-13 groups, ~87 component files:
+13 groups, ~90 component files:
 - `layout/` — Sidebar, EmailList, ReadingPane, TitleBar
 - `email/` — ThreadView, ThreadCard, MessageItem, EmailRenderer, ActionBar, AttachmentList, SnoozeDialog, ContactSidebar, FollowUpDialog, InlineAttachmentPreview, InlineReply, SmartReplySuggestions, ThreadSummary, AuthBadge, AuthWarningBanner, PhishingBanner, LinkConfirmDialog, CategoryTabs
 - `composer/` — Composer (TipTap v3 rich text editor), AddressInput, EditorToolbar, AttachmentPicker, ScheduleSendDialog, SignatureSelector, TemplatePicker, UndoSendToast, AiAssistPanel, FromSelector
@@ -163,7 +163,7 @@ Tailwind CSS v4 — uses `@import "tailwindcss"`, `@theme {}` for custom propert
 
 Vitest + jsdom. Setup file: `src/test/setup.ts` (imports `@testing-library/jest-dom/vitest`). Config: `globals: true` (no imports needed for `describe`, `it`, `expect`). Tests are colocated with source files (e.g., `uiStore.test.ts` next to `uiStore.ts`). Zustand test pattern: `useStore.setState()` in beforeEach, assert via `.getState()`.
 
-106 test files across stores (8), services (49), utils (13), components (19), constants (3), router (1), hooks (2), and config (1).
+111 test files across stores (8), services (56), utils (13), components (27), constants (3), router (1), hooks (2), and config (1).
 
 ## Database
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -5,7 +5,7 @@ Velo follows a **three-layer architecture** with clear separation of concerns.
 ```
 +--------------------------+
 |     React 19 + Zustand   |   UI Layer
-|  Components + 8 Stores   |   (TypeScript)
+|  Components + 9 Stores   |   (TypeScript)
 +--------------------------+
 |     Service Layer         |   Business Logic
 |  Email Provider / Gmail / |   (TypeScript)
@@ -39,7 +39,7 @@ Velo follows a **three-layer architecture** with clear separation of concerns.
 ## Data Flow
 
 1. **Sync** -- Background sync every 60s. Gmail accounts use Gmail History API (delta sync, falls back to full sync if history expires ~30 days). IMAP accounts use UIDVALIDITY/last_uid tracking for efficient delta sync.
-2. **Storage** -- All messages, threads, labels, contacts, calendar events, and AI results stored in local SQLite (33 tables) with FTS5 full-text indexing.
+2. **Storage** -- All messages, threads, labels, contacts, calendar events, and AI results stored in local SQLite (34 tables) with FTS5 full-text indexing.
 3. **State** -- Eight Zustand stores manage UI state. No middleware, no persistence needed -- ephemeral state rebuilds from SQLite on startup.
 4. **Rendering** -- Email HTML is sanitized with DOMPurify and rendered in sandboxed iframes. Remote images blocked by default.
 5. **Background services** -- Seven interval checkers run continuously: sync (60s), snooze (60s), scheduled send (60s), follow-up reminders (60s), newsletter bundles (60s), offline queue processor (30s), and attachment pre-cache (15min).
@@ -50,7 +50,7 @@ Velo follows a **three-layer architecture** with clear separation of concerns.
 ```
 velo/
 ├── src/
-│   ├── components/           # React components (12 groups, ~81 files)
+│   ├── components/           # React components (13 groups, ~90 files)
 │   │   ├── layout/           # Sidebar, EmailList, ReadingPane, TitleBar
 │   │   ├── email/            # ThreadView, MessageItem, EmailRenderer,
 │   │   │                     # ContactSidebar, SmartReplySuggestions,
@@ -188,7 +188,7 @@ Nine Zustand stores manage ephemeral UI state:
 
 ## Database
 
-SQLite via Tauri SQL plugin. 18 migrations, 36 tables total.
+SQLite via Tauri SQL plugin. 18 migrations, 34 tables total.
 
 Key tables: `accounts` (with `provider`, IMAP/SMTP fields), `messages` (with FTS5 index, `auth_results`, IMAP headers, `imap_uid`, `imap_folder`), `threads` (with `is_pinned`, `is_muted`), `thread_labels`, `labels` (with `imap_folder_path`, `imap_special_use`), `contacts`, `attachments` (with `imap_part_id`), `filter_rules`, `scheduled_emails`, `templates`, `signatures`, `image_allowlist`, `settings`, `ai_cache`, `thread_categories`, `calendar_events`, `follow_up_reminders`, `notification_vips`, `unsubscribe_actions`, `bundle_rules`, `bundled_threads`, `send_as_aliases`, `smart_folders`, `link_scan_results`, `phishing_allowlist`, `quick_steps`, `folder_sync_state` (IMAP sync tracking), `pending_operations` (offline action queue), `local_drafts` (offline draft persistence), `writing_style_profiles` (AI writing style per account), `tasks` (full task management with priorities, subtasks, recurrence), `task_tags` (custom task tag colors).
 

--- a/docs/keyboard-shortcuts.md
+++ b/docs/keyboard-shortcuts.md
@@ -40,12 +40,21 @@ Velo is designed to be used entirely from the keyboard. All shortcuts are custom
 | `Ctrl+A` | Select all threads |
 | `Ctrl+Shift+A` | Select all from current position |
 
+## In-thread
+
+| Key | Action |
+|-----|--------|
+| `↓` (Arrow Down) | Next message in thread |
+| `↑` (Arrow Up) | Previous message in thread |
+
 ## App
 
 | Key | Action |
 |-----|--------|
 | `/` or `Ctrl+K` | Command palette |
 | `?` | Keyboard shortcuts help |
+| `i` | Ask Inbox (AI) |
+| `F5` | Sync current folder |
 | `Ctrl+Shift+E` | Toggle sidebar |
 
 ## Multi-select

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -6532,7 +6532,7 @@ checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "velo"
-version = "0.3.3"
+version = "0.4.4"
 dependencies = [
  "async-imap",
  "base64 0.22.1",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "velo"
 # x-release-please-version
-version = "0.3.3"
+version = "0.4.4"
 description = "Email at the speed of thought"
 authors = ["Avihay"]
 license = "Apache-2.0"

--- a/src/constants/helpContent.ts
+++ b/src/constants/helpContent.ts
@@ -55,6 +55,10 @@ import {
   ListTodo,
   Repeat,
   PenSquare,
+  Printer,
+  Code,
+  RefreshCw,
+  ListFilter,
 } from "lucide-react";
 
 // ---------- Types ----------
@@ -242,6 +246,49 @@ export const HELP_CATEGORIES: HelpCategory[] = [
           { text: "\"Manual only\" never auto-marks — you control it yourself." },
         ],
         relatedSettingsTab: "general",
+      },
+      {
+        id: "read-filter",
+        icon: ListFilter,
+        title: "Read / Unread filter",
+        summary: "Filter the email list to show all, unread, or read threads.",
+        description:
+          "Use the filter dropdown at the top of the email list to narrow down what's shown. Choose 'All' to see every thread, 'Unread' to focus on threads that still need attention, or 'Read' to review threads you've already opened. The filter applies to whatever folder or label you're currently viewing. Your filter preference is saved and restored across sessions.",
+        tips: [
+          { text: "The filter dropdown is in the email list header, next to the thread count." },
+          { text: "Options: All, Unread, Read." },
+          { text: "Combine with labels or smart folders for precise filtering." },
+          { text: "Your filter preference persists across restarts." },
+        ],
+        relatedSettingsTab: "general",
+      },
+      {
+        id: "print-export",
+        icon: Printer,
+        title: "Print & export threads",
+        summary: "Print a thread or export it as an .eml file.",
+        description:
+          "From the action bar, you can print the entire thread or export it as an .eml file. Print generates a clean, formatted view of the full conversation with headers and timestamps, then opens your system print dialog. Export saves the thread as a standard RFC 2822 .eml file that can be opened in any email client — useful for backup, legal records, or sharing outside the app.",
+        tips: [
+          { text: "Click the Print icon in the action bar to print the thread." },
+          { text: "Click the Download icon in the action bar to export as .eml." },
+          { text: "The .eml format is a universal standard readable by any email client." },
+          { text: "Print view includes all messages, senders, and timestamps." },
+        ],
+      },
+      {
+        id: "raw-message",
+        icon: Code,
+        title: "View raw message source",
+        summary: "Inspect the raw MIME source of any email.",
+        description:
+          "Right-click on any message in a thread and select 'View Source' to see the full raw MIME source code. This shows all headers (including routing, authentication, and custom headers), the raw message body, and MIME structure. Useful for debugging delivery issues, verifying authentication headers, or understanding how an email was constructed.",
+        tips: [
+          { text: "Right-click a message and choose 'View Source'." },
+          { text: "Shows all headers: From, To, Authentication-Results, DKIM, etc." },
+          { text: "Useful for debugging delivery or spam filter issues." },
+          { text: "The raw view opens in a scrollable modal." },
+        ],
       },
     ],
   },
@@ -433,8 +480,11 @@ export const HELP_CATEGORIES: HelpCategory[] = [
         tips: [
           { text: "View all shortcuts", shortcut: "?" },
           { text: "Navigation: j/k (up/down), o (open), Escape (back)" },
+          { text: "In-thread: Arrow Up/Down to navigate between messages" },
           { text: "Actions: e (archive), s (star), # (trash), r (reply)" },
           { text: "Two-key: g then i (Inbox), g then s (Starred), g then t (Sent)" },
+          { text: "Ask Inbox (AI)", shortcut: "i" },
+          { text: "Sync current folder", shortcut: "F5" },
           { text: "Customize all shortcuts in Settings > Shortcuts." },
           { text: "Shortcuts are disabled in text inputs to prevent conflicts." },
         ],
@@ -555,6 +605,20 @@ export const HELP_CATEGORIES: HelpCategory[] = [
           { text: "Shift+click to select a range of threads." },
           { text: "All keyboard actions (archive, trash, star) work on the selection." },
           { text: "Press Escape to clear the selection." },
+        ],
+      },
+      {
+        id: "bulk-actions",
+        icon: ListFilter,
+        title: "Bulk actions bar",
+        summary: "A toolbar appears when multiple threads are selected.",
+        description:
+          "When you select two or more threads, a bulk actions bar appears at the top of the email list. It provides one-click buttons for the most common batch operations: Archive, Delete, Mark as Spam, and Clear Selection. This is faster than using keyboard shortcuts when you want to visually confirm your selection before acting. The bar also shows how many threads are currently selected.",
+        tips: [
+          { text: "Select multiple threads, then use the bar for quick batch actions." },
+          { text: "Available actions: Archive, Delete, Spam, Clear Selection." },
+          { text: "The bar shows the count of selected threads." },
+          { text: "Keyboard shortcuts also work on the selection alongside the bar." },
         ],
       },
       {
@@ -1104,6 +1168,19 @@ export const HELP_CATEGORIES: HelpCategory[] = [
           { text: "Pop-out windows are fully functional — read, reply, and act." },
           { text: "Multiple threads can be open in separate windows." },
           { text: "Pop-out windows are independent of the main app window." },
+        ],
+      },
+      {
+        id: "manual-sync",
+        icon: RefreshCw,
+        title: "Manual sync",
+        summary: "Trigger an immediate sync of the current folder.",
+        description:
+          "Press F5 to immediately sync the current folder or label instead of waiting for the next 60-second background sync cycle. This is useful when you're expecting an email and don't want to wait, or after making changes in another client. For Gmail, this fetches new history changes; for IMAP, it checks for new UIDs in the current folder.",
+        tips: [
+          { text: "Sync current folder", shortcut: "F5" },
+          { text: "Background sync runs every 60 seconds automatically." },
+          { text: "Manual sync is useful when you're expecting a new email." },
         ],
       },
       {


### PR DESCRIPTION
## Summary
- **Cargo.toml version**: 0.3.3 → 0.4.4 (was out of sync with package.json and tauri.conf.json)
- **CLAUDE.md**: component count ~87 → ~90, test count 106 → 111 (with updated per-category breakdown)
- **docs/architecture.md**: component groups 12 → 13, store count 8 → 9, file count ~81 → ~90, table count 33/36 → 34
- **docs/keyboard-shortcuts.md**: added 4 missing shortcuts — Arrow Up/Down (in-thread message nav), `i` (Ask Inbox), `F5` (sync folder)
- **helpContent.ts**: added 5 missing help cards — Read/Unread filter, Print & Export, Raw message source, Bulk actions bar, Manual sync
- **helpContent.ts**: added missing shortcut tips (`i`, `F5`, arrow keys) to the keyboard shortcuts help card

## Test plan
- [x] All 111 tests pass (1235 assertions)
- [x] TypeScript compiles cleanly (`tsc --noEmit`)
- [x] helpContent.test.ts passes (validates structure, unique IDs, etc.)