### PR TITLE
fix: attachments not showing in attachment list

### DIFF
--- a/src/components/email/EmailRenderer.test.tsx
+++ b/src/components/email/EmailRenderer.test.tsx
@@ -1,0 +1,193 @@
+import { render, waitFor } from "@testing-library/react";
+import { EmailRenderer } from "./EmailRenderer";
+import type { DbAttachment } from "@/services/db/attachments";
+
+// Mock dependencies
+vi.mock("@tauri-apps/plugin-opener", () => ({
+  openUrl: vi.fn(),
+}));
+
+vi.mock("@/utils/sanitize", () => ({
+  sanitizeHtml: (html: string) => html,
+  escapeHtml: (text: string) => text,
+}));
+
+vi.mock("@/services/db/imageAllowlist", () => ({
+  addToAllowlist: vi.fn(),
+}));
+
+vi.mock("@/stores/uiStore", () => ({
+  useUIStore: (selector: (s: { theme: string }) => string) =>
+    selector({ theme: "light" }),
+}));
+
+const mockFetchAttachment = vi.fn();
+
+vi.mock("@/services/email/providerFactory", () => ({
+  getEmailProvider: vi.fn().mockResolvedValue({
+    fetchAttachment: (...args: unknown[]) => mockFetchAttachment(...args),
+  }),
+}));
+
+// Mock ResizeObserver for jsdom
+class MockResizeObserver {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+}
+globalThis.ResizeObserver = MockResizeObserver as unknown as typeof ResizeObserver;
+
+function makeAttachment(overrides: Partial<DbAttachment> = {}): DbAttachment {
+  return {
+    id: "att-1",
+    message_id: "msg-1",
+    account_id: "acc-1",
+    filename: "icon.png",
+    mime_type: "image/png",
+    size: 1024,
+    gmail_attachment_id: "gmail-att-1",
+    content_id: "icon@example.com",
+    is_inline: 1,
+    local_path: null,
+    ...overrides,
+  };
+}
+
+describe("EmailRenderer", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("renders plain text when no html provided", () => {
+    const { container } = render(
+      <EmailRenderer html={null} text="Hello world" />,
+    );
+    expect(container.querySelector("iframe")).toBeTruthy();
+  });
+
+  it("renders html content in iframe", () => {
+    const { container } = render(
+      <EmailRenderer html="<p>Hello</p>" text={null} />,
+    );
+    expect(container.querySelector("iframe")).toBeTruthy();
+  });
+
+  it("resolves cid: references by fetching inline attachment data", async () => {
+    const base64Data = btoa("fake-image-data");
+    mockFetchAttachment.mockResolvedValue({ data: base64Data, size: 100 });
+
+    const inlineAttachments = [makeAttachment()];
+
+    const { container } = render(
+      <EmailRenderer
+        html='<img src="cid:icon@example.com" />'
+        text={null}
+        accountId="acc-1"
+        messageId="msg-1"
+        inlineAttachments={inlineAttachments}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(mockFetchAttachment).toHaveBeenCalledWith("msg-1", "gmail-att-1");
+    });
+
+    expect(container.querySelector("iframe")).toBeTruthy();
+  });
+
+  it("skips cid resolution when no inline attachments", () => {
+    render(
+      <EmailRenderer
+        html='<img src="cid:missing@example.com" />'
+        text={null}
+        accountId="acc-1"
+        messageId="msg-1"
+        inlineAttachments={[]}
+      />,
+    );
+
+    expect(mockFetchAttachment).not.toHaveBeenCalled();
+  });
+
+  it("skips cid resolution when accountId or messageId missing", () => {
+    const inlineAttachments = [makeAttachment()];
+
+    render(
+      <EmailRenderer
+        html='<img src="cid:icon@example.com" />'
+        text={null}
+        inlineAttachments={inlineAttachments}
+      />,
+    );
+
+    expect(mockFetchAttachment).not.toHaveBeenCalled();
+  });
+
+  it("handles fetch failure gracefully", async () => {
+    mockFetchAttachment.mockRejectedValue(new Error("Network error"));
+
+    const inlineAttachments = [makeAttachment()];
+
+    const { container } = render(
+      <EmailRenderer
+        html='<img src="cid:icon@example.com" />'
+        text={null}
+        accountId="acc-1"
+        messageId="msg-1"
+        inlineAttachments={inlineAttachments}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(mockFetchAttachment).toHaveBeenCalled();
+    });
+
+    expect(container.querySelector("iframe")).toBeTruthy();
+  });
+
+  it("resolves multiple cid references", async () => {
+    mockFetchAttachment
+      .mockResolvedValueOnce({ data: btoa("img1"), size: 50 })
+      .mockResolvedValueOnce({ data: btoa("img2"), size: 60 });
+
+    const inlineAttachments = [
+      makeAttachment({ id: "att-1", content_id: "img1@ex.com", gmail_attachment_id: "g1" }),
+      makeAttachment({ id: "att-2", content_id: "img2@ex.com", gmail_attachment_id: "g2", mime_type: "image/jpeg" }),
+    ];
+
+    render(
+      <EmailRenderer
+        html='<img src="cid:img1@ex.com" /><img src="cid:img2@ex.com" />'
+        text={null}
+        accountId="acc-1"
+        messageId="msg-1"
+        inlineAttachments={inlineAttachments}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(mockFetchAttachment).toHaveBeenCalledTimes(2);
+      expect(mockFetchAttachment).toHaveBeenCalledWith("msg-1", "g1");
+      expect(mockFetchAttachment).toHaveBeenCalledWith("msg-1", "g2");
+    });
+  });
+
+  it("ignores attachments without content_id or gmail_attachment_id", () => {
+    const inlineAttachments = [
+      makeAttachment({ content_id: null }),
+      makeAttachment({ id: "att-2", gmail_attachment_id: null }),
+    ];
+
+    render(
+      <EmailRenderer
+        html='<img src="cid:icon@example.com" />'
+        text={null}
+        accountId="acc-1"
+        messageId="msg-1"
+        inlineAttachments={inlineAttachments}
+      />,
+    );
+
+    expect(mockFetchAttachment).not.toHaveBeenCalled();
+  });
+});

--- a/src/components/email/InlineAttachmentPreview.test.tsx
+++ b/src/components/email/InlineAttachmentPreview.test.tsx
@@ -68,12 +68,27 @@ describe("InlineAttachmentPreview", () => {
     expect(container.innerHTML).toBe("");
   });
 
-  it("renders nothing when all attachments are inline", () => {
+  it("renders nothing when all attachments are true inline (no filename)", () => {
     const { container } = render(
       <InlineAttachmentPreview
         accountId="acc-1"
         messageId="msg-1"
-        attachments={[makeAttachment({ is_inline: 1 })]}
+        attachments={[makeAttachment({ is_inline: 1, filename: null })]}
+        onAttachmentClick={onAttachmentClick}
+      />,
+    );
+
+    expect(container.innerHTML).toBe("");
+  });
+
+  it("renders nothing when all attachments have CIDs referenced in the HTML body", () => {
+    const referencedCids = new Set(["img001@example.com"]);
+    const { container } = render(
+      <InlineAttachmentPreview
+        accountId="acc-1"
+        messageId="msg-1"
+        attachments={[makeAttachment({ content_id: "img001@example.com", filename: "photo.png", mime_type: "image/png" })]}
+        referencedCids={referencedCids}
         onAttachmentClick={onAttachmentClick}
       />,
     );


### PR DESCRIPTION
## Summary
- **Parser fix**: `messageParser.ts` was marking ANY attachment with a Content-ID header as `isInline: true`. Now only marks as inline if `Content-Disposition: inline` AND no filename (true embedded CID images)
- **CID-aware display**: Scans HTML body for `cid:` references to identify images already rendered inline in the email body — excludes those from AttachmentList and InlineAttachmentPreview to prevent duplication
- **Content-based dedup**: Changed dedup strategy from `gmail_attachment_id` to `filename+size` to handle the same file existing as both a CID inline part and a regular attachment part (different MIME parts with different IDs)

Closes #114 

## Attachment visibility after fix

| Attachment type | Email body | AttachmentList | InlineAttachmentPreview |
|---|---|---|---|
| CID inline image (no filename) | Shown via CID | Hidden | Hidden |
| CID image with filename (referenced in body) | Shown via CID | Hidden (CID ref) | Hidden (CID ref) |
| Regular file (PDF, doc, etc.) | — | Shown | PDF card shown |
| Regular image (no CID) | — | Shown | Thumbnail shown |
| Same file as CID + regular attachment | Shown via CID | Shown once (deduped) | Shown once (deduped) |

## Test plan
- [x] All 1253 tests pass (112 test files)
- [x] New tests for parser `isInline` classification (3 tests)
- [x] New tests for CID-referenced attachment filtering
- [x] New tests for content-based dedup
- [ ] Manual: open email with file attachments → confirm they appear
- [ ] Manual: open email with inline CID images → confirm no duplication