### PR TITLE
feat: add CalDAV calendar integration

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -43,6 +43,7 @@
         "react": "^19.2.4",
         "react-dom": "^19.2.4",
         "react-transition-group": "^4.4.5",
+        "tsdav": "^2.1.8",
         "zustand": "^5.0.11"
       },
       "devDependencies": {
@@ -3217,6 +3218,12 @@
         "node": ">=12"
       }
     },
+    "node_modules/base-64": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/base-64/-/base-64-1.0.0.tgz",
+      "integrity": "sha512-kwDPIFCGx0NZHog36dj+tHiwP4QMzsZ3AgMViUBKI0+V5n4U0ufTCUMhnQ04diaRI8EX/QcPfql7zlhZ7j4zgg==",
+      "license": "MIT"
+    },
     "node_modules/baseline-browser-mapping": {
       "version": "2.9.19",
       "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.9.19.tgz",
@@ -3321,6 +3328,15 @@
       "integrity": "sha512-VQ2MBenTq1fWZUH9DJNGti7kKv6EeAuYr3cLwxUWhIu1baTaXh4Ib5W2CqHVqib4/MqbYGJqiL3Zb8GJZr3l4g==",
       "license": "MIT"
     },
+    "node_modules/cross-fetch": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-4.1.0.tgz",
+      "integrity": "sha512-uKm5PU+MHTootlWEY+mZ4vvXoCn4fLQxT9dSc1sXVMSFkINTJVN8cAQROpwcKm8bJ/c7rgZVIBWzH5T78sNZZw==",
+      "license": "MIT",
+      "dependencies": {
+        "node-fetch": "^2.7.0"
+      }
+    },
     "node_modules/css-tree": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.1.0.tgz",
@@ -3392,7 +3408,6 @@
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
       "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ms": "^2.1.3"
@@ -4190,7 +4205,6 @@
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/nanoid": {
@@ -4210,6 +4224,48 @@
       },
       "engines": {
         "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/node-fetch": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
+      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/node-fetch/node_modules/tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
+      "license": "MIT"
+    },
+    "node_modules/node-fetch/node_modules/webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/node-fetch/node_modules/whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
       }
     },
     "node_modules/node-releases": {
@@ -4712,6 +4768,15 @@
       "integrity": "sha512-UT5EDe2cu2E/6O4igUr5PSFs23nvvukicWHx6GnOPlHAiiYbzNuCRQCuiUdHJQcqKalLKlrYJnjY0ySGsXNQXQ==",
       "license": "MIT"
     },
+    "node_modules/sax": {
+      "version": "1.4.4",
+      "resolved": "https://registry.npmjs.org/sax/-/sax-1.4.4.tgz",
+      "integrity": "sha512-1n3r/tGXO6b6VXMdFT54SHzT9ytu9yr7TaELowdYpMqY/Ao7EnlQGmAQ1+RatX7Tkkdm6hONI2owqNx2aZj5Sw==",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=11.0.0"
+      }
+    },
     "node_modules/saxes": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
@@ -4941,6 +5006,21 @@
       "resolved": "https://registry.npmjs.org/ts-algebra/-/ts-algebra-2.0.0.tgz",
       "integrity": "sha512-FPAhNPFMrkwz76P7cdjdmiShwMynZYN6SgOujD1urY4oNm80Ou9oMdmbR45LotcKOXoy7wSmHkRFE6Mxbrhefw==",
       "license": "MIT"
+    },
+    "node_modules/tsdav": {
+      "version": "2.1.8",
+      "resolved": "https://registry.npmjs.org/tsdav/-/tsdav-2.1.8.tgz",
+      "integrity": "sha512-zvQvhZLzTaEmNNgJbBlUYT/JOq9Xpw/xkxCqs7IT2d2/7o7pss0iZOlZXuHJ5VcvSvTny42Vc6+6GyzZcrCJ1g==",
+      "license": "MIT",
+      "dependencies": {
+        "base-64": "1.0.0",
+        "cross-fetch": "4.1.0",
+        "debug": "4.4.3",
+        "xml-js": "1.6.11"
+      },
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/tslib": {
       "version": "2.8.1",
@@ -5240,6 +5320,18 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/xml-js": {
+      "version": "1.6.11",
+      "resolved": "https://registry.npmjs.org/xml-js/-/xml-js-1.6.11.tgz",
+      "integrity": "sha512-7rVi2KMfwfWFl+GpPg6m80IVMWXLRjO+PxTq7V2CDhoGak0wzYzFgUY2m4XJ47OGdXd8eLE8EmwfAmdjw7lC1g==",
+      "license": "MIT",
+      "dependencies": {
+        "sax": "^1.2.4"
+      },
+      "bin": {
+        "xml-js": "bin/cli.js"
       }
     },
     "node_modules/xml-name-validator": {

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "react": "^19.2.4",
     "react-dom": "^19.2.4",
     "react-transition-group": "^4.4.5",
+    "tsdav": "^2.1.8",
     "zustand": "^5.0.11"
   },
   "devDependencies": {

--- a/src/ComposerWindow.tsx
+++ b/src/ComposerWindow.tsx
@@ -51,6 +51,7 @@ export default function ComposerWindow() {
           displayName: a.display_name,
           avatarUrl: a.avatar_url,
           isActive: a.is_active === 1,
+          provider: a.provider,
         }));
         setAccounts(mapped);
 

--- a/src/ThreadWindow.tsx
+++ b/src/ThreadWindow.tsx
@@ -61,6 +61,7 @@ export default function ThreadWindow() {
           displayName: a.display_name,
           avatarUrl: a.avatar_url,
           isActive: a.is_active === 1,
+          provider: a.provider,
         }));
         setAccounts(mapped);
 

--- a/src/components/accounts/AccountSwitcher.tsx
+++ b/src/components/accounts/AccountSwitcher.tsx
@@ -1,6 +1,6 @@
 import { useState, useRef, useCallback } from "react";
 import { useAccountStore, type Account } from "@/stores/accountStore";
-import { ChevronDown, Check, Plus, UserPlus } from "lucide-react";
+import { ChevronDown, Check, Plus, UserPlus, Calendar } from "lucide-react";
 import { useClickOutside } from "@/hooks/useClickOutside";
 
 interface AccountSwitcherProps {
@@ -108,8 +108,11 @@ export function AccountSwitcher({
               >
                 <AccountAvatarSmall account={account} isActive={isActive} />
                 <div className="flex-1 min-w-0">
-                  <div className="text-sm font-medium truncate leading-tight">
+                  <div className="text-sm font-medium truncate leading-tight flex items-center gap-1.5">
                     {account.displayName || account.email.split("@")[0]}
+                    {account.provider === "caldav" && (
+                      <Calendar size={12} className="shrink-0 text-text-tertiary" />
+                    )}
                   </div>
                   <div className="text-xs text-text-secondary truncate leading-tight">
                     {account.email}

--- a/src/components/accounts/AddAccount.tsx
+++ b/src/components/accounts/AddAccount.tsx
@@ -1,5 +1,5 @@
 import { useState } from "react";
-import { Mail } from "lucide-react";
+import { Mail, Calendar } from "lucide-react";
 import { startOAuthFlow } from "@/services/gmail/auth";
 import { insertAccount } from "@/services/db/accounts";
 import { getClientId, getClientSecret } from "@/services/gmail/tokenManager";
@@ -7,6 +7,7 @@ import { useAccountStore } from "@/stores/accountStore";
 import { Modal } from "@/components/ui/Modal";
 import { SetupClientId } from "./SetupClientId";
 import { AddImapAccount } from "./AddImapAccount";
+import { AddCalDavAccount } from "./AddCalDavAccount";
 import { getCurrentUnixTimestamp } from "@/utils/timestamp";
 
 interface AddAccountProps {
@@ -14,7 +15,7 @@ interface AddAccountProps {
   onSuccess: () => void;
 }
 
-type View = "select-provider" | "gmail" | "imap";
+type View = "select-provider" | "gmail" | "imap" | "caldav";
 
 export function AddAccount({ onClose, onSuccess }: AddAccountProps) {
   const [view, setView] = useState<View>("select-provider");
@@ -79,6 +80,16 @@ export function AddAccount({ onClose, onSuccess }: AddAccountProps) {
           setStatus("idle");
         }}
         onCancel={onClose}
+      />
+    );
+  }
+
+  if (view === "caldav") {
+    return (
+      <AddCalDavAccount
+        onClose={onClose}
+        onSuccess={onSuccess}
+        onBack={() => setView("select-provider")}
       />
     );
   }
@@ -208,6 +219,23 @@ export function AddAccount({ onClose, onSuccess }: AddAccountProps) {
               </div>
               <div className="text-xs text-text-tertiary mt-0.5">
                 Connect any email provider with manual server configuration
+              </div>
+            </div>
+          </button>
+
+          <button
+            onClick={() => setView("caldav")}
+            className="w-full flex items-center gap-4 p-4 rounded-lg border border-border-primary bg-bg-secondary hover:bg-bg-hover transition-colors text-left group"
+          >
+            <div className="flex-shrink-0 w-10 h-10 rounded-lg bg-bg-tertiary flex items-center justify-center">
+              <Calendar className="w-5 h-5 text-text-secondary" />
+            </div>
+            <div className="flex-1 min-w-0">
+              <div className="text-sm font-medium text-text-primary group-hover:text-accent transition-colors">
+                CalDAV (Calendar Only)
+              </div>
+              <div className="text-xs text-text-tertiary mt-0.5">
+                Connect iCloud, Fastmail, Nextcloud, or any CalDAV calendar server
               </div>
             </div>
           </button>

--- a/src/components/accounts/AddCalDavAccount.tsx
+++ b/src/components/accounts/AddCalDavAccount.tsx
@@ -1,0 +1,288 @@
+import { useState, useCallback } from "react";
+import {
+  ArrowLeft,
+  ArrowRight,
+  CheckCircle2,
+  XCircle,
+  Loader2,
+  Calendar,
+} from "lucide-react";
+import { Modal } from "@/components/ui/Modal";
+import { TextField } from "@/components/ui/TextField";
+import { insertCalDavAccount } from "@/services/db/accounts";
+import { useAccountStore } from "@/stores/accountStore";
+import { discoverCalDavSettings, testCalDavConnection } from "@/services/calendar/autoDiscovery";
+
+interface AddCalDavAccountProps {
+  onClose: () => void;
+  onSuccess: () => void;
+  onBack: () => void;
+}
+
+type Step = "basic" | "server" | "test" | "done";
+
+export function AddCalDavAccount({ onClose, onSuccess, onBack }: AddCalDavAccountProps) {
+  const addAccount = useAccountStore((s) => s.addAccount);
+  const [step, setStep] = useState<Step>("basic");
+
+  // Form state
+  const [email, setEmail] = useState("");
+  const [displayName, setDisplayName] = useState("");
+  const [caldavUrl, setCaldavUrl] = useState("");
+  const [username, setUsername] = useState("");
+  const [password, setPassword] = useState("");
+  const [providerName, setProviderName] = useState<string | null>(null);
+  const [needsAppPassword, setNeedsAppPassword] = useState(false);
+
+  // Test state
+  const [testing, setTesting] = useState(false);
+  const [testResult, setTestResult] = useState<{ success: boolean; message: string } | null>(null);
+  const [calendarCount, setCalendarCount] = useState(0);
+
+  // Creating account
+  const [creating, setCreating] = useState(false);
+
+  const handleDiscoverAndNext = useCallback(async () => {
+    if (!email.trim()) return;
+    setUsername(email);
+
+    const result = await discoverCalDavSettings(email);
+    if (result.caldavUrl) {
+      setCaldavUrl(result.caldavUrl);
+    }
+    setProviderName(result.providerName);
+    setNeedsAppPassword(result.needsAppPassword);
+    setStep("server");
+  }, [email]);
+
+  const handleTest = useCallback(async () => {
+    setTesting(true);
+    setTestResult(null);
+
+    const result = await testCalDavConnection(caldavUrl, username, password);
+    setTestResult(result);
+    setCalendarCount(result.calendarCount ?? 0);
+    setTesting(false);
+  }, [caldavUrl, username, password]);
+
+  const handleCreate = useCallback(async () => {
+    setCreating(true);
+    try {
+      const id = crypto.randomUUID();
+      await insertCalDavAccount({
+        id,
+        email,
+        displayName: displayName || null,
+        caldavUrl,
+        caldavUsername: username,
+        caldavPassword: password,
+      });
+
+      addAccount({
+        id,
+        email,
+        displayName: displayName || null,
+        avatarUrl: null,
+        isActive: true,
+      });
+
+      setStep("done");
+    } catch (err) {
+      console.error("Failed to create CalDAV account:", err);
+      setTestResult({ success: false, message: "Failed to save account" });
+    } finally {
+      setCreating(false);
+    }
+  }, [email, displayName, caldavUrl, username, password, addAccount]);
+
+  return (
+    <Modal isOpen={true} onClose={onClose} title="Add CalDAV Calendar" width="w-full max-w-md">
+      <div className="p-4">
+        {step === "basic" && (
+          <div className="space-y-4">
+            <div className="flex items-center gap-3 mb-4">
+              <div className="w-10 h-10 rounded-full bg-accent/10 flex items-center justify-center">
+                <Calendar size={20} className="text-accent" />
+              </div>
+              <div>
+                <h3 className="text-sm font-medium text-text-primary">CalDAV Calendar Account</h3>
+                <p className="text-xs text-text-tertiary">
+                  Connect to iCloud, Fastmail, Nextcloud, or any CalDAV server
+                </p>
+              </div>
+            </div>
+
+            <TextField
+              label="Email"
+              type="email"
+              value={email}
+              onChange={(e) => setEmail(e.target.value)}
+              placeholder="your@email.com"
+              autoFocus
+            />
+
+            <TextField
+              label="Display Name (optional)"
+              type="text"
+              value={displayName}
+              onChange={(e) => setDisplayName(e.target.value)}
+              placeholder="My Calendar"
+            />
+
+            <div className="flex justify-between pt-2">
+              <button
+                onClick={onBack}
+                className="flex items-center gap-1 text-sm text-text-secondary hover:text-text-primary transition-colors"
+              >
+                <ArrowLeft size={14} />
+                Back
+              </button>
+              <button
+                onClick={handleDiscoverAndNext}
+                disabled={!email.trim()}
+                className="flex items-center gap-1 px-4 py-2 text-sm font-medium text-white bg-accent hover:bg-accent-hover rounded-md transition-colors disabled:opacity-50"
+              >
+                Next
+                <ArrowRight size={14} />
+              </button>
+            </div>
+          </div>
+        )}
+
+        {step === "server" && (
+          <div className="space-y-4">
+            {providerName && (
+              <div className="text-xs text-accent font-medium">
+                Detected: {providerName}
+              </div>
+            )}
+
+            {needsAppPassword && (
+              <div className="p-3 bg-warning/10 border border-warning/30 rounded text-xs text-text-secondary">
+                This provider requires an app-specific password. Generate one in your provider's security settings.
+              </div>
+            )}
+
+            <TextField
+              label="CalDAV Server URL"
+              type="url"
+              value={caldavUrl}
+              onChange={(e) => setCaldavUrl(e.target.value)}
+              placeholder="https://caldav.example.com/"
+            />
+
+            <TextField
+              label="Username"
+              type="text"
+              value={username}
+              onChange={(e) => setUsername(e.target.value)}
+              placeholder="your@email.com"
+            />
+
+            <TextField
+              label={needsAppPassword ? "App Password" : "Password"}
+              type="password"
+              value={password}
+              onChange={(e) => setPassword(e.target.value)}
+              placeholder={needsAppPassword ? "App-specific password" : "Password"}
+            />
+
+            <div className="flex justify-between pt-2">
+              <button
+                onClick={() => setStep("basic")}
+                className="flex items-center gap-1 text-sm text-text-secondary hover:text-text-primary transition-colors"
+              >
+                <ArrowLeft size={14} />
+                Back
+              </button>
+              <button
+                onClick={() => { setStep("test"); handleTest(); }}
+                disabled={!caldavUrl || !password}
+                className="flex items-center gap-1 px-4 py-2 text-sm font-medium text-white bg-accent hover:bg-accent-hover rounded-md transition-colors disabled:opacity-50"
+              >
+                Test & Connect
+                <ArrowRight size={14} />
+              </button>
+            </div>
+          </div>
+        )}
+
+        {step === "test" && (
+          <div className="space-y-4">
+            <div className="text-center py-6">
+              {testing && (
+                <>
+                  <Loader2 size={32} className="animate-spin text-accent mx-auto mb-3" />
+                  <p className="text-sm text-text-secondary">Testing connection...</p>
+                </>
+              )}
+
+              {!testing && testResult?.success && (
+                <>
+                  <CheckCircle2 size={32} className="text-success mx-auto mb-3" />
+                  <p className="text-sm font-medium text-text-primary">{testResult.message}</p>
+                  {calendarCount > 0 && (
+                    <p className="text-xs text-text-tertiary mt-1">
+                      Found {calendarCount} calendar{calendarCount !== 1 ? "s" : ""}
+                    </p>
+                  )}
+                </>
+              )}
+
+              {!testing && testResult && !testResult.success && (
+                <>
+                  <XCircle size={32} className="text-danger mx-auto mb-3" />
+                  <p className="text-sm font-medium text-text-primary">Connection failed</p>
+                  <p className="text-xs text-text-tertiary mt-1">{testResult.message}</p>
+                </>
+              )}
+            </div>
+
+            <div className="flex justify-between pt-2">
+              <button
+                onClick={() => { setStep("server"); setTestResult(null); }}
+                className="flex items-center gap-1 text-sm text-text-secondary hover:text-text-primary transition-colors"
+              >
+                <ArrowLeft size={14} />
+                Back
+              </button>
+
+              {testResult?.success ? (
+                <button
+                  onClick={handleCreate}
+                  disabled={creating}
+                  className="flex items-center gap-1 px-4 py-2 text-sm font-medium text-white bg-accent hover:bg-accent-hover rounded-md transition-colors disabled:opacity-50"
+                >
+                  {creating ? "Creating..." : "Add Account"}
+                </button>
+              ) : !testing ? (
+                <button
+                  onClick={handleTest}
+                  className="flex items-center gap-1 px-4 py-2 text-sm font-medium text-white bg-accent hover:bg-accent-hover rounded-md transition-colors"
+                >
+                  Retry
+                </button>
+              ) : null}
+            </div>
+          </div>
+        )}
+
+        {step === "done" && (
+          <div className="text-center py-6">
+            <CheckCircle2 size={32} className="text-success mx-auto mb-3" />
+            <p className="text-sm font-medium text-text-primary">CalDAV account added!</p>
+            <p className="text-xs text-text-tertiary mt-1">
+              Your calendars will sync automatically.
+            </p>
+            <button
+              onClick={onSuccess}
+              className="mt-4 px-4 py-2 text-sm font-medium text-white bg-accent hover:bg-accent-hover rounded-md transition-colors"
+            >
+              Done
+            </button>
+          </div>
+        )}
+      </div>
+    </Modal>
+  );
+}

--- a/src/components/calendar/CalendarList.test.tsx
+++ b/src/components/calendar/CalendarList.test.tsx
@@ -1,0 +1,131 @@
+import { render, screen, fireEvent } from "@testing-library/react";
+import { vi } from "vitest";
+import { CalendarList } from "./CalendarList";
+import type { DbCalendar } from "@/services/db/calendars";
+
+function makeCalendar(overrides: Partial<DbCalendar> = {}): DbCalendar {
+  return {
+    id: "cal-1",
+    account_id: "acc-1",
+    provider: "google",
+    remote_id: "remote-1",
+    display_name: "Work",
+    color: "#4285f4",
+    is_primary: 0,
+    is_visible: 1,
+    sync_token: null,
+    ctag: null,
+    created_at: 1700000000,
+    updated_at: 1700000000,
+    ...overrides,
+  };
+}
+
+describe("CalendarList", () => {
+  it("renders all calendar names", () => {
+    const calendars = [
+      makeCalendar({ id: "cal-1", display_name: "Work" }),
+      makeCalendar({ id: "cal-2", display_name: "Personal" }),
+      makeCalendar({ id: "cal-3", display_name: "Holidays" }),
+    ];
+
+    render(
+      <CalendarList calendars={calendars} onVisibilityChange={vi.fn()} />,
+    );
+
+    expect(screen.getByText("Work")).toBeInTheDocument();
+    expect(screen.getByText("Personal")).toBeInTheDocument();
+    expect(screen.getByText("Holidays")).toBeInTheDocument();
+  });
+
+  it('shows "Primary" badge for primary calendar', () => {
+    const calendars = [
+      makeCalendar({ id: "cal-1", display_name: "Main", is_primary: 1 }),
+      makeCalendar({ id: "cal-2", display_name: "Secondary", is_primary: 0 }),
+    ];
+
+    render(
+      <CalendarList calendars={calendars} onVisibilityChange={vi.fn()} />,
+    );
+
+    expect(screen.getByText("Primary")).toBeInTheDocument();
+    // Only one Primary badge
+    expect(screen.getAllByText("Primary")).toHaveLength(1);
+  });
+
+  it("checkboxes reflect is_visible state", () => {
+    const calendars = [
+      makeCalendar({ id: "cal-1", display_name: "Visible", is_visible: 1 }),
+      makeCalendar({
+        id: "cal-2",
+        display_name: "Hidden",
+        is_visible: 0,
+      }),
+    ];
+
+    render(
+      <CalendarList calendars={calendars} onVisibilityChange={vi.fn()} />,
+    );
+
+    const checkboxes = screen.getAllByRole("checkbox");
+    expect(checkboxes[0]).toBeChecked();
+    expect(checkboxes[1]).not.toBeChecked();
+  });
+
+  it("clicking checkbox calls onVisibilityChange with correct calendarId and new state", () => {
+    const onVisibilityChange = vi.fn();
+    const calendars = [
+      makeCalendar({ id: "cal-1", display_name: "Work", is_visible: 1 }),
+      makeCalendar({ id: "cal-2", display_name: "Personal", is_visible: 0 }),
+    ];
+
+    render(
+      <CalendarList
+        calendars={calendars}
+        onVisibilityChange={onVisibilityChange}
+      />,
+    );
+
+    const checkboxes = screen.getAllByRole("checkbox");
+
+    // Uncheck the visible calendar
+    fireEvent.click(checkboxes[0]);
+    expect(onVisibilityChange).toHaveBeenCalledWith("cal-1", false);
+
+    // Check the hidden calendar
+    fireEvent.click(checkboxes[1]);
+    expect(onVisibilityChange).toHaveBeenCalledWith("cal-2", true);
+  });
+
+  it("calendar color is applied to the checkbox indicator", () => {
+    const calendars = [
+      makeCalendar({
+        id: "cal-1",
+        display_name: "Work",
+        color: "#e63946",
+        is_visible: 1,
+      }),
+    ];
+
+    render(
+      <CalendarList calendars={calendars} onVisibilityChange={vi.fn()} />,
+    );
+
+    // The color indicator span is the sibling after the sr-only checkbox
+    const checkbox = screen.getByRole("checkbox");
+    const indicator = checkbox.nextElementSibling as HTMLElement;
+    expect(indicator.style.backgroundColor).toBe("rgb(230, 57, 70)");
+  });
+
+  it('handles null display_name by showing "Calendar" fallback', () => {
+    const calendars = [
+      makeCalendar({ id: "cal-1", display_name: null }),
+    ];
+
+    render(
+      <CalendarList calendars={calendars} onVisibilityChange={vi.fn()} />,
+    );
+
+    expect(screen.getByText("Calendar")).toBeInTheDocument();
+  });
+});

--- a/src/components/calendar/CalendarList.tsx
+++ b/src/components/calendar/CalendarList.tsx
@@ -1,0 +1,51 @@
+import type { DbCalendar } from "@/services/db/calendars";
+
+interface CalendarListProps {
+  calendars: DbCalendar[];
+  onVisibilityChange: (calendarId: string, visible: boolean) => void;
+}
+
+export function CalendarList({ calendars, onVisibilityChange }: CalendarListProps) {
+  return (
+    <div className="w-52 border-r border-border-primary p-3 overflow-y-auto shrink-0">
+      <h3 className="text-xs font-medium text-text-tertiary uppercase tracking-wider mb-2">
+        Calendars
+      </h3>
+      <div className="space-y-1">
+        {calendars.map((cal) => (
+          <label
+            key={cal.id}
+            className="flex items-center gap-2 px-2 py-1.5 rounded hover:bg-bg-hover cursor-pointer transition-colors"
+          >
+            <input
+              type="checkbox"
+              checked={!!cal.is_visible}
+              onChange={(e) => onVisibilityChange(cal.id, e.target.checked)}
+              className="sr-only"
+            />
+            <span
+              className={`w-3 h-3 rounded-sm border-2 flex items-center justify-center shrink-0 transition-colors ${
+                cal.is_visible
+                  ? "border-transparent"
+                  : "border-border-primary bg-transparent"
+              }`}
+              style={cal.is_visible ? { backgroundColor: cal.color ?? "var(--color-accent)" } : undefined}
+            >
+              {!!cal.is_visible && (
+                <svg width="8" height="8" viewBox="0 0 8 8" fill="none">
+                  <path d="M1.5 4L3 5.5L6.5 2" stroke="white" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" />
+                </svg>
+              )}
+            </span>
+            <span className="text-sm text-text-primary truncate">
+              {cal.display_name ?? "Calendar"}
+            </span>
+            {!!cal.is_primary && (
+              <span className="text-[0.6rem] text-text-tertiary ml-auto shrink-0">Primary</span>
+            )}
+          </label>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/components/calendar/CalendarToolbar.tsx
+++ b/src/components/calendar/CalendarToolbar.tsx
@@ -1,4 +1,4 @@
-import { ChevronLeft, ChevronRight, Plus } from "lucide-react";
+import { ChevronLeft, ChevronRight, Plus, CalendarDays } from "lucide-react";
 
 export type CalendarView = "day" | "week" | "month";
 
@@ -10,6 +10,8 @@ interface CalendarToolbarProps {
   onToday: () => void;
   onViewChange: (view: CalendarView) => void;
   onCreateEvent: () => void;
+  onToggleCalendarList?: () => void;
+  showCalendarListButton?: boolean;
 }
 
 export function CalendarToolbar({
@@ -20,6 +22,8 @@ export function CalendarToolbar({
   onToday,
   onViewChange,
   onCreateEvent,
+  onToggleCalendarList,
+  showCalendarListButton,
 }: CalendarToolbarProps) {
   const title = formatTitle(currentDate, view);
 
@@ -50,6 +54,15 @@ export function CalendarToolbar({
       </div>
 
       <div className="flex items-center gap-2">
+        {showCalendarListButton && onToggleCalendarList && (
+          <button
+            onClick={onToggleCalendarList}
+            className="p-1.5 text-text-secondary hover:text-text-primary hover:bg-bg-hover rounded transition-colors"
+            title="Toggle calendar list"
+          >
+            <CalendarDays size={16} />
+          </button>
+        )}
         <div className="flex bg-bg-tertiary rounded-md p-0.5">
           {(["day", "week", "month"] as CalendarView[]).map((v) => (
             <button

--- a/src/components/calendar/EventCreateModal.tsx
+++ b/src/components/calendar/EventCreateModal.tsx
@@ -2,8 +2,10 @@ import { useState, useCallback } from "react";
 import { Button } from "@/components/ui/Button";
 import { Modal } from "@/components/ui/Modal";
 import { TextField } from "@/components/ui/TextField";
+import type { DbCalendar } from "@/services/db/calendars";
 
 interface EventCreateModalProps {
+  calendars?: DbCalendar[];
   onClose: () => void;
   onCreate: (event: {
     summary: string;
@@ -11,21 +13,32 @@ interface EventCreateModalProps {
     location: string;
     startTime: string;
     endTime: string;
+    calendarId?: string;
   }) => void;
 }
 
-export function EventCreateModal({ onClose, onCreate }: EventCreateModalProps) {
+export function EventCreateModal({ calendars, onClose, onCreate }: EventCreateModalProps) {
   const [summary, setSummary] = useState("");
   const [description, setDescription] = useState("");
   const [location, setLocation] = useState("");
   const [startTime, setStartTime] = useState(getDefaultStart());
   const [endTime, setEndTime] = useState(getDefaultEnd());
+  const [calendarId, setCalendarId] = useState<string>(
+    calendars?.find((c) => c.is_primary)?.id ?? calendars?.[0]?.id ?? "",
+  );
 
   const handleSubmit = useCallback((e: React.FormEvent) => {
     e.preventDefault();
     if (!summary.trim()) return;
-    onCreate({ summary: summary.trim(), description, location, startTime, endTime });
-  }, [summary, description, location, startTime, endTime, onCreate]);
+    onCreate({
+      summary: summary.trim(),
+      description,
+      location,
+      startTime,
+      endTime,
+      calendarId: calendarId || undefined,
+    });
+  }, [summary, description, location, startTime, endTime, calendarId, onCreate]);
 
   return (
     <Modal isOpen={true} onClose={onClose} title="Create Event" width="w-full max-w-md">
@@ -38,6 +51,24 @@ export function EventCreateModal({ onClose, onCreate }: EventCreateModalProps) {
           placeholder="Event title"
           autoFocus
         />
+
+        {calendars && calendars.length > 1 && (
+          <div>
+            <label className="text-xs text-text-secondary block mb-1">Calendar</label>
+            <select
+              value={calendarId}
+              onChange={(e) => setCalendarId(e.target.value)}
+              className="w-full px-3 py-1.5 bg-bg-tertiary border border-border-primary rounded text-sm text-text-primary outline-none focus:border-accent"
+            >
+              {calendars.map((cal) => (
+                <option key={cal.id} value={cal.id}>
+                  {cal.display_name ?? "Calendar"}
+                  {cal.is_primary ? " (Primary)" : ""}
+                </option>
+              ))}
+            </select>
+          </div>
+        )}
 
         <div className="grid grid-cols-2 gap-3">
           <TextField

--- a/src/components/calendar/EventDetailModal.tsx
+++ b/src/components/calendar/EventDetailModal.tsx
@@ -1,0 +1,232 @@
+import { useState, useCallback } from "react";
+import { MapPin, Clock, User, Pencil, Trash2 } from "lucide-react";
+import { Button } from "@/components/ui/Button";
+import { Modal } from "@/components/ui/Modal";
+import { TextField } from "@/components/ui/TextField";
+import type { DbCalendarEvent } from "@/services/db/calendarEvents";
+import type { DbCalendar } from "@/services/db/calendars";
+import { getCalendarProvider } from "@/services/calendar/providerFactory";
+import { deleteCalendarEvent as deleteCalendarEventDb } from "@/services/db/calendarEvents";
+
+interface EventDetailModalProps {
+  event: DbCalendarEvent;
+  calendars: DbCalendar[];
+  accountId: string;
+  onClose: () => void;
+  onUpdated: () => void;
+}
+
+export function EventDetailModal({ event, calendars, accountId, onClose, onUpdated }: EventDetailModalProps) {
+  const [editing, setEditing] = useState(false);
+  const [summary, setSummary] = useState(event.summary ?? "");
+  const [description, setDescription] = useState(event.description ?? "");
+  const [location, setLocation] = useState(event.location ?? "");
+  const [startTime, setStartTime] = useState(toLocalISOString(new Date(event.start_time * 1000)));
+  const [endTime, setEndTime] = useState(toLocalISOString(new Date(event.end_time * 1000)));
+  const [saving, setSaving] = useState(false);
+  const [deleting, setDeleting] = useState(false);
+  const [confirmDelete, setConfirmDelete] = useState(false);
+
+  const calendar = calendars.find((c) => c.id === event.calendar_id);
+
+  const handleSave = useCallback(async () => {
+    setSaving(true);
+    try {
+      const provider = await getCalendarProvider(accountId);
+      const calendarRemoteId = calendar?.remote_id ?? "primary";
+      const remoteEventId = event.remote_event_id ?? event.google_event_id;
+
+      await provider.updateEvent(calendarRemoteId, remoteEventId, {
+        summary,
+        description: description || undefined,
+        location: location || undefined,
+        startTime: new Date(startTime).toISOString(),
+        endTime: new Date(endTime).toISOString(),
+      }, event.etag ?? undefined);
+
+      onUpdated();
+    } catch (err) {
+      console.error("Failed to update event:", err);
+    } finally {
+      setSaving(false);
+    }
+  }, [accountId, calendar, event, summary, description, location, startTime, endTime, onUpdated]);
+
+  const handleDelete = useCallback(async () => {
+    setDeleting(true);
+    try {
+      const provider = await getCalendarProvider(accountId);
+      const calendarRemoteId = calendar?.remote_id ?? "primary";
+      const remoteEventId = event.remote_event_id ?? event.google_event_id;
+
+      await provider.deleteEvent(calendarRemoteId, remoteEventId, event.etag ?? undefined);
+
+      // Remove from local DB
+      await deleteCalendarEventDb(event.id);
+
+      onUpdated();
+    } catch (err) {
+      console.error("Failed to delete event:", err);
+    } finally {
+      setDeleting(false);
+    }
+  }, [accountId, calendar, event, onUpdated]);
+
+  const formatTime = (ts: number) => {
+    return new Date(ts * 1000).toLocaleString(undefined, {
+      weekday: "short",
+      month: "short",
+      day: "numeric",
+      hour: "numeric",
+      minute: "2-digit",
+    });
+  };
+
+  const attendees = event.attendees_json ? JSON.parse(event.attendees_json) as { email: string; displayName?: string }[] : [];
+
+  if (editing) {
+    return (
+      <Modal isOpen={true} onClose={onClose} title="Edit Event" width="w-full max-w-md">
+        <div className="p-4 space-y-3">
+          <TextField
+            label="Title"
+            type="text"
+            value={summary}
+            onChange={(e) => setSummary(e.target.value)}
+            autoFocus
+          />
+
+          <div className="grid grid-cols-2 gap-3">
+            <TextField
+              label="Start"
+              type="datetime-local"
+              value={startTime}
+              onChange={(e) => setStartTime(e.target.value)}
+            />
+            <TextField
+              label="End"
+              type="datetime-local"
+              value={endTime}
+              onChange={(e) => setEndTime(e.target.value)}
+            />
+          </div>
+
+          <TextField
+            label="Location"
+            type="text"
+            value={location}
+            onChange={(e) => setLocation(e.target.value)}
+            placeholder="Add location"
+          />
+
+          <div>
+            <label className="text-xs text-text-secondary block mb-1">Description</label>
+            <textarea
+              value={description}
+              onChange={(e) => setDescription(e.target.value)}
+              placeholder="Add description"
+              rows={3}
+              className="w-full px-3 py-1.5 bg-bg-tertiary border border-border-primary rounded text-sm text-text-primary outline-none focus:border-accent resize-none"
+            />
+          </div>
+
+          <div className="flex justify-end gap-2 pt-2">
+            <Button variant="secondary" size="md" onClick={() => setEditing(false)}>
+              Cancel
+            </Button>
+            <Button variant="primary" size="md" onClick={handleSave} disabled={saving || !summary.trim()}>
+              {saving ? "Saving..." : "Save"}
+            </Button>
+          </div>
+        </div>
+      </Modal>
+    );
+  }
+
+  return (
+    <Modal isOpen={true} onClose={onClose} title={event.summary ?? "Event"} width="w-full max-w-md">
+      <div className="p-4 space-y-3">
+        {calendar && (
+          <div className="flex items-center gap-2 text-xs text-text-tertiary">
+            <span
+              className="w-2.5 h-2.5 rounded-full"
+              style={{ backgroundColor: calendar.color ?? "var(--color-accent)" }}
+            />
+            {calendar.display_name}
+          </div>
+        )}
+
+        <div className="flex items-start gap-2.5 text-sm text-text-secondary">
+          <Clock size={14} className="mt-0.5 shrink-0 text-text-tertiary" />
+          <div>
+            <div>{formatTime(event.start_time)}</div>
+            <div>{formatTime(event.end_time)}</div>
+          </div>
+        </div>
+
+        {event.location && (
+          <div className="flex items-start gap-2.5 text-sm text-text-secondary">
+            <MapPin size={14} className="mt-0.5 shrink-0 text-text-tertiary" />
+            <span>{event.location}</span>
+          </div>
+        )}
+
+        {event.description && (
+          <div className="text-sm text-text-secondary whitespace-pre-wrap border-t border-border-primary pt-3">
+            {event.description}
+          </div>
+        )}
+
+        {attendees.length > 0 && (
+          <div className="border-t border-border-primary pt-3">
+            <div className="text-xs text-text-tertiary mb-1.5">Attendees</div>
+            <div className="space-y-1">
+              {attendees.map((a, i) => (
+                <div key={i} className="flex items-center gap-2 text-sm text-text-secondary">
+                  <User size={12} className="text-text-tertiary" />
+                  <span>{a.displayName ?? a.email}</span>
+                </div>
+              ))}
+            </div>
+          </div>
+        )}
+
+        <div className="flex justify-between pt-2 border-t border-border-primary">
+          {confirmDelete ? (
+            <div className="flex items-center gap-2">
+              <span className="text-xs text-danger">Delete this event?</span>
+              <Button variant="danger" size="xs" onClick={handleDelete} disabled={deleting}>
+                {deleting ? "Deleting..." : "Yes, delete"}
+              </Button>
+              <Button variant="secondary" size="xs" onClick={() => setConfirmDelete(false)}>
+                Cancel
+              </Button>
+            </div>
+          ) : (
+            <Button
+              variant="ghost"
+              size="sm"
+              icon={<Trash2 size={14} />}
+              onClick={() => setConfirmDelete(true)}
+            >
+              Delete
+            </Button>
+          )}
+          <Button
+            variant="secondary"
+            size="sm"
+            icon={<Pencil size={14} />}
+            onClick={() => setEditing(true)}
+          >
+            Edit
+          </Button>
+        </div>
+      </div>
+    </Modal>
+  );
+}
+
+function toLocalISOString(date: Date): string {
+  const pad = (n: number) => String(n).padStart(2, "0");
+  return `${date.getFullYear()}-${pad(date.getMonth() + 1)}-${pad(date.getDate())}T${pad(date.getHours())}:${pad(date.getMinutes())}`;
+}

--- a/src/components/settings/CalDavSettings.tsx
+++ b/src/components/settings/CalDavSettings.tsx
@@ -1,0 +1,159 @@
+import { useState, useCallback, useEffect } from "react";
+import { Loader2, CheckCircle2, XCircle } from "lucide-react";
+import { Button } from "@/components/ui/Button";
+import { TextField } from "@/components/ui/TextField";
+import { discoverCalDavSettings, testCalDavConnection } from "@/services/calendar/autoDiscovery";
+import { updateAccountCalDav, type DbAccount } from "@/services/db/accounts";
+import { removeCalendarProvider } from "@/services/calendar/providerFactory";
+
+interface CalDavSettingsProps {
+  account: DbAccount;
+  onSaved: () => void;
+}
+
+export function CalDavSettings({ account, onSaved }: CalDavSettingsProps) {
+  const [caldavUrl, setCaldavUrl] = useState(account.caldav_url ?? "");
+  const [username, setUsername] = useState(account.caldav_username ?? account.email);
+  const [password, setPassword] = useState(account.caldav_password ?? "");
+  const [testing, setTesting] = useState(false);
+  const [testResult, setTestResult] = useState<{ success: boolean; message: string } | null>(null);
+  const [saving, setSaving] = useState(false);
+  const [discovered, setDiscovered] = useState(false);
+
+  // Auto-discover on mount if not already configured
+  useEffect(() => {
+    if (!account.caldav_url && !discovered) {
+      setDiscovered(true);
+      discoverCalDavSettings(account.email).then((result) => {
+        if (result.caldavUrl) {
+          setCaldavUrl(result.caldavUrl);
+        }
+      });
+    }
+  }, [account.email, account.caldav_url, discovered]);
+
+  const handleTest = useCallback(async () => {
+    setTesting(true);
+    setTestResult(null);
+    const result = await testCalDavConnection(caldavUrl, username, password);
+    setTestResult(result);
+    setTesting(false);
+  }, [caldavUrl, username, password]);
+
+  const handleSave = useCallback(async () => {
+    setSaving(true);
+    try {
+      await updateAccountCalDav(account.id, {
+        caldavUrl,
+        caldavUsername: username,
+        caldavPassword: password,
+        calendarProvider: "caldav",
+      });
+      removeCalendarProvider(account.id);
+      onSaved();
+    } catch (err) {
+      console.error("Failed to save CalDAV settings:", err);
+    } finally {
+      setSaving(false);
+    }
+  }, [account.id, caldavUrl, username, password, onSaved]);
+
+  const handleRemove = useCallback(async () => {
+    setSaving(true);
+    try {
+      await updateAccountCalDav(account.id, {
+        caldavUrl: "",
+        caldavUsername: "",
+        caldavPassword: "",
+        calendarProvider: "",
+      });
+      removeCalendarProvider(account.id);
+      setCaldavUrl("");
+      setUsername(account.email);
+      setPassword("");
+      setTestResult(null);
+      onSaved();
+    } finally {
+      setSaving(false);
+    }
+  }, [account.id, account.email, onSaved]);
+
+  const isConfigured = !!account.caldav_url;
+
+  return (
+    <div className="space-y-4">
+      <div className="flex items-center justify-between">
+        <h4 className="text-sm font-medium text-text-primary">Calendar (CalDAV)</h4>
+        {isConfigured && (
+          <span className="text-xs text-success font-medium">Connected</span>
+        )}
+      </div>
+      <p className="text-xs text-text-tertiary">
+        Connect a CalDAV calendar server to enable calendar features for this IMAP account.
+      </p>
+
+      <TextField
+        label="CalDAV Server URL"
+        type="url"
+        value={caldavUrl}
+        onChange={(e) => setCaldavUrl(e.target.value)}
+        placeholder="https://caldav.example.com/"
+      />
+
+      <TextField
+        label="Username"
+        type="text"
+        value={username}
+        onChange={(e) => setUsername(e.target.value)}
+        placeholder="your@email.com"
+      />
+
+      <TextField
+        label="Password / App Password"
+        type="password"
+        value={password}
+        onChange={(e) => setPassword(e.target.value)}
+        placeholder="App-specific password"
+      />
+
+      {testResult && (
+        <div className={`flex items-center gap-2 text-xs ${testResult.success ? "text-success" : "text-danger"}`}>
+          {testResult.success ? <CheckCircle2 size={14} /> : <XCircle size={14} />}
+          {testResult.message}
+        </div>
+      )}
+
+      <div className="flex items-center gap-2">
+        <Button
+          variant="secondary"
+          size="sm"
+          onClick={handleTest}
+          disabled={testing || !caldavUrl || !password}
+        >
+          {testing && <Loader2 size={14} className="animate-spin" />}
+          {testing ? "Testing..." : "Test Connection"}
+        </Button>
+
+        <Button
+          variant="primary"
+          size="sm"
+          onClick={handleSave}
+          disabled={saving || !caldavUrl || !password}
+        >
+          {saving ? "Saving..." : "Save"}
+        </Button>
+
+        {isConfigured && (
+          <Button
+            variant="ghost"
+            size="sm"
+            onClick={handleRemove}
+            disabled={saving}
+          >
+            Remove
+          </Button>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/services/calendar/autoDiscovery.test.ts
+++ b/src/services/calendar/autoDiscovery.test.ts
@@ -1,0 +1,130 @@
+import { discoverCalDavSettings, testCalDavConnection } from "./autoDiscovery";
+
+vi.mock("tsdav", () => ({
+  DAVClient: vi.fn(),
+}));
+
+describe("discoverCalDavSettings", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("returns Google preset for gmail.com", async () => {
+    const result = await discoverCalDavSettings("user@gmail.com");
+    expect(result).toEqual({
+      providerName: "Google",
+      caldavUrl: "https://apidata.googleusercontent.com/caldav/v2/",
+      authMethod: "oauth2",
+      needsAppPassword: false,
+    });
+  });
+
+  it("returns iCloud preset for icloud.com with needsAppPassword", async () => {
+    const result = await discoverCalDavSettings("user@icloud.com");
+    expect(result).toEqual({
+      providerName: "iCloud",
+      caldavUrl: "https://caldav.icloud.com",
+      authMethod: "basic",
+      needsAppPassword: true,
+    });
+  });
+
+  it("returns Fastmail preset for fastmail.com", async () => {
+    const result = await discoverCalDavSettings("user@fastmail.com");
+    expect(result).toEqual({
+      providerName: "Fastmail",
+      caldavUrl: "https://caldav.fastmail.com/",
+      authMethod: "basic",
+      needsAppPassword: false,
+    });
+  });
+
+  it("returns Google preset with oauth2 authMethod", async () => {
+    const result = await discoverCalDavSettings("user@googlemail.com");
+    expect(result.authMethod).toBe("oauth2");
+  });
+
+  it("returns null caldavUrl for unknown domain with no .well-known", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockRejectedValue(new Error("Network error")),
+    );
+
+    const result = await discoverCalDavSettings("user@unknown-domain.example");
+    expect(result).toEqual({
+      providerName: null,
+      caldavUrl: null,
+      authMethod: "basic",
+      needsAppPassword: false,
+    });
+  });
+
+  it("returns redirect Location for unknown domain with .well-known 301", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        status: 301,
+        ok: false,
+        headers: new Headers({
+          Location: "https://caldav.unknown-domain.example/dav/",
+        }),
+      }),
+    );
+
+    const result = await discoverCalDavSettings("user@unknown-domain.example");
+    expect(result).toEqual({
+      providerName: null,
+      caldavUrl: "https://caldav.unknown-domain.example/dav/",
+      authMethod: "basic",
+      needsAppPassword: false,
+    });
+  });
+});
+
+describe("testCalDavConnection", () => {
+  it("returns success with calendar count on successful connection", async () => {
+    const { DAVClient } = await import("tsdav");
+    const mockLogin = vi.fn().mockResolvedValue(undefined);
+    const mockFetchCalendars = vi
+      .fn()
+      .mockResolvedValue([{ displayName: "Personal" }, { displayName: "Work" }]);
+
+    vi.mocked(DAVClient).mockImplementation(function () {
+      return {
+        login: mockLogin,
+        fetchCalendars: mockFetchCalendars,
+      } as unknown as InstanceType<typeof DAVClient>;
+    });
+
+    const result = await testCalDavConnection(
+      "https://caldav.example.com",
+      "user",
+      "pass",
+    );
+    expect(result).toEqual({
+      success: true,
+      message: "Connected — found 2 calendars",
+      calendarCount: 2,
+    });
+  });
+
+  it("returns failure with error message on failed connection", async () => {
+    const { DAVClient } = await import("tsdav");
+
+    vi.mocked(DAVClient).mockImplementation(function () {
+      return {
+        login: vi.fn().mockRejectedValue(new Error("Invalid credentials")),
+      } as unknown as InstanceType<typeof DAVClient>;
+    });
+
+    const result = await testCalDavConnection(
+      "https://caldav.example.com",
+      "user",
+      "wrong-pass",
+    );
+    expect(result).toEqual({
+      success: false,
+      message: "Invalid credentials",
+    });
+  });
+});

--- a/src/services/calendar/autoDiscovery.ts
+++ b/src/services/calendar/autoDiscovery.ts
@@ -1,0 +1,168 @@
+interface CalDavPreset {
+  name: string;
+  domains: string[];
+  caldavUrl: string;
+  authMethod: "basic" | "oauth2";
+}
+
+const PRESETS: CalDavPreset[] = [
+  {
+    name: "Google",
+    domains: ["gmail.com", "googlemail.com", "google.com"],
+    caldavUrl: "https://apidata.googleusercontent.com/caldav/v2/",
+    authMethod: "oauth2",
+  },
+  {
+    name: "iCloud",
+    domains: ["icloud.com", "me.com", "mac.com"],
+    caldavUrl: "https://caldav.icloud.com",
+    authMethod: "basic",
+  },
+  {
+    name: "Fastmail",
+    domains: ["fastmail.com", "fastmail.fm", "messagingengine.com"],
+    caldavUrl: "https://caldav.fastmail.com/",
+    authMethod: "basic",
+  },
+  {
+    name: "Zoho",
+    domains: ["zoho.com", "zohomail.com"],
+    caldavUrl: "https://calendar.zoho.com/caldav/",
+    authMethod: "basic",
+  },
+  {
+    name: "GMX",
+    domains: ["gmx.com", "gmx.net", "gmx.de"],
+    caldavUrl: "https://caldav.gmx.net/",
+    authMethod: "basic",
+  },
+];
+
+export interface CalDavDiscoveryResult {
+  providerName: string | null;
+  caldavUrl: string | null;
+  authMethod: "basic" | "oauth2";
+  needsAppPassword: boolean;
+}
+
+/**
+ * Discover CalDAV settings from an email address.
+ * Matches known providers by domain, or attempts .well-known/caldav discovery.
+ */
+export async function discoverCalDavSettings(email: string): Promise<CalDavDiscoveryResult> {
+  const domain = email.split("@")[1]?.toLowerCase();
+  if (!domain) {
+    return { providerName: null, caldavUrl: null, authMethod: "basic", needsAppPassword: false };
+  }
+
+  // Check known presets
+  for (const preset of PRESETS) {
+    if (preset.domains.includes(domain)) {
+      return {
+        providerName: preset.name,
+        caldavUrl: preset.caldavUrl,
+        authMethod: preset.authMethod,
+        needsAppPassword: preset.name === "iCloud",
+      };
+    }
+  }
+
+  // Attempt .well-known/caldav discovery (RFC 6764)
+  const wellKnownUrl = await tryWellKnownDiscovery(domain);
+  if (wellKnownUrl) {
+    return {
+      providerName: null,
+      caldavUrl: wellKnownUrl,
+      authMethod: "basic",
+      needsAppPassword: false,
+    };
+  }
+
+  // Try common Nextcloud path
+  const nextcloudUrl = await tryNextcloudDiscovery(domain);
+  if (nextcloudUrl) {
+    return {
+      providerName: "Nextcloud",
+      caldavUrl: nextcloudUrl,
+      authMethod: "basic",
+      needsAppPassword: false,
+    };
+  }
+
+  return { providerName: null, caldavUrl: null, authMethod: "basic", needsAppPassword: false };
+}
+
+async function tryWellKnownDiscovery(domain: string): Promise<string | null> {
+  try {
+    const response = await fetch(`https://${domain}/.well-known/caldav`, {
+      method: "GET",
+      redirect: "manual",
+    });
+
+    // RFC 6764: server should respond with 301/302 redirect to the CalDAV endpoint
+    if (response.status === 301 || response.status === 302) {
+      const location = response.headers.get("Location");
+      if (location) {
+        // Handle relative URLs
+        if (location.startsWith("/")) {
+          return `https://${domain}${location}`;
+        }
+        return location;
+      }
+    }
+
+    // Some servers respond with 200 directly at the well-known URL
+    if (response.ok) {
+      return `https://${domain}/.well-known/caldav`;
+    }
+  } catch {
+    // Discovery failed — not all servers support this
+  }
+  return null;
+}
+
+async function tryNextcloudDiscovery(domain: string): Promise<string | null> {
+  try {
+    const response = await fetch(`https://${domain}/remote.php/dav/`, {
+      method: "OPTIONS",
+    });
+    if (response.ok || response.status === 401) {
+      // 401 means the endpoint exists but requires auth
+      return `https://${domain}/remote.php/dav/`;
+    }
+  } catch {
+    // Not a Nextcloud instance
+  }
+  return null;
+}
+
+/**
+ * Test CalDAV connection with given credentials.
+ */
+export async function testCalDavConnection(
+  url: string,
+  username: string,
+  password: string,
+): Promise<{ success: boolean; message: string; calendarCount?: number }> {
+  try {
+    const { DAVClient } = await import("tsdav");
+    const client = new DAVClient({
+      serverUrl: url,
+      credentials: { username, password },
+      authMethod: "Basic",
+      defaultAccountType: "caldav",
+    });
+
+    await client.login();
+    const calendars = await client.fetchCalendars();
+
+    return {
+      success: true,
+      message: `Connected — found ${calendars.length} calendar${calendars.length !== 1 ? "s" : ""}`,
+      calendarCount: calendars.length,
+    };
+  } catch (err) {
+    const message = err instanceof Error ? err.message : "Connection failed";
+    return { success: false, message };
+  }
+}

--- a/src/services/calendar/caldavProvider.test.ts
+++ b/src/services/calendar/caldavProvider.test.ts
@@ -1,0 +1,281 @@
+import { CalDAVProvider } from "./caldavProvider";
+
+const MOCK_ICAL_DATA =
+  "BEGIN:VCALENDAR\r\nVERSION:2.0\r\nBEGIN:VEVENT\r\nUID:test-uid\r\nSUMMARY:Test Event\r\nDTSTART:20240101T100000Z\r\nDTEND:20240101T110000Z\r\nEND:VEVENT\r\nEND:VCALENDAR";
+
+const MOCK_ICAL_DATA_2 =
+  "BEGIN:VCALENDAR\r\nVERSION:2.0\r\nBEGIN:VEVENT\r\nUID:test-uid-2\r\nSUMMARY:Second Event\r\nDTSTART:20240102T140000Z\r\nDTEND:20240102T150000Z\r\nEND:VEVENT\r\nEND:VCALENDAR";
+
+const mockLogin = vi.fn().mockResolvedValue(undefined);
+const mockFetchCalendars = vi.fn();
+const mockFetchCalendarObjects = vi.fn();
+const mockCreateCalendarObject = vi.fn().mockResolvedValue(undefined);
+const mockUpdateCalendarObject = vi.fn().mockResolvedValue(undefined);
+const mockDeleteCalendarObject = vi.fn().mockResolvedValue(undefined);
+
+vi.mock("tsdav", () => {
+  const MockDAVClient = vi.fn(function (this: Record<string, unknown>) {
+    this.login = mockLogin;
+    this.fetchCalendars = mockFetchCalendars;
+    this.fetchCalendarObjects = mockFetchCalendarObjects;
+    this.createCalendarObject = mockCreateCalendarObject;
+    this.updateCalendarObject = mockUpdateCalendarObject;
+    this.deleteCalendarObject = mockDeleteCalendarObject;
+  });
+  return { DAVClient: MockDAVClient };
+});
+
+vi.mock("@/services/db/accounts", () => ({
+  getAccount: vi.fn().mockResolvedValue({
+    id: "acc-1",
+    email: "user@example.com",
+    caldav_url: "https://caldav.example.com",
+    caldav_username: "user@example.com",
+    caldav_password: "secret",
+  }),
+}));
+
+describe("CalDAVProvider", () => {
+  let provider: CalDAVProvider;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    provider = new CalDAVProvider("acc-1");
+  });
+
+  describe("listCalendars", () => {
+    it("maps tsdav calendars to CalendarInfo array", async () => {
+      mockFetchCalendars.mockResolvedValue([
+        { url: "/cal/personal/", displayName: "Personal" },
+        { url: "/cal/work/", displayName: "Work", calendarColor: "#ff0000" },
+      ]);
+
+      const calendars = await provider.listCalendars();
+
+      expect(calendars).toEqual([
+        { remoteId: "/cal/personal/", displayName: "Personal", color: null, isPrimary: true },
+        { remoteId: "/cal/work/", displayName: "Work", color: "#ff0000", isPrimary: false },
+      ]);
+    });
+
+    it("handles non-string displayName by falling back to indexed name", async () => {
+      mockFetchCalendars.mockResolvedValue([
+        { url: "/cal/unnamed/", displayName: undefined },
+        { url: "/cal/also-unnamed/", displayName: null },
+      ]);
+
+      const calendars = await provider.listCalendars();
+
+      expect(calendars[0]!.displayName).toBe("Calendar 1");
+      expect(calendars[1]!.displayName).toBe("Calendar 2");
+    });
+  });
+
+  describe("fetchEvents", () => {
+    it("passes time range and parses iCalendar data from objects", async () => {
+      mockFetchCalendarObjects.mockResolvedValue([
+        { data: MOCK_ICAL_DATA, url: "/cal/personal/test-uid.ics", etag: '"etag-1"' },
+        { data: MOCK_ICAL_DATA_2, url: "/cal/personal/test-uid-2.ics", etag: '"etag-2"' },
+      ]);
+
+      const events = await provider.fetchEvents("/cal/personal/", "2024-01-01T00:00:00Z", "2024-01-31T23:59:59Z");
+
+      expect(mockFetchCalendarObjects).toHaveBeenCalledWith({
+        calendar: { url: "/cal/personal/" },
+        timeRange: { start: "2024-01-01T00:00:00Z", end: "2024-01-31T23:59:59Z" },
+      });
+
+      expect(events).toHaveLength(2);
+      expect(events[0]!.summary).toBe("Test Event");
+      expect(events[0]!.uid).toBe("test-uid");
+      expect(events[0]!.etag).toBe('"etag-1"');
+      expect(events[0]!.remoteEventId).toBe("/cal/personal/test-uid.ics");
+      expect(events[1]!.summary).toBe("Second Event");
+      expect(events[1]!.etag).toBe('"etag-2"');
+    });
+
+    it("filters out objects with no data", async () => {
+      mockFetchCalendarObjects.mockResolvedValue([
+        { data: MOCK_ICAL_DATA, url: "/cal/personal/test-uid.ics", etag: '"etag-1"' },
+        { data: null, url: "/cal/personal/empty.ics", etag: null },
+      ]);
+
+      const events = await provider.fetchEvents("/cal/personal/", "2024-01-01T00:00:00Z", "2024-01-31T23:59:59Z");
+
+      expect(events).toHaveLength(1);
+    });
+  });
+
+  describe("createEvent", () => {
+    it("generates iCalendar and calls createCalendarObject", async () => {
+      vi.spyOn(crypto, "randomUUID").mockReturnValue("generated-uuid" as `${string}-${string}-${string}-${string}-${string}`);
+
+      const event = await provider.createEvent("/cal/personal/", {
+        summary: "New Meeting",
+        startTime: "2024-03-15T09:00:00Z",
+        endTime: "2024-03-15T10:00:00Z",
+      });
+
+      expect(mockCreateCalendarObject).toHaveBeenCalledWith({
+        calendar: { url: "/cal/personal/" },
+        filename: "generated-uuid.ics",
+        iCalString: expect.stringContaining("SUMMARY:New Meeting"),
+      });
+
+      expect(event.summary).toBe("New Meeting");
+      expect(event.remoteEventId).toBe("/cal/personal/generated-uuid.ics");
+    });
+  });
+
+  describe("updateEvent", () => {
+    it("fetches existing, merges updates, and calls updateCalendarObject", async () => {
+      mockFetchCalendarObjects.mockResolvedValue([
+        { data: MOCK_ICAL_DATA, url: "/cal/personal/test-uid.ics", etag: '"old-etag"' },
+      ]);
+
+      const event = await provider.updateEvent(
+        "/cal/personal/",
+        "/cal/personal/test-uid.ics",
+        { summary: "Updated Event" },
+        '"old-etag"',
+      );
+
+      expect(mockFetchCalendarObjects).toHaveBeenCalledWith({
+        calendar: { url: "/cal/personal/" },
+        objectUrls: ["/cal/personal/test-uid.ics"],
+      });
+
+      expect(mockUpdateCalendarObject).toHaveBeenCalledWith({
+        calendarObject: {
+          url: "/cal/personal/test-uid.ics",
+          data: expect.stringContaining("SUMMARY:Updated Event"),
+          etag: '"old-etag"',
+        },
+        headers: { "If-Match": '"old-etag"' },
+      });
+
+      expect(event.summary).toBe("Updated Event");
+      expect(event.remoteEventId).toBe("/cal/personal/test-uid.ics");
+    });
+
+    it("throws when the existing event is not found", async () => {
+      mockFetchCalendarObjects.mockResolvedValue([]);
+
+      await expect(
+        provider.updateEvent("/cal/personal/", "/cal/personal/missing.ics", { summary: "Nope" }),
+      ).rejects.toThrow("Event not found on server");
+    });
+  });
+
+  describe("deleteEvent", () => {
+    it("calls deleteCalendarObject with etag", async () => {
+      await provider.deleteEvent("/cal/personal/", "/cal/personal/test-uid.ics", '"delete-etag"');
+
+      expect(mockDeleteCalendarObject).toHaveBeenCalledWith({
+        calendarObject: {
+          url: "/cal/personal/test-uid.ics",
+          etag: '"delete-etag"',
+        },
+        headers: { "If-Match": '"delete-etag"' },
+      });
+    });
+
+    it("calls deleteCalendarObject without etag when not provided", async () => {
+      await provider.deleteEvent("/cal/personal/", "/cal/personal/test-uid.ics");
+
+      expect(mockDeleteCalendarObject).toHaveBeenCalledWith({
+        calendarObject: {
+          url: "/cal/personal/test-uid.ics",
+          etag: undefined,
+        },
+        headers: {},
+      });
+    });
+  });
+
+  describe("syncEvents", () => {
+    it("fetches all objects in time range and returns them as created events", async () => {
+      mockFetchCalendarObjects.mockResolvedValue([
+        { data: MOCK_ICAL_DATA, url: "/cal/personal/test-uid.ics", etag: '"sync-etag"' },
+        { data: MOCK_ICAL_DATA_2, url: "/cal/personal/test-uid-2.ics", etag: '"sync-etag-2"' },
+      ]);
+
+      const result = await provider.syncEvents("/cal/personal/");
+
+      expect(mockFetchCalendarObjects).toHaveBeenCalledWith({
+        calendar: { url: "/cal/personal/" },
+        timeRange: {
+          start: expect.any(String),
+          end: expect.any(String),
+        },
+      });
+
+      expect(result.created).toHaveLength(2);
+      expect(result.created[0]!.summary).toBe("Test Event");
+      expect(result.created[0]!.etag).toBe('"sync-etag"');
+      expect(result.created[1]!.summary).toBe("Second Event");
+      expect(result.updated).toEqual([]);
+      expect(result.deletedRemoteIds).toEqual([]);
+      expect(result.newSyncToken).toBeNull();
+      expect(result.newCtag).toBeNull();
+    });
+  });
+
+  describe("testConnection", () => {
+    it("returns success with calendar count on successful connection", async () => {
+      mockFetchCalendars.mockResolvedValue([
+        { url: "/cal/personal/", displayName: "Personal" },
+        { url: "/cal/work/", displayName: "Work" },
+      ]);
+
+      const result = await provider.testConnection();
+
+      expect(result).toEqual({
+        success: true,
+        message: "Connected — found 2 calendars",
+      });
+    });
+
+    it("returns singular form for one calendar", async () => {
+      mockFetchCalendars.mockResolvedValue([
+        { url: "/cal/personal/", displayName: "Personal" },
+      ]);
+
+      const result = await provider.testConnection();
+
+      expect(result.message).toBe("Connected — found 1 calendar");
+    });
+
+    it("resets client and returns error message on failure", async () => {
+      mockLogin.mockRejectedValueOnce(new Error("Authentication failed"));
+      // Need a fresh provider so getClient() will attempt login again
+      const freshProvider = new CalDAVProvider("acc-1");
+
+      const result = await freshProvider.testConnection();
+
+      expect(result).toEqual({
+        success: false,
+        message: "Authentication failed",
+      });
+
+      // Verify client was reset by confirming a second call attempts login again
+      mockLogin.mockResolvedValueOnce(undefined);
+      mockFetchCalendars.mockResolvedValue([]);
+      const retryResult = await freshProvider.testConnection();
+      expect(retryResult.success).toBe(true);
+      expect(mockLogin).toHaveBeenCalledTimes(2); // initial fail + retry after client reset
+    });
+
+    it("handles non-Error thrown values gracefully", async () => {
+      mockLogin.mockRejectedValueOnce("some string error");
+      const freshProvider = new CalDAVProvider("acc-1");
+
+      const result = await freshProvider.testConnection();
+
+      expect(result).toEqual({
+        success: false,
+        message: "Connection failed",
+      });
+    });
+  });
+});

--- a/src/services/calendar/caldavProvider.ts
+++ b/src/services/calendar/caldavProvider.ts
@@ -1,0 +1,206 @@
+import { DAVClient, type DAVCalendar, type DAVObject } from "tsdav";
+import type {
+  CalendarProvider,
+  CalendarProviderType,
+  CalendarInfo,
+  CalendarEventData,
+  CalendarSyncResult,
+  CreateEventInput,
+  UpdateEventInput,
+} from "./types";
+import { generateVEvent, parseVEvent } from "./icalHelper";
+import { getAccount } from "@/services/db/accounts";
+
+export class CalDAVProvider implements CalendarProvider {
+  readonly type: CalendarProviderType = "caldav";
+  private client: DAVClient | null = null;
+
+  constructor(readonly accountId: string) {}
+
+  private async getClient(): Promise<DAVClient> {
+    if (this.client) return this.client;
+
+    const account = await getAccount(this.accountId);
+    if (!account) throw new Error("Account not found");
+
+    const serverUrl = account.caldav_url;
+    const username = account.caldav_username ?? account.email;
+    const password = account.caldav_password;
+
+    if (!serverUrl || !password) {
+      throw new Error("CalDAV credentials not configured");
+    }
+
+    this.client = new DAVClient({
+      serverUrl,
+      credentials: { username, password },
+      authMethod: "Basic",
+      defaultAccountType: "caldav",
+    });
+
+    await this.client.login();
+    return this.client;
+  }
+
+  async listCalendars(): Promise<CalendarInfo[]> {
+    const client = await this.getClient();
+    const calendars = await client.fetchCalendars();
+
+    return calendars.map((cal, index) => ({
+      remoteId: cal.url,
+      displayName: typeof cal.displayName === "string" ? cal.displayName : `Calendar ${index + 1}`,
+      color: extractCalendarColor(cal) ?? null,
+      isPrimary: index === 0,
+    }));
+  }
+
+  async fetchEvents(calendarRemoteId: string, timeMin: string, timeMax: string): Promise<CalendarEventData[]> {
+    const client = await this.getClient();
+
+    const objects = await client.fetchCalendarObjects({
+      calendar: { url: calendarRemoteId } as DAVCalendar,
+      timeRange: {
+        start: timeMin,
+        end: timeMax,
+      },
+    });
+
+    return objects
+      .filter((obj) => obj.data)
+      .map((obj) => {
+        const event = parseVEvent(obj.data!, obj.url);
+        event.etag = obj.etag ?? null;
+        return event;
+      });
+  }
+
+  async createEvent(calendarRemoteId: string, event: CreateEventInput): Promise<CalendarEventData> {
+    const client = await this.getClient();
+    const uid = crypto.randomUUID();
+    const icalData = generateVEvent(event, uid);
+    const filename = `${uid}.ics`;
+
+    await client.createCalendarObject({
+      calendar: { url: calendarRemoteId } as DAVCalendar,
+      filename,
+      iCalString: icalData,
+    });
+
+    const parsed = parseVEvent(icalData, `${calendarRemoteId}${filename}`);
+    return parsed;
+  }
+
+  async updateEvent(
+    calendarRemoteId: string,
+    remoteEventId: string,
+    event: UpdateEventInput,
+    etag?: string,
+  ): Promise<CalendarEventData> {
+    const client = await this.getClient();
+
+    // Fetch the existing object to get its current data
+    const objects = await client.fetchCalendarObjects({
+      calendar: { url: calendarRemoteId } as DAVCalendar,
+      objectUrls: [remoteEventId],
+    });
+
+    const existing = objects[0];
+    if (!existing?.data) throw new Error("Event not found on server");
+
+    // Parse existing, merge updates, regenerate
+    const parsed = parseVEvent(existing.data, remoteEventId);
+    const merged: CreateEventInput = {
+      summary: event.summary ?? parsed.summary ?? "",
+      description: event.description ?? parsed.description ?? undefined,
+      location: event.location ?? parsed.location ?? undefined,
+      startTime: event.startTime ?? new Date(parsed.startTime * 1000).toISOString(),
+      endTime: event.endTime ?? new Date(parsed.endTime * 1000).toISOString(),
+      isAllDay: event.isAllDay ?? parsed.isAllDay,
+    };
+
+    const icalData = generateVEvent(merged, parsed.uid ?? undefined);
+
+    const headers: Record<string, string> = {};
+    if (etag) headers["If-Match"] = etag;
+
+    await client.updateCalendarObject({
+      calendarObject: {
+        url: remoteEventId,
+        data: icalData,
+        etag: etag ?? existing.etag ?? undefined,
+      } as DAVObject,
+      headers,
+    });
+
+    const result = parseVEvent(icalData, remoteEventId);
+    return result;
+  }
+
+  async deleteEvent(_calendarRemoteId: string, remoteEventId: string, etag?: string): Promise<void> {
+    const client = await this.getClient();
+
+    const headers: Record<string, string> = {};
+    if (etag) headers["If-Match"] = etag;
+
+    await client.deleteCalendarObject({
+      calendarObject: {
+        url: remoteEventId,
+        etag: etag ?? undefined,
+      } as DAVObject,
+      headers,
+    });
+  }
+
+  async syncEvents(calendarRemoteId: string, _syncToken?: string): Promise<CalendarSyncResult> {
+    const client = await this.getClient();
+    const created: CalendarEventData[] = [];
+
+    // Full fetch — tsdav's syncCalendars doesn't reliably expose per-object deltas,
+    // so we do a time-range fetch and let the DB upsert logic handle deduplication.
+    const now = new Date();
+    const timeMin = new Date(now);
+    timeMin.setDate(timeMin.getDate() - 90);
+    const timeMax = new Date(now);
+    timeMax.setFullYear(timeMax.getFullYear() + 1);
+
+    const objects = await client.fetchCalendarObjects({
+      calendar: { url: calendarRemoteId } as DAVCalendar,
+      timeRange: {
+        start: timeMin.toISOString(),
+        end: timeMax.toISOString(),
+      },
+    });
+
+    for (const obj of objects) {
+      if (obj.data) {
+        const event = parseVEvent(obj.data, obj.url);
+        event.etag = obj.etag ?? null;
+        created.push(event);
+      }
+    }
+
+    return { created, updated: [], deletedRemoteIds: [], newSyncToken: null, newCtag: null };
+  }
+
+  async testConnection(): Promise<{ success: boolean; message: string }> {
+    try {
+      const client = await this.getClient();
+      const calendars = await client.fetchCalendars();
+      return {
+        success: true,
+        message: `Connected — found ${calendars.length} calendar${calendars.length !== 1 ? "s" : ""}`,
+      };
+    } catch (err) {
+      // Reset client on failure so next attempt can retry
+      this.client = null;
+      return { success: false, message: err instanceof Error ? err.message : "Connection failed" };
+    }
+  }
+}
+
+function extractCalendarColor(cal: DAVCalendar): string | null {
+  // tsdav may expose calendar-color in props
+  const props = cal as unknown as Record<string, unknown>;
+  if (typeof props.calendarColor === "string") return props.calendarColor;
+  return null;
+}

--- a/src/services/calendar/googleCalendarProvider.test.ts
+++ b/src/services/calendar/googleCalendarProvider.test.ts
@@ -1,0 +1,397 @@
+import { GoogleCalendarProvider } from "./googleCalendarProvider";
+import { getGmailClient } from "@/services/gmail/tokenManager";
+
+vi.mock("@/services/gmail/tokenManager", () => ({
+  getGmailClient: vi.fn(),
+}));
+
+const CALENDAR_API_BASE = "https://www.googleapis.com/calendar/v3";
+
+function createMockClient() {
+  return { request: vi.fn() };
+}
+
+describe("GoogleCalendarProvider", () => {
+  const accountId = "test-account-1";
+  let provider: GoogleCalendarProvider;
+  let mockClient: ReturnType<typeof createMockClient>;
+
+  beforeEach(() => {
+    mockClient = createMockClient();
+    vi.mocked(getGmailClient).mockResolvedValue(mockClient as never);
+    provider = new GoogleCalendarProvider(accountId);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  describe("listCalendars", () => {
+    it("maps Google API response to CalendarInfo array", async () => {
+      mockClient.request.mockResolvedValue({
+        items: [
+          { id: "primary", summary: "My Calendar", backgroundColor: "#0000ff", primary: true },
+          { id: "work@example.com", summary: "Work", accessRole: "owner" },
+        ],
+      });
+
+      const result = await provider.listCalendars();
+
+      expect(mockClient.request).toHaveBeenCalledWith(
+        `${CALENDAR_API_BASE}/users/me/calendarList`,
+      );
+      expect(result).toEqual([
+        { remoteId: "primary", displayName: "My Calendar", color: "#0000ff", isPrimary: true },
+        { remoteId: "work@example.com", displayName: "Work", color: null, isPrimary: false },
+      ]);
+    });
+
+    it("returns empty array when no items", async () => {
+      mockClient.request.mockResolvedValue({});
+
+      const result = await provider.listCalendars();
+
+      expect(result).toEqual([]);
+    });
+  });
+
+  describe("fetchEvents", () => {
+    it("passes correct URL params and maps events", async () => {
+      const googleEvent = {
+        id: "evt-1",
+        summary: "Meeting",
+        description: "Discuss plans",
+        location: "Room A",
+        start: { dateTime: "2025-06-15T10:00:00Z" },
+        end: { dateTime: "2025-06-15T11:00:00Z" },
+        status: "confirmed",
+        organizer: { email: "org@example.com" },
+        attendees: [{ email: "a@example.com", responseStatus: "accepted" }],
+        htmlLink: "https://calendar.google.com/event/evt-1",
+        iCalUID: "uid-1@google.com",
+        etag: '"etag-1"',
+      };
+
+      mockClient.request.mockResolvedValue({ items: [googleEvent] });
+
+      const result = await provider.fetchEvents("cal-id", "2025-06-01T00:00:00Z", "2025-06-30T23:59:59Z");
+
+      const calledUrl = mockClient.request.mock.calls[0][0] as string;
+      expect(calledUrl).toContain("/calendars/cal-id/events?");
+      expect(calledUrl).toContain("timeMin=2025-06-01T00%3A00%3A00Z");
+      expect(calledUrl).toContain("timeMax=2025-06-30T23%3A59%3A59Z");
+      expect(calledUrl).toContain("singleEvents=true");
+      expect(calledUrl).toContain("orderBy=startTime");
+      expect(calledUrl).toContain("maxResults=250");
+
+      expect(result).toHaveLength(1);
+      expect(result[0]).toMatchObject({
+        remoteEventId: "evt-1",
+        summary: "Meeting",
+        description: "Discuss plans",
+        location: "Room A",
+        isAllDay: false,
+        status: "confirmed",
+        organizerEmail: "org@example.com",
+        htmlLink: "https://calendar.google.com/event/evt-1",
+        uid: "uid-1@google.com",
+        etag: '"etag-1"',
+      });
+      expect(result[0].startTime).toBe(Math.floor(new Date("2025-06-15T10:00:00Z").getTime() / 1000));
+      expect(result[0].endTime).toBe(Math.floor(new Date("2025-06-15T11:00:00Z").getTime() / 1000));
+    });
+
+    it("encodes calendar ID in URL", async () => {
+      mockClient.request.mockResolvedValue({ items: [] });
+
+      await provider.fetchEvents("user@example.com", "2025-01-01T00:00:00Z", "2025-01-31T23:59:59Z");
+
+      const calledUrl = mockClient.request.mock.calls[0][0] as string;
+      expect(calledUrl).toContain("/calendars/user%40example.com/events?");
+    });
+  });
+
+  describe("createEvent", () => {
+    it("sends POST with correct body and returns mapped event", async () => {
+      const createdEvent = {
+        id: "new-evt",
+        summary: "Lunch",
+        description: "Team lunch",
+        location: "Cafe",
+        start: { dateTime: "2025-06-20T12:00:00Z" },
+        end: { dateTime: "2025-06-20T13:00:00Z" },
+        status: "confirmed",
+      };
+
+      mockClient.request.mockResolvedValue(createdEvent);
+
+      const result = await provider.createEvent("cal-1", {
+        summary: "Lunch",
+        description: "Team lunch",
+        location: "Cafe",
+        startTime: "2025-06-20T12:00:00Z",
+        endTime: "2025-06-20T13:00:00Z",
+      });
+
+      const [url, options] = mockClient.request.mock.calls[0];
+      expect(url).toBe(`${CALENDAR_API_BASE}/calendars/cal-1/events`);
+      expect(options.method).toBe("POST");
+
+      const body = JSON.parse(options.body as string);
+      expect(body.summary).toBe("Lunch");
+      expect(body.description).toBe("Team lunch");
+      expect(body.location).toBe("Cafe");
+      expect(body.start.dateTime).toBeDefined();
+      expect(body.end.dateTime).toBeDefined();
+
+      expect(result.remoteEventId).toBe("new-evt");
+      expect(result.summary).toBe("Lunch");
+    });
+
+    it("creates all-day event with date-only start/end", async () => {
+      mockClient.request.mockResolvedValue({
+        id: "allday-evt",
+        summary: "Holiday",
+        start: { date: "2025-12-25" },
+        end: { date: "2025-12-26" },
+      });
+
+      await provider.createEvent("cal-1", {
+        summary: "Holiday",
+        startTime: "2025-12-25T00:00:00Z",
+        endTime: "2025-12-26T00:00:00Z",
+        isAllDay: true,
+      });
+
+      const body = JSON.parse(mockClient.request.mock.calls[0][1].body as string);
+      expect(body.start).toEqual({ date: "2025-12-25" });
+      expect(body.end).toEqual({ date: "2025-12-26" });
+    });
+
+    it("includes attendees when provided", async () => {
+      mockClient.request.mockResolvedValue({
+        id: "evt-att",
+        summary: "Sync",
+        start: { dateTime: "2025-06-20T14:00:00Z" },
+        end: { dateTime: "2025-06-20T15:00:00Z" },
+      });
+
+      await provider.createEvent("cal-1", {
+        summary: "Sync",
+        startTime: "2025-06-20T14:00:00Z",
+        endTime: "2025-06-20T15:00:00Z",
+        attendees: [{ email: "bob@example.com" }],
+      });
+
+      const body = JSON.parse(mockClient.request.mock.calls[0][1].body as string);
+      expect(body.attendees).toEqual([{ email: "bob@example.com" }]);
+    });
+  });
+
+  describe("updateEvent", () => {
+    it("sends PATCH with partial body", async () => {
+      mockClient.request.mockResolvedValue({
+        id: "evt-1",
+        summary: "Updated Title",
+        start: { dateTime: "2025-06-20T12:00:00Z" },
+        end: { dateTime: "2025-06-20T13:00:00Z" },
+      });
+
+      const result = await provider.updateEvent("cal-1", "evt-1", {
+        summary: "Updated Title",
+      });
+
+      const [url, options] = mockClient.request.mock.calls[0];
+      expect(url).toBe(`${CALENDAR_API_BASE}/calendars/cal-1/events/evt-1`);
+      expect(options.method).toBe("PATCH");
+
+      const body = JSON.parse(options.body as string);
+      expect(body.summary).toBe("Updated Title");
+      expect(body.description).toBeUndefined();
+      expect(body.start).toBeUndefined();
+
+      expect(result.remoteEventId).toBe("evt-1");
+      expect(result.summary).toBe("Updated Title");
+    });
+
+    it("includes time fields when both startTime and endTime are provided", async () => {
+      mockClient.request.mockResolvedValue({
+        id: "evt-1",
+        summary: "Rescheduled",
+        start: { dateTime: "2025-06-21T09:00:00Z" },
+        end: { dateTime: "2025-06-21T10:00:00Z" },
+      });
+
+      await provider.updateEvent("cal-1", "evt-1", {
+        startTime: "2025-06-21T09:00:00Z",
+        endTime: "2025-06-21T10:00:00Z",
+      });
+
+      const body = JSON.parse(mockClient.request.mock.calls[0][1].body as string);
+      expect(body.start.dateTime).toBeDefined();
+      expect(body.end.dateTime).toBeDefined();
+    });
+  });
+
+  describe("deleteEvent", () => {
+    it("sends DELETE request with correct URL", async () => {
+      mockClient.request.mockResolvedValue(undefined);
+
+      await provider.deleteEvent("cal-1", "evt-1");
+
+      const [url, options] = mockClient.request.mock.calls[0];
+      expect(url).toBe(`${CALENDAR_API_BASE}/calendars/cal-1/events/evt-1`);
+      expect(options.method).toBe("DELETE");
+    });
+
+    it("encodes calendar and event IDs", async () => {
+      mockClient.request.mockResolvedValue(undefined);
+
+      await provider.deleteEvent("user@example.com", "evt/special");
+
+      const calledUrl = mockClient.request.mock.calls[0][0] as string;
+      expect(calledUrl).toContain("/calendars/user%40example.com/events/evt%2Fspecial");
+    });
+  });
+
+  describe("syncEvents", () => {
+    it("uses syncToken for incremental sync and handles cancelled events as deletions", async () => {
+      mockClient.request.mockResolvedValue({
+        items: [
+          {
+            id: "evt-updated",
+            summary: "Updated Event",
+            start: { dateTime: "2025-06-15T10:00:00Z" },
+            end: { dateTime: "2025-06-15T11:00:00Z" },
+            status: "confirmed",
+          },
+          {
+            id: "evt-deleted",
+            summary: undefined,
+            start: { dateTime: "2025-06-15T10:00:00Z" },
+            end: { dateTime: "2025-06-15T11:00:00Z" },
+            status: "cancelled",
+          },
+        ],
+        nextSyncToken: "new-sync-token-123",
+      });
+
+      const result = await provider.syncEvents("cal-1", "old-sync-token");
+
+      const calledUrl = mockClient.request.mock.calls[0][0] as string;
+      expect(calledUrl).toContain("syncToken=old-sync-token");
+      expect(calledUrl).not.toContain("timeMin");
+      expect(calledUrl).not.toContain("singleEvents");
+
+      expect(result.created).toHaveLength(1);
+      expect(result.created[0].remoteEventId).toBe("evt-updated");
+      expect(result.deletedRemoteIds).toEqual(["evt-deleted"]);
+      expect(result.newSyncToken).toBe("new-sync-token-123");
+      expect(result.newCtag).toBeNull();
+    });
+
+    it("sets time range for initial sync without syncToken", async () => {
+      mockClient.request.mockResolvedValue({
+        items: [],
+        nextSyncToken: "initial-token",
+      });
+
+      const result = await provider.syncEvents("cal-1");
+
+      const calledUrl = mockClient.request.mock.calls[0][0] as string;
+      expect(calledUrl).toContain("timeMin=");
+      expect(calledUrl).toContain("timeMax=");
+      expect(calledUrl).toContain("singleEvents=true");
+      expect(calledUrl).not.toContain("syncToken");
+
+      expect(result.newSyncToken).toBe("initial-token");
+    });
+
+    it("handles 410 error (expired sync token) gracefully", async () => {
+      mockClient.request.mockRejectedValue(new Error("410 Gone: sync token expired"));
+
+      const result = await provider.syncEvents("cal-1", "expired-token");
+
+      expect(result).toEqual({
+        created: [],
+        updated: [],
+        deletedRemoteIds: [],
+        newSyncToken: null,
+        newCtag: null,
+      });
+    });
+
+    it("handles 'sync token' message in error gracefully", async () => {
+      mockClient.request.mockRejectedValue(new Error("Invalid sync token"));
+
+      const result = await provider.syncEvents("cal-1", "bad-token");
+
+      expect(result).toEqual({
+        created: [],
+        updated: [],
+        deletedRemoteIds: [],
+        newSyncToken: null,
+        newCtag: null,
+      });
+    });
+
+    it("rethrows non-sync-token errors", async () => {
+      mockClient.request.mockRejectedValue(new Error("Network error"));
+
+      await expect(provider.syncEvents("cal-1", "token")).rejects.toThrow("Network error");
+    });
+
+    it("follows pagination with nextPageToken", async () => {
+      mockClient.request
+        .mockResolvedValueOnce({
+          items: [
+            { id: "evt-1", summary: "Page 1", start: { dateTime: "2025-06-15T10:00:00Z" }, end: { dateTime: "2025-06-15T11:00:00Z" } },
+          ],
+          nextPageToken: "page-2-token",
+        })
+        .mockResolvedValueOnce({
+          items: [
+            { id: "evt-2", summary: "Page 2", start: { dateTime: "2025-06-16T10:00:00Z" }, end: { dateTime: "2025-06-16T11:00:00Z" } },
+          ],
+          nextSyncToken: "final-sync-token",
+        });
+
+      const result = await provider.syncEvents("cal-1", "token");
+
+      expect(mockClient.request).toHaveBeenCalledTimes(2);
+      const secondUrl = mockClient.request.mock.calls[1][0] as string;
+      expect(secondUrl).toContain("pageToken=page-2-token");
+
+      expect(result.created).toHaveLength(2);
+      expect(result.created[0].remoteEventId).toBe("evt-1");
+      expect(result.created[1].remoteEventId).toBe("evt-2");
+      expect(result.newSyncToken).toBe("final-sync-token");
+    });
+  });
+
+  describe("testConnection", () => {
+    it("returns success when listCalendars succeeds", async () => {
+      mockClient.request.mockResolvedValue({ items: [] });
+
+      const result = await provider.testConnection();
+
+      expect(result).toEqual({ success: true, message: "Connected to Google Calendar" });
+    });
+
+    it("returns failure with error message on error", async () => {
+      mockClient.request.mockRejectedValue(new Error("Unauthorized"));
+
+      const result = await provider.testConnection();
+
+      expect(result).toEqual({ success: false, message: "Unauthorized" });
+    });
+
+    it("returns generic failure message for non-Error throws", async () => {
+      mockClient.request.mockRejectedValue("something went wrong");
+
+      const result = await provider.testConnection();
+
+      expect(result).toEqual({ success: false, message: "Connection failed" });
+    });
+  });
+});

--- a/src/services/calendar/googleCalendarProvider.ts
+++ b/src/services/calendar/googleCalendarProvider.ts
@@ -1,0 +1,248 @@
+import type {
+  CalendarProvider,
+  CalendarProviderType,
+  CalendarInfo,
+  CalendarEventData,
+  CalendarSyncResult,
+  CreateEventInput,
+  UpdateEventInput,
+} from "./types";
+import { getGmailClient } from "@/services/gmail/tokenManager";
+import type { GmailClient } from "@/services/gmail/client";
+
+const CALENDAR_API_BASE = "https://www.googleapis.com/calendar/v3";
+
+interface GoogleCalendarListItem {
+  id: string;
+  summary: string;
+  backgroundColor?: string;
+  primary?: boolean;
+  accessRole?: string;
+}
+
+interface GoogleCalendarListResponse {
+  items?: GoogleCalendarListItem[];
+}
+
+interface GoogleCalendarEvent {
+  id: string;
+  summary?: string;
+  description?: string;
+  location?: string;
+  start: { dateTime?: string; date?: string; timeZone?: string };
+  end: { dateTime?: string; date?: string; timeZone?: string };
+  status?: string;
+  organizer?: { email: string; displayName?: string };
+  attendees?: { email: string; displayName?: string; responseStatus?: string }[];
+  htmlLink?: string;
+  iCalUID?: string;
+  etag?: string;
+}
+
+interface GoogleEventListResponse {
+  items?: GoogleCalendarEvent[];
+  nextPageToken?: string;
+  nextSyncToken?: string;
+}
+
+export class GoogleCalendarProvider implements CalendarProvider {
+  readonly type: CalendarProviderType = "google_api";
+
+  constructor(readonly accountId: string) {}
+
+  private async getClient(): Promise<GmailClient> {
+    return getGmailClient(this.accountId);
+  }
+
+  async listCalendars(): Promise<CalendarInfo[]> {
+    const client = await this.getClient();
+    const response = await client.request<GoogleCalendarListResponse>(
+      `${CALENDAR_API_BASE}/users/me/calendarList`,
+    );
+    return (response.items ?? []).map((cal) => ({
+      remoteId: cal.id,
+      displayName: cal.summary,
+      color: cal.backgroundColor ?? null,
+      isPrimary: !!cal.primary,
+    }));
+  }
+
+  async fetchEvents(calendarRemoteId: string, timeMin: string, timeMax: string): Promise<CalendarEventData[]> {
+    const client = await this.getClient();
+    const params = new URLSearchParams({
+      timeMin,
+      timeMax,
+      singleEvents: "true",
+      orderBy: "startTime",
+      maxResults: "250",
+    });
+
+    const encodedId = encodeURIComponent(calendarRemoteId);
+    const url = `${CALENDAR_API_BASE}/calendars/${encodedId}/events?${params}`;
+    const response = await client.request<GoogleEventListResponse>(url);
+    return (response.items ?? []).map(mapGoogleEvent);
+  }
+
+  async createEvent(calendarRemoteId: string, event: CreateEventInput): Promise<CalendarEventData> {
+    const client = await this.getClient();
+    const tz = Intl.DateTimeFormat().resolvedOptions().timeZone;
+    const encodedId = encodeURIComponent(calendarRemoteId);
+    const url = `${CALENDAR_API_BASE}/calendars/${encodedId}/events`;
+
+    const body: Record<string, unknown> = {
+      summary: event.summary,
+      description: event.description,
+      location: event.location,
+    };
+
+    if (event.isAllDay) {
+      body.start = { date: event.startTime.split("T")[0] };
+      body.end = { date: event.endTime.split("T")[0] };
+    } else {
+      body.start = { dateTime: new Date(event.startTime).toISOString(), timeZone: tz };
+      body.end = { dateTime: new Date(event.endTime).toISOString(), timeZone: tz };
+    }
+
+    if (event.attendees) {
+      body.attendees = event.attendees;
+    }
+
+    const created = await client.request<GoogleCalendarEvent>(url, {
+      method: "POST",
+      body: JSON.stringify(body),
+    });
+    return mapGoogleEvent(created);
+  }
+
+  async updateEvent(calendarRemoteId: string, remoteEventId: string, event: UpdateEventInput): Promise<CalendarEventData> {
+    const client = await this.getClient();
+    const tz = Intl.DateTimeFormat().resolvedOptions().timeZone;
+    const encodedCalId = encodeURIComponent(calendarRemoteId);
+    const encodedEventId = encodeURIComponent(remoteEventId);
+    const url = `${CALENDAR_API_BASE}/calendars/${encodedCalId}/events/${encodedEventId}`;
+
+    const body: Record<string, unknown> = {};
+    if (event.summary !== undefined) body.summary = event.summary;
+    if (event.description !== undefined) body.description = event.description;
+    if (event.location !== undefined) body.location = event.location;
+
+    if (event.startTime && event.endTime) {
+      if (event.isAllDay) {
+        body.start = { date: event.startTime.split("T")[0] };
+        body.end = { date: event.endTime.split("T")[0] };
+      } else {
+        body.start = { dateTime: new Date(event.startTime).toISOString(), timeZone: tz };
+        body.end = { dateTime: new Date(event.endTime).toISOString(), timeZone: tz };
+      }
+    }
+
+    const updated = await client.request<GoogleCalendarEvent>(url, {
+      method: "PATCH",
+      body: JSON.stringify(body),
+    });
+    return mapGoogleEvent(updated);
+  }
+
+  async deleteEvent(calendarRemoteId: string, remoteEventId: string): Promise<void> {
+    const client = await this.getClient();
+    const encodedCalId = encodeURIComponent(calendarRemoteId);
+    const encodedEventId = encodeURIComponent(remoteEventId);
+    const url = `${CALENDAR_API_BASE}/calendars/${encodedCalId}/events/${encodedEventId}`;
+    await client.request(url, { method: "DELETE" });
+  }
+
+  async syncEvents(calendarRemoteId: string, syncToken?: string): Promise<CalendarSyncResult> {
+    const client = await this.getClient();
+    const encodedId = encodeURIComponent(calendarRemoteId);
+    const created: CalendarEventData[] = [];
+    const updated: CalendarEventData[] = [];
+    const deletedRemoteIds: string[] = [];
+
+    let pageToken: string | undefined;
+    let nextSyncToken: string | null = null;
+
+    do {
+      const params = new URLSearchParams({ maxResults: "250" });
+      if (syncToken) {
+        params.set("syncToken", syncToken);
+      } else {
+        // Initial sync: fetch last 90 days to 365 days forward
+        const timeMin = new Date();
+        timeMin.setDate(timeMin.getDate() - 90);
+        params.set("timeMin", timeMin.toISOString());
+        const timeMax = new Date();
+        timeMax.setFullYear(timeMax.getFullYear() + 1);
+        params.set("timeMax", timeMax.toISOString());
+        params.set("singleEvents", "true");
+      }
+      if (pageToken) params.set("pageToken", pageToken);
+
+      const url = `${CALENDAR_API_BASE}/calendars/${encodedId}/events?${params}`;
+
+      let response: GoogleEventListResponse;
+      try {
+        response = await client.request<GoogleEventListResponse>(url);
+      } catch (err) {
+        const message = err instanceof Error ? err.message : "";
+        if (message.includes("410") || message.includes("sync token")) {
+          // Sync token expired — caller should do full sync
+          return { created: [], updated: [], deletedRemoteIds: [], newSyncToken: null, newCtag: null };
+        }
+        throw err;
+      }
+
+      for (const item of response.items ?? []) {
+        if (item.status === "cancelled") {
+          deletedRemoteIds.push(item.id);
+        } else {
+          const eventData = mapGoogleEvent(item);
+          // For sync, we put everything in "created" (upsert logic handles deduplication)
+          created.push(eventData);
+        }
+      }
+
+      pageToken = response.nextPageToken;
+      if (response.nextSyncToken) {
+        nextSyncToken = response.nextSyncToken;
+      }
+    } while (pageToken);
+
+    return { created, updated, deletedRemoteIds, newSyncToken: nextSyncToken, newCtag: null };
+  }
+
+  async testConnection(): Promise<{ success: boolean; message: string }> {
+    try {
+      await this.listCalendars();
+      return { success: true, message: "Connected to Google Calendar" };
+    } catch (err) {
+      return { success: false, message: err instanceof Error ? err.message : "Connection failed" };
+    }
+  }
+}
+
+function mapGoogleEvent(event: GoogleCalendarEvent): CalendarEventData {
+  const isAllDay = !!event.start.date;
+  const startTime = event.start.dateTime
+    ? Math.floor(new Date(event.start.dateTime).getTime() / 1000)
+    : Math.floor(new Date(event.start.date + "T00:00:00").getTime() / 1000);
+  const endTime = event.end.dateTime
+    ? Math.floor(new Date(event.end.dateTime).getTime() / 1000)
+    : Math.floor(new Date(event.end.date + "T23:59:59").getTime() / 1000);
+
+  return {
+    remoteEventId: event.id,
+    uid: event.iCalUID ?? null,
+    etag: event.etag ?? null,
+    summary: event.summary ?? null,
+    description: event.description ?? null,
+    location: event.location ?? null,
+    startTime,
+    endTime,
+    isAllDay,
+    status: event.status ?? "confirmed",
+    organizerEmail: event.organizer?.email ?? null,
+    attendeesJson: event.attendees ? JSON.stringify(event.attendees) : null,
+    htmlLink: event.htmlLink ?? null,
+    icalData: null,
+  };
+}

--- a/src/services/calendar/icalHelper.test.ts
+++ b/src/services/calendar/icalHelper.test.ts
@@ -1,0 +1,532 @@
+import { generateVEvent, parseVEvent } from "./icalHelper";
+import type { CreateEventInput } from "./types";
+
+beforeEach(() => {
+  crypto.randomUUID = vi.fn(() => "test-uuid-1234") as () => `${string}-${string}-${string}-${string}-${string}`;
+  vi.useFakeTimers();
+  vi.setSystemTime(new Date("2025-06-15T10:00:00Z"));
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+  vi.restoreAllMocks();
+});
+
+describe("generateVEvent", () => {
+  it("generates a basic event with summary and times", () => {
+    const event: CreateEventInput = {
+      summary: "Team Meeting",
+      startTime: "2025-06-20T14:00:00Z",
+      endTime: "2025-06-20T15:00:00Z",
+    };
+
+    const result = generateVEvent(event);
+
+    expect(result).toContain("BEGIN:VCALENDAR");
+    expect(result).toContain("VERSION:2.0");
+    expect(result).toContain("PRODID:-//Velo Mail//CalDAV Client//EN");
+    expect(result).toContain("BEGIN:VEVENT");
+    expect(result).toContain("UID:test-uuid-1234");
+    expect(result).toContain("SUMMARY:Team Meeting");
+    expect(result).toContain("DTSTART:20250620T140000Z");
+    expect(result).toContain("DTEND:20250620T150000Z");
+    expect(result).toContain("END:VEVENT");
+    expect(result).toContain("END:VCALENDAR");
+  });
+
+  it("uses provided UID when given", () => {
+    const event: CreateEventInput = {
+      summary: "Test",
+      startTime: "2025-06-20T14:00:00Z",
+      endTime: "2025-06-20T15:00:00Z",
+    };
+
+    const result = generateVEvent(event, "custom-uid-5678");
+
+    expect(result).toContain("UID:custom-uid-5678");
+    expect(result).not.toContain("test-uuid-1234");
+  });
+
+  it("generates an all-day event with VALUE=DATE format", () => {
+    const event: CreateEventInput = {
+      summary: "Holiday",
+      startTime: "2025-12-25T00:00:00Z",
+      endTime: "2025-12-26T00:00:00Z",
+      isAllDay: true,
+    };
+
+    const result = generateVEvent(event);
+
+    expect(result).toContain("DTSTART;VALUE=DATE:20251225");
+    expect(result).toContain("DTEND;VALUE=DATE:20251226");
+    expect(result).not.toContain("DTSTART:2025");
+  });
+
+  it("includes description when provided", () => {
+    const event: CreateEventInput = {
+      summary: "Review",
+      description: "Quarterly review meeting",
+      startTime: "2025-06-20T14:00:00Z",
+      endTime: "2025-06-20T15:00:00Z",
+    };
+
+    const result = generateVEvent(event);
+
+    expect(result).toContain("DESCRIPTION:Quarterly review meeting");
+  });
+
+  it("includes location when provided", () => {
+    const event: CreateEventInput = {
+      summary: "Lunch",
+      location: "Conference Room B",
+      startTime: "2025-06-20T12:00:00Z",
+      endTime: "2025-06-20T13:00:00Z",
+    };
+
+    const result = generateVEvent(event);
+
+    expect(result).toContain("LOCATION:Conference Room B");
+  });
+
+  it("includes attendees with RSVP", () => {
+    const event: CreateEventInput = {
+      summary: "Standup",
+      startTime: "2025-06-20T09:00:00Z",
+      endTime: "2025-06-20T09:15:00Z",
+      attendees: [
+        { email: "alice@example.com" },
+        { email: "bob@example.com" },
+      ],
+    };
+
+    const result = generateVEvent(event);
+
+    expect(result).toContain("ATTENDEE;RSVP=TRUE:mailto:alice@example.com");
+    expect(result).toContain("ATTENDEE;RSVP=TRUE:mailto:bob@example.com");
+  });
+
+  it("escapes special characters in text fields", () => {
+    const event: CreateEventInput = {
+      summary: "Meeting; with, special\\chars",
+      description: "Line1\nLine2",
+      location: "Room A; Floor 2, Building 1",
+      startTime: "2025-06-20T14:00:00Z",
+      endTime: "2025-06-20T15:00:00Z",
+    };
+
+    const result = generateVEvent(event);
+
+    expect(result).toContain("SUMMARY:Meeting\\; with\\, special\\\\chars");
+    expect(result).toContain("DESCRIPTION:Line1\\nLine2");
+    expect(result).toContain("LOCATION:Room A\\; Floor 2\\, Building 1");
+  });
+
+  it("uses CRLF line endings", () => {
+    const event: CreateEventInput = {
+      summary: "Test",
+      startTime: "2025-06-20T14:00:00Z",
+      endTime: "2025-06-20T15:00:00Z",
+    };
+
+    const result = generateVEvent(event);
+
+    expect(result).toContain("\r\n");
+    const lines = result.split("\r\n");
+    expect(lines[0]).toBe("BEGIN:VCALENDAR");
+  });
+
+  it("omits description and location when not provided", () => {
+    const event: CreateEventInput = {
+      summary: "Simple",
+      startTime: "2025-06-20T14:00:00Z",
+      endTime: "2025-06-20T15:00:00Z",
+    };
+
+    const result = generateVEvent(event);
+
+    expect(result).not.toContain("DESCRIPTION:");
+    expect(result).not.toContain("LOCATION:");
+    expect(result).not.toContain("ATTENDEE");
+  });
+
+  it("includes DTSTAMP with current UTC time", () => {
+    const event: CreateEventInput = {
+      summary: "Test",
+      startTime: "2025-06-20T14:00:00Z",
+      endTime: "2025-06-20T15:00:00Z",
+    };
+
+    const result = generateVEvent(event);
+
+    expect(result).toContain("DTSTAMP:20250615T100000Z");
+  });
+});
+
+describe("parseVEvent", () => {
+  it("parses a basic VEVENT", () => {
+    const ical = [
+      "BEGIN:VCALENDAR",
+      "BEGIN:VEVENT",
+      "UID:abc-123",
+      "SUMMARY:Team Sync",
+      "DTSTART:20250620T140000Z",
+      "DTEND:20250620T150000Z",
+      "END:VEVENT",
+      "END:VCALENDAR",
+    ].join("\r\n");
+
+    const result = parseVEvent(ical);
+
+    expect(result.uid).toBe("abc-123");
+    expect(result.summary).toBe("Team Sync");
+    expect(result.isAllDay).toBe(false);
+    expect(result.startTime).toBe(Math.floor(new Date("2025-06-20T14:00:00Z").getTime() / 1000));
+    expect(result.endTime).toBe(Math.floor(new Date("2025-06-20T15:00:00Z").getTime() / 1000));
+    expect(result.remoteEventId).toBe("abc-123");
+    expect(result.status).toBe("confirmed");
+    expect(result.etag).toBeNull();
+    expect(result.htmlLink).toBeNull();
+  });
+
+  it("parses an all-day event with VALUE=DATE", () => {
+    const ical = [
+      "BEGIN:VEVENT",
+      "UID:allday-1",
+      "SUMMARY:Conference",
+      "DTSTART;VALUE=DATE:20250701",
+      "DTEND;VALUE=DATE:20250703",
+      "END:VEVENT",
+    ].join("\r\n");
+
+    const result = parseVEvent(ical);
+
+    expect(result.isAllDay).toBe(true);
+    expect(result.summary).toBe("Conference");
+    const expectedStart = Math.floor(new Date(2025, 6, 1).getTime() / 1000);
+    const expectedEnd = Math.floor(new Date(2025, 6, 3).getTime() / 1000);
+    expect(result.startTime).toBe(expectedStart);
+    expect(result.endTime).toBe(expectedEnd);
+  });
+
+  it("parses description and location", () => {
+    const ical = [
+      "BEGIN:VEVENT",
+      "UID:detail-1",
+      "SUMMARY:Workshop",
+      "DESCRIPTION:Learn new things",
+      "LOCATION:Main Hall",
+      "DTSTART:20250620T090000Z",
+      "DTEND:20250620T170000Z",
+      "END:VEVENT",
+    ].join("\r\n");
+
+    const result = parseVEvent(ical);
+
+    expect(result.description).toBe("Learn new things");
+    expect(result.location).toBe("Main Hall");
+  });
+
+  it("parses attendees with CN and PARTSTAT", () => {
+    const ical = [
+      "BEGIN:VEVENT",
+      "UID:attend-1",
+      "SUMMARY:Planning",
+      'ATTENDEE;CN="Alice Smith";PARTSTAT=ACCEPTED:mailto:alice@example.com',
+      "ATTENDEE;CN=Bob;PARTSTAT=TENTATIVE:mailto:bob@example.com",
+      "DTSTART:20250620T100000Z",
+      "DTEND:20250620T110000Z",
+      "END:VEVENT",
+    ].join("\r\n");
+
+    const result = parseVEvent(ical);
+
+    expect(result.attendeesJson).not.toBeNull();
+    const attendees = JSON.parse(result.attendeesJson!);
+    expect(attendees).toHaveLength(2);
+    expect(attendees[0]).toEqual({
+      email: "alice@example.com",
+      displayName: "Alice Smith",
+      responseStatus: "accepted",
+    });
+    expect(attendees[1]).toEqual({
+      email: "bob@example.com",
+      displayName: "Bob",
+      responseStatus: "tentative",
+    });
+  });
+
+  it("parses organizer email", () => {
+    const ical = [
+      "BEGIN:VEVENT",
+      "UID:org-1",
+      "SUMMARY:Review",
+      "ORGANIZER;CN=Manager:mailto:manager@example.com",
+      "DTSTART:20250620T100000Z",
+      "DTEND:20250620T110000Z",
+      "END:VEVENT",
+    ].join("\r\n");
+
+    const result = parseVEvent(ical);
+
+    expect(result.organizerEmail).toBe("manager@example.com");
+  });
+
+  it("parses STATUS field", () => {
+    const ical = [
+      "BEGIN:VEVENT",
+      "UID:status-1",
+      "SUMMARY:Cancelled Event",
+      "STATUS:CANCELLED",
+      "DTSTART:20250620T100000Z",
+      "DTEND:20250620T110000Z",
+      "END:VEVENT",
+    ].join("\r\n");
+
+    const result = parseVEvent(ical);
+
+    expect(result.status).toBe("cancelled");
+  });
+
+  it("handles missing fields gracefully", () => {
+    const ical = [
+      "BEGIN:VEVENT",
+      "UID:minimal-1",
+      "END:VEVENT",
+    ].join("\r\n");
+
+    const result = parseVEvent(ical);
+
+    expect(result.uid).toBe("minimal-1");
+    expect(result.summary).toBeNull();
+    expect(result.description).toBeNull();
+    expect(result.location).toBeNull();
+    expect(result.organizerEmail).toBeNull();
+    expect(result.attendeesJson).toBeNull();
+    expect(result.startTime).toBe(0);
+    // endTime defaults to startTime + 3600 when missing
+    expect(result.endTime).toBe(3600);
+  });
+
+  it("uses href as remoteEventId when provided", () => {
+    const ical = [
+      "BEGIN:VEVENT",
+      "UID:uid-1",
+      "DTSTART:20250620T100000Z",
+      "DTEND:20250620T110000Z",
+      "END:VEVENT",
+    ].join("\r\n");
+
+    const result = parseVEvent(ical, "/calendars/cal1/events/event-abc.ics");
+
+    expect(result.remoteEventId).toBe("/calendars/cal1/events/event-abc.ics");
+  });
+
+  it("falls back to randomUUID when no UID and no href", () => {
+    const ical = [
+      "BEGIN:VEVENT",
+      "SUMMARY:No UID",
+      "DTSTART:20250620T100000Z",
+      "DTEND:20250620T110000Z",
+      "END:VEVENT",
+    ].join("\r\n");
+
+    const result = parseVEvent(ical);
+
+    expect(result.remoteEventId).toBe("test-uuid-1234");
+    expect(result.uid).toBeNull();
+  });
+
+  it("unescapes special characters in text fields", () => {
+    const ical = [
+      "BEGIN:VEVENT",
+      "UID:esc-1",
+      "SUMMARY:Meeting\\; with\\, special\\\\chars",
+      "DESCRIPTION:Line1\\nLine2",
+      "LOCATION:Room A\\; Floor 2",
+      "DTSTART:20250620T100000Z",
+      "DTEND:20250620T110000Z",
+      "END:VEVENT",
+    ].join("\r\n");
+
+    const result = parseVEvent(ical);
+
+    expect(result.summary).toBe("Meeting; with, special\\chars");
+    expect(result.description).toBe("Line1\nLine2");
+    expect(result.location).toBe("Room A; Floor 2");
+  });
+
+  it("unfolds continuation lines (RFC 5545)", () => {
+    const ical = [
+      "BEGIN:VEVENT",
+      "UID:fold-1",
+      "SUMMARY:This is a very long summ",
+      " ary that was folded",
+      "DTSTART:20250620T100000Z",
+      "DTEND:20250620T110000Z",
+      "END:VEVENT",
+    ].join("\r\n");
+
+    const result = parseVEvent(ical);
+
+    expect(result.summary).toBe("This is a very long summary that was folded");
+  });
+
+  it("unfolds continuation lines with tab", () => {
+    const ical = [
+      "BEGIN:VEVENT",
+      "UID:fold-tab-1",
+      "SUMMARY:Folded with",
+      "\ttab character",
+      "DTSTART:20250620T100000Z",
+      "DTEND:20250620T110000Z",
+      "END:VEVENT",
+    ].join("\r\n");
+
+    const result = parseVEvent(ical);
+
+    expect(result.summary).toBe("Folded withtab character");
+  });
+
+  it("handles values containing colons", () => {
+    const ical = [
+      "BEGIN:VEVENT",
+      "UID:colon-1",
+      "SUMMARY:Meeting at 10:30:00",
+      "DTSTART:20250620T100000Z",
+      "DTEND:20250620T110000Z",
+      "END:VEVENT",
+    ].join("\r\n");
+
+    const result = parseVEvent(ical);
+
+    expect(result.summary).toBe("Meeting at 10:30:00");
+  });
+
+  it("parses non-UTC datetime (no Z suffix)", () => {
+    const ical = [
+      "BEGIN:VEVENT",
+      "UID:local-1",
+      "DTSTART:20250620T140000",
+      "DTEND:20250620T150000",
+      "END:VEVENT",
+    ].join("\r\n");
+
+    const result = parseVEvent(ical);
+
+    // Local time -- new Date(2025, 5, 20, 14, 0, 0)
+    const expectedStart = Math.floor(new Date(2025, 5, 20, 14, 0, 0).getTime() / 1000);
+    const expectedEnd = Math.floor(new Date(2025, 5, 20, 15, 0, 0).getTime() / 1000);
+    expect(result.startTime).toBe(expectedStart);
+    expect(result.endTime).toBe(expectedEnd);
+  });
+
+  it("stores original icalData on the result", () => {
+    const ical = [
+      "BEGIN:VEVENT",
+      "UID:raw-1",
+      "SUMMARY:Test",
+      "DTSTART:20250620T100000Z",
+      "DTEND:20250620T110000Z",
+      "END:VEVENT",
+    ].join("\r\n");
+
+    const result = parseVEvent(ical);
+
+    expect(result.icalData).toBe(ical);
+  });
+
+  it("handles attendees without CN or PARTSTAT", () => {
+    const ical = [
+      "BEGIN:VEVENT",
+      "UID:att-simple",
+      "ATTENDEE;RSVP=TRUE:mailto:plain@example.com",
+      "DTSTART:20250620T100000Z",
+      "DTEND:20250620T110000Z",
+      "END:VEVENT",
+    ].join("\r\n");
+
+    const result = parseVEvent(ical);
+    const attendees = JSON.parse(result.attendeesJson!);
+
+    expect(attendees).toHaveLength(1);
+    expect(attendees[0].email).toBe("plain@example.com");
+    expect(attendees[0].displayName).toBeUndefined();
+    expect(attendees[0].responseStatus).toBeUndefined();
+  });
+});
+
+describe("round-trip: generateVEvent -> parseVEvent", () => {
+  it("preserves basic event data through generate and parse", () => {
+    const input: CreateEventInput = {
+      summary: "Round Trip Test",
+      description: "Testing full cycle",
+      location: "Office",
+      startTime: "2025-07-01T09:00:00Z",
+      endTime: "2025-07-01T10:30:00Z",
+    };
+
+    const ical = generateVEvent(input, "roundtrip-uid");
+    const parsed = parseVEvent(ical);
+
+    expect(parsed.uid).toBe("roundtrip-uid");
+    expect(parsed.summary).toBe("Round Trip Test");
+    expect(parsed.description).toBe("Testing full cycle");
+    expect(parsed.location).toBe("Office");
+    expect(parsed.isAllDay).toBe(false);
+    expect(parsed.startTime).toBe(Math.floor(new Date("2025-07-01T09:00:00Z").getTime() / 1000));
+    expect(parsed.endTime).toBe(Math.floor(new Date("2025-07-01T10:30:00Z").getTime() / 1000));
+  });
+
+  it("preserves all-day event data through round-trip", () => {
+    const input: CreateEventInput = {
+      summary: "Vacation",
+      startTime: "2025-08-01T00:00:00Z",
+      endTime: "2025-08-08T00:00:00Z",
+      isAllDay: true,
+    };
+
+    const ical = generateVEvent(input, "allday-rt");
+    const parsed = parseVEvent(ical);
+
+    expect(parsed.uid).toBe("allday-rt");
+    expect(parsed.summary).toBe("Vacation");
+    expect(parsed.isAllDay).toBe(true);
+  });
+
+  it("preserves attendee emails through round-trip", () => {
+    const input: CreateEventInput = {
+      summary: "Group Call",
+      startTime: "2025-07-01T15:00:00Z",
+      endTime: "2025-07-01T16:00:00Z",
+      attendees: [
+        { email: "dev@example.com" },
+        { email: "pm@example.com" },
+      ],
+    };
+
+    const ical = generateVEvent(input, "att-rt");
+    const parsed = parseVEvent(ical);
+
+    const attendees = JSON.parse(parsed.attendeesJson!);
+    expect(attendees).toHaveLength(2);
+    expect(attendees[0].email).toBe("dev@example.com");
+    expect(attendees[1].email).toBe("pm@example.com");
+  });
+
+  it("preserves special characters through round-trip", () => {
+    const input: CreateEventInput = {
+      summary: "Review; Q2, Results\\Final",
+      description: "Line one\nLine two\nLine three",
+      location: "Building A; Room 3, Floor 2",
+      startTime: "2025-07-01T09:00:00Z",
+      endTime: "2025-07-01T10:00:00Z",
+    };
+
+    const ical = generateVEvent(input, "escape-rt");
+    const parsed = parseVEvent(ical);
+
+    expect(parsed.summary).toBe("Review; Q2, Results\\Final");
+    expect(parsed.description).toBe("Line one\nLine two\nLine three");
+    expect(parsed.location).toBe("Building A; Room 3, Floor 2");
+  });
+});

--- a/src/services/calendar/icalHelper.ts
+++ b/src/services/calendar/icalHelper.ts
@@ -1,0 +1,202 @@
+import type { CalendarEventData, CreateEventInput, UpdateEventInput } from "./types";
+
+/**
+ * Generate a VEVENT iCalendar string from event input.
+ */
+export function generateVEvent(event: CreateEventInput | UpdateEventInput, uid?: string): string {
+  const eventUid = uid ?? crypto.randomUUID();
+  const now = formatDateTimeUTC(new Date());
+
+  const lines: string[] = [
+    "BEGIN:VCALENDAR",
+    "VERSION:2.0",
+    "PRODID:-//Velo Mail//CalDAV Client//EN",
+    "BEGIN:VEVENT",
+    `UID:${eventUid}`,
+    `DTSTAMP:${now}`,
+  ];
+
+  if (event.summary) {
+    lines.push(`SUMMARY:${escapeICalText(event.summary)}`);
+  }
+
+  if (event.startTime && event.endTime) {
+    if (event.isAllDay) {
+      lines.push(`DTSTART;VALUE=DATE:${formatDateOnly(new Date(event.startTime))}`);
+      lines.push(`DTEND;VALUE=DATE:${formatDateOnly(new Date(event.endTime))}`);
+    } else {
+      lines.push(`DTSTART:${formatDateTimeUTC(new Date(event.startTime))}`);
+      lines.push(`DTEND:${formatDateTimeUTC(new Date(event.endTime))}`);
+    }
+  }
+
+  if (event.description) {
+    lines.push(`DESCRIPTION:${escapeICalText(event.description)}`);
+  }
+
+  if (event.location) {
+    lines.push(`LOCATION:${escapeICalText(event.location)}`);
+  }
+
+  if ("attendees" in event && event.attendees) {
+    for (const attendee of event.attendees) {
+      lines.push(`ATTENDEE;RSVP=TRUE:mailto:${attendee.email}`);
+    }
+  }
+
+  lines.push("END:VEVENT");
+  lines.push("END:VCALENDAR");
+
+  return lines.join("\r\n");
+}
+
+/**
+ * Parse a VEVENT from iCalendar data into CalendarEventData.
+ */
+export function parseVEvent(icalData: string, href?: string): CalendarEventData {
+  const lines = unfoldLines(icalData);
+
+  let uid: string | null = null;
+  let summary: string | null = null;
+  let description: string | null = null;
+  let location: string | null = null;
+  let dtstart: string | null = null;
+  let dtend: string | null = null;
+  let status = "confirmed";
+  let organizerEmail: string | null = null;
+  let isAllDay = false;
+  const attendees: { email: string; displayName?: string; responseStatus?: string }[] = [];
+
+  for (const line of lines) {
+    const [nameWithParams, ...valueParts] = line.split(":");
+    if (!nameWithParams) continue;
+    const value = valueParts.join(":");
+    const nameParts = nameWithParams.split(";");
+    const propName = nameParts[0]!.toUpperCase();
+    const params = nameParts.slice(1).join(";").toUpperCase();
+
+    switch (propName) {
+      case "UID":
+        uid = value;
+        break;
+      case "SUMMARY":
+        summary = unescapeICalText(value);
+        break;
+      case "DESCRIPTION":
+        description = unescapeICalText(value);
+        break;
+      case "LOCATION":
+        location = unescapeICalText(value);
+        break;
+      case "DTSTART":
+        dtstart = value;
+        if (params.includes("VALUE=DATE") && !params.includes("VALUE=DATE-TIME")) {
+          isAllDay = true;
+        }
+        break;
+      case "DTEND":
+        dtend = value;
+        break;
+      case "STATUS":
+        status = value.toLowerCase();
+        break;
+      case "ORGANIZER": {
+        const mailto = value.match(/mailto:(.+)/i);
+        if (mailto) organizerEmail = mailto[1]!;
+        break;
+      }
+      case "ATTENDEE": {
+        const attendeeMailto = value.match(/mailto:(.+)/i);
+        if (attendeeMailto) {
+          const cnMatch = nameWithParams.match(/CN=([^;]+)/i);
+          const statusMatch = nameWithParams.match(/PARTSTAT=([^;]+)/i);
+          attendees.push({
+            email: attendeeMailto[1]!,
+            displayName: cnMatch?.[1]?.replace(/^"(.*)"$/, "$1"),
+            responseStatus: statusMatch?.[1]?.toLowerCase(),
+          });
+        }
+        break;
+      }
+    }
+  }
+
+  const startTime = dtstart ? parseICalDateTime(dtstart, isAllDay) : 0;
+  const endTime = dtend ? parseICalDateTime(dtend, isAllDay) : startTime + 3600;
+
+  return {
+    remoteEventId: href ?? uid ?? crypto.randomUUID(),
+    uid,
+    etag: null,
+    summary,
+    description,
+    location,
+    startTime,
+    endTime,
+    isAllDay,
+    status,
+    organizerEmail,
+    attendeesJson: attendees.length > 0 ? JSON.stringify(attendees) : null,
+    htmlLink: null,
+    icalData,
+  };
+}
+
+/** Unfold continuation lines (RFC 5545 §3.1) */
+function unfoldLines(icalData: string): string[] {
+  const raw = icalData.replace(/\r\n[ \t]/g, "").replace(/\r\n/g, "\n").replace(/\r/g, "\n");
+  return raw.split("\n").filter((l) => l.length > 0);
+}
+
+function formatDateTimeUTC(date: Date): string {
+  return date.toISOString().replace(/[-:]/g, "").replace(/\.\d{3}/, "");
+}
+
+function formatDateOnly(date: Date): string {
+  const y = date.getFullYear();
+  const m = String(date.getMonth() + 1).padStart(2, "0");
+  const d = String(date.getDate()).padStart(2, "0");
+  return `${y}${m}${d}`;
+}
+
+function escapeICalText(text: string): string {
+  return text
+    .replace(/\\/g, "\\\\")
+    .replace(/;/g, "\\;")
+    .replace(/,/g, "\\,")
+    .replace(/\n/g, "\\n");
+}
+
+function unescapeICalText(text: string): string {
+  return text
+    .replace(/\\n/gi, "\n")
+    .replace(/\\,/g, ",")
+    .replace(/\\;/g, ";")
+    .replace(/\\\\/g, "\\");
+}
+
+function parseICalDateTime(value: string, isAllDay: boolean): number {
+  if (isAllDay) {
+    // Format: YYYYMMDD
+    const y = parseInt(value.substring(0, 4), 10);
+    const m = parseInt(value.substring(4, 6), 10) - 1;
+    const d = parseInt(value.substring(6, 8), 10);
+    return Math.floor(new Date(y, m, d).getTime() / 1000);
+  }
+
+  // Format: YYYYMMDDTHHMMSS or YYYYMMDDTHHMMSSZ
+  const isUTC = value.endsWith("Z");
+  const cleaned = value.replace("Z", "");
+  const y = parseInt(cleaned.substring(0, 4), 10);
+  const m = parseInt(cleaned.substring(4, 6), 10) - 1;
+  const d = parseInt(cleaned.substring(6, 8), 10);
+  const h = parseInt(cleaned.substring(9, 11), 10);
+  const min = parseInt(cleaned.substring(11, 13), 10);
+  const s = parseInt(cleaned.substring(13, 15), 10) || 0;
+
+  const date = isUTC
+    ? new Date(Date.UTC(y, m, d, h, min, s))
+    : new Date(y, m, d, h, min, s);
+
+  return Math.floor(date.getTime() / 1000);
+}

--- a/src/services/calendar/providerFactory.test.ts
+++ b/src/services/calendar/providerFactory.test.ts
@@ -1,0 +1,201 @@
+import {
+  createMockGmailAccount,
+  createMockImapAccount,
+} from "@/test/mocks/entities.mock";
+import type { DbAccount } from "@/services/db/accounts";
+
+vi.mock("@/services/db/accounts", () => ({
+  getAccount: vi.fn(),
+}));
+
+// Mock the provider constructors so they don't do real work,
+// but preserve the class identity and `type` property.
+vi.mock("./googleCalendarProvider", () => {
+  class GoogleCalendarProvider {
+    readonly accountId: string;
+    readonly type = "google_api" as const;
+    constructor(accountId: string) {
+      this.accountId = accountId;
+    }
+  }
+  return { GoogleCalendarProvider };
+});
+
+vi.mock("./caldavProvider", () => {
+  class CalDAVProvider {
+    readonly accountId: string;
+    readonly type = "caldav" as const;
+    constructor(accountId: string) {
+      this.accountId = accountId;
+    }
+  }
+  return { CalDAVProvider };
+});
+
+import { getAccount } from "@/services/db/accounts";
+import {
+  getCalendarProvider,
+  hasCalendarSupport,
+  removeCalendarProvider,
+  clearAllCalendarProviders,
+} from "./providerFactory";
+
+const mockGetAccount = vi.mocked(getAccount);
+
+describe("providerFactory", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    clearAllCalendarProviders();
+  });
+
+  describe("getCalendarProvider", () => {
+    it("returns GoogleCalendarProvider for gmail_api accounts", async () => {
+      const account = createMockGmailAccount();
+      mockGetAccount.mockResolvedValue(account);
+
+      const provider = await getCalendarProvider(account.id);
+
+      expect(provider.type).toBe("google_api");
+      expect(provider.accountId).toBe(account.id);
+    });
+
+    it("returns CalDAVProvider for standalone caldav accounts", async () => {
+      const account = createMockImapAccount({
+        id: "acc-caldav",
+        provider: "caldav" as DbAccount["provider"],
+        caldav_url: "https://caldav.example.com",
+      });
+      mockGetAccount.mockResolvedValue(account);
+
+      const provider = await getCalendarProvider("acc-caldav");
+
+      expect(provider.type).toBe("caldav");
+      expect(provider.accountId).toBe("acc-caldav");
+    });
+
+    it("returns CalDAVProvider for IMAP accounts with caldav_url configured", async () => {
+      const account = createMockImapAccount({
+        calendar_provider: "caldav",
+        caldav_url: "https://caldav.example.com/dav",
+      });
+      mockGetAccount.mockResolvedValue(account);
+
+      const provider = await getCalendarProvider(account.id);
+
+      expect(provider.type).toBe("caldav");
+      expect(provider.accountId).toBe(account.id);
+    });
+
+    it("throws error for IMAP accounts without calendar configured", async () => {
+      const account = createMockImapAccount();
+      mockGetAccount.mockResolvedValue(account);
+
+      await expect(getCalendarProvider(account.id)).rejects.toThrow(
+        `No calendar provider configured for account ${account.id}`,
+      );
+    });
+
+    it("throws error when account is not found", async () => {
+      mockGetAccount.mockResolvedValue(null);
+
+      await expect(getCalendarProvider("nonexistent")).rejects.toThrow(
+        "Account nonexistent not found",
+      );
+    });
+
+    it("caches providers and returns same instance on second call", async () => {
+      const account = createMockGmailAccount();
+      mockGetAccount.mockResolvedValue(account);
+
+      const first = await getCalendarProvider(account.id);
+      const second = await getCalendarProvider(account.id);
+
+      expect(first).toBe(second);
+      // getAccount should only be called once due to caching
+      expect(mockGetAccount).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe("removeCalendarProvider", () => {
+    it("clears cached provider for a specific account", async () => {
+      const account = createMockGmailAccount();
+      mockGetAccount.mockResolvedValue(account);
+
+      const first = await getCalendarProvider(account.id);
+      removeCalendarProvider(account.id);
+      const second = await getCalendarProvider(account.id);
+
+      expect(first).not.toBe(second);
+      expect(mockGetAccount).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  describe("clearAllCalendarProviders", () => {
+    it("clears all cached providers", async () => {
+      const gmailAccount = createMockGmailAccount();
+      const caldavAccount = createMockImapAccount({
+        id: "acc-caldav",
+        provider: "caldav" as DbAccount["provider"],
+        caldav_url: "https://caldav.example.com",
+      });
+
+      mockGetAccount.mockImplementation(async (id: string) => {
+        if (id === gmailAccount.id) return gmailAccount;
+        if (id === caldavAccount.id) return caldavAccount;
+        return null;
+      });
+
+      const gmail1 = await getCalendarProvider(gmailAccount.id);
+      const caldav1 = await getCalendarProvider(caldavAccount.id);
+
+      clearAllCalendarProviders();
+
+      const gmail2 = await getCalendarProvider(gmailAccount.id);
+      const caldav2 = await getCalendarProvider(caldavAccount.id);
+
+      expect(gmail1).not.toBe(gmail2);
+      expect(caldav1).not.toBe(caldav2);
+    });
+  });
+
+  describe("hasCalendarSupport", () => {
+    it("returns true for gmail_api accounts", async () => {
+      const account = createMockGmailAccount();
+      mockGetAccount.mockResolvedValue(account);
+
+      expect(await hasCalendarSupport(account.id)).toBe(true);
+    });
+
+    it("returns true for standalone caldav accounts", async () => {
+      const account = createMockImapAccount({
+        provider: "caldav" as DbAccount["provider"],
+      });
+      mockGetAccount.mockResolvedValue(account);
+
+      expect(await hasCalendarSupport(account.id)).toBe(true);
+    });
+
+    it("returns true for IMAP accounts with caldav_url configured", async () => {
+      const account = createMockImapAccount({
+        calendar_provider: "caldav",
+        caldav_url: "https://caldav.example.com/dav",
+      });
+      mockGetAccount.mockResolvedValue(account);
+
+      expect(await hasCalendarSupport(account.id)).toBe(true);
+    });
+
+    it("returns false for plain IMAP accounts without calendar", async () => {
+      const account = createMockImapAccount();
+      mockGetAccount.mockResolvedValue(account);
+
+      expect(await hasCalendarSupport(account.id)).toBe(false);
+    });
+
+    it("returns false when account is not found", async () => {
+      mockGetAccount.mockResolvedValue(null);
+
+      expect(await hasCalendarSupport("nonexistent")).toBe(false);
+    });
+  });
+});

--- a/src/services/calendar/providerFactory.ts
+++ b/src/services/calendar/providerFactory.ts
@@ -1,0 +1,63 @@
+import type { CalendarProvider } from "./types";
+import { GoogleCalendarProvider } from "./googleCalendarProvider";
+import { CalDAVProvider } from "./caldavProvider";
+import { getAccount } from "@/services/db/accounts";
+
+const providerCache = new Map<string, CalendarProvider>();
+
+/**
+ * Get a CalendarProvider for the given account.
+ * Routes based on `account.calendar_provider` or `account.provider` for standalone CalDAV accounts.
+ */
+export async function getCalendarProvider(accountId: string): Promise<CalendarProvider> {
+  const cached = providerCache.get(accountId);
+  if (cached) return cached;
+
+  const account = await getAccount(accountId);
+  if (!account) throw new Error(`Account ${accountId} not found`);
+
+  let provider: CalendarProvider;
+
+  // Standalone CalDAV account
+  if (account.provider === "caldav") {
+    provider = new CalDAVProvider(accountId);
+  }
+  // IMAP account with CalDAV configured
+  else if (account.calendar_provider === "caldav" && account.caldav_url) {
+    provider = new CalDAVProvider(accountId);
+  }
+  // Gmail API account
+  else if (account.provider === "gmail_api" || account.calendar_provider === "google_api") {
+    provider = new GoogleCalendarProvider(accountId);
+  }
+  // Default for Gmail accounts
+  else if (account.provider === "gmail_api") {
+    provider = new GoogleCalendarProvider(accountId);
+  } else {
+    throw new Error(`No calendar provider configured for account ${accountId}`);
+  }
+
+  providerCache.set(accountId, provider);
+  return provider;
+}
+
+/**
+ * Check if an account has calendar support configured.
+ */
+export async function hasCalendarSupport(accountId: string): Promise<boolean> {
+  const account = await getAccount(accountId);
+  if (!account) return false;
+
+  if (account.provider === "caldav") return true;
+  if (account.provider === "gmail_api") return true;
+  if (account.calendar_provider === "caldav" && account.caldav_url) return true;
+  return false;
+}
+
+export function removeCalendarProvider(accountId: string): void {
+  providerCache.delete(accountId);
+}
+
+export function clearAllCalendarProviders(): void {
+  providerCache.clear();
+}

--- a/src/services/calendar/types.ts
+++ b/src/services/calendar/types.ts
@@ -1,0 +1,68 @@
+export type CalendarProviderType = "google_api" | "caldav";
+
+export interface CalendarInfo {
+  remoteId: string;
+  displayName: string;
+  color: string | null;
+  isPrimary: boolean;
+}
+
+export interface CalendarEventData {
+  remoteEventId: string;
+  uid: string | null;
+  etag: string | null;
+  summary: string | null;
+  description: string | null;
+  location: string | null;
+  startTime: number;
+  endTime: number;
+  isAllDay: boolean;
+  status: string;
+  organizerEmail: string | null;
+  attendeesJson: string | null;
+  htmlLink: string | null;
+  icalData: string | null;
+}
+
+export interface CreateEventInput {
+  summary: string;
+  description?: string;
+  location?: string;
+  startTime: string; // ISO 8601
+  endTime: string;   // ISO 8601
+  isAllDay?: boolean;
+  attendees?: { email: string }[];
+}
+
+export interface UpdateEventInput {
+  summary?: string;
+  description?: string;
+  location?: string;
+  startTime?: string;
+  endTime?: string;
+  isAllDay?: boolean;
+}
+
+export interface CalendarSyncResult {
+  created: CalendarEventData[];
+  updated: CalendarEventData[];
+  deletedRemoteIds: string[];
+  newSyncToken: string | null;
+  newCtag: string | null;
+}
+
+export interface CalendarProvider {
+  readonly accountId: string;
+  readonly type: CalendarProviderType;
+
+  listCalendars(): Promise<CalendarInfo[]>;
+
+  fetchEvents(calendarRemoteId: string, timeMin: string, timeMax: string): Promise<CalendarEventData[]>;
+  createEvent(calendarRemoteId: string, event: CreateEventInput): Promise<CalendarEventData>;
+  updateEvent(calendarRemoteId: string, remoteEventId: string, event: UpdateEventInput, etag?: string): Promise<CalendarEventData>;
+  deleteEvent(calendarRemoteId: string, remoteEventId: string, etag?: string): Promise<void>;
+
+  syncEvents(calendarRemoteId: string, syncToken?: string): Promise<CalendarSyncResult>;
+
+  testConnection(): Promise<{ success: boolean; message: string }>;
+}

--- a/src/services/db/calendarEvents.test.ts
+++ b/src/services/db/calendarEvents.test.ts
@@ -1,0 +1,295 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+
+vi.mock("@/services/db/connection", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/services/db/connection")>();
+  return {
+    ...actual,
+    getDb: vi.fn(),
+    selectFirstBy: vi.fn(),
+  };
+});
+
+import { getDb, selectFirstBy } from "@/services/db/connection";
+import {
+  upsertCalendarEvent,
+  getCalendarEventsInRange,
+  getCalendarEventsInRangeMulti,
+  deleteEventsForCalendar,
+  getEventByRemoteId,
+  deleteEventByRemoteId,
+  deleteCalendarEvent,
+  type DbCalendarEvent,
+} from "./calendarEvents";
+import { createMockDb } from "@/test/mocks";
+
+const mockDb = createMockDb();
+
+const makeEvent = (overrides: Partial<DbCalendarEvent> = {}): DbCalendarEvent => ({
+  id: "evt-1",
+  account_id: "acc-1",
+  google_event_id: "gev-1",
+  summary: "Team standup",
+  description: "Daily sync",
+  location: "Room A",
+  start_time: 1000,
+  end_time: 2000,
+  is_all_day: 0,
+  status: "confirmed",
+  organizer_email: "org@example.com",
+  attendees_json: null,
+  html_link: "https://calendar.google.com/event/1",
+  updated_at: 999,
+  calendar_id: null,
+  remote_event_id: null,
+  etag: null,
+  ical_data: null,
+  uid: null,
+  ...overrides,
+});
+
+describe("calendarEvents service", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(getDb).mockResolvedValue(mockDb as unknown as Awaited<ReturnType<typeof getDb>>);
+  });
+
+  describe("upsertCalendarEvent", () => {
+    it("inserts event with all fields including CalDAV fields", async () => {
+      await upsertCalendarEvent({
+        accountId: "acc-1",
+        googleEventId: "gev-1",
+        summary: "Team standup",
+        description: "Daily sync",
+        location: "Room A",
+        startTime: 1000,
+        endTime: 2000,
+        isAllDay: false,
+        status: "confirmed",
+        organizerEmail: "org@example.com",
+        attendeesJson: '[{"email":"a@b.com"}]',
+        htmlLink: "https://calendar.google.com/event/1",
+        calendarId: "cal-1",
+        remoteEventId: "remote-1",
+        etag: '"etag-abc"',
+        icalData: "BEGIN:VEVENT\nEND:VEVENT",
+        uid: "uid-123@example.com",
+      });
+
+      expect(mockDb.execute).toHaveBeenCalledTimes(1);
+      const [sql, params] = mockDb.execute.mock.calls[0] as [string, unknown[]];
+      expect(sql).toContain("INSERT INTO calendar_events");
+      expect(sql).toContain("ON CONFLICT(account_id, google_event_id) DO UPDATE");
+      // params[0] is the generated UUID id, skip it
+      expect(params[1]).toBe("acc-1");
+      expect(params[2]).toBe("gev-1");
+      expect(params[3]).toBe("Team standup");
+      expect(params[4]).toBe("Daily sync");
+      expect(params[5]).toBe("Room A");
+      expect(params[6]).toBe(1000);
+      expect(params[7]).toBe(2000);
+      expect(params[8]).toBe(0); // isAllDay false -> 0
+      expect(params[9]).toBe("confirmed");
+      expect(params[10]).toBe("org@example.com");
+      expect(params[11]).toBe('[{"email":"a@b.com"}]');
+      expect(params[12]).toBe("https://calendar.google.com/event/1");
+      expect(params[13]).toBe("cal-1");
+      expect(params[14]).toBe("remote-1");
+      expect(params[15]).toBe('"etag-abc"');
+      expect(params[16]).toBe("BEGIN:VEVENT\nEND:VEVENT");
+      expect(params[17]).toBe("uid-123@example.com");
+    });
+
+    it("converts isAllDay true to 1", async () => {
+      await upsertCalendarEvent({
+        accountId: "acc-1",
+        googleEventId: "gev-2",
+        summary: null,
+        description: null,
+        location: null,
+        startTime: 1000,
+        endTime: 2000,
+        isAllDay: true,
+        status: "confirmed",
+        organizerEmail: null,
+        attendeesJson: null,
+        htmlLink: null,
+      });
+
+      const [, params] = mockDb.execute.mock.calls[0] as [string, unknown[]];
+      expect(params[8]).toBe(1);
+    });
+
+    it("defaults optional CalDAV fields to null", async () => {
+      await upsertCalendarEvent({
+        accountId: "acc-1",
+        googleEventId: "gev-3",
+        summary: null,
+        description: null,
+        location: null,
+        startTime: 1000,
+        endTime: 2000,
+        isAllDay: false,
+        status: "confirmed",
+        organizerEmail: null,
+        attendeesJson: null,
+        htmlLink: null,
+      });
+
+      const [, params] = mockDb.execute.mock.calls[0] as [string, unknown[]];
+      expect(params[13]).toBeNull(); // calendarId
+      expect(params[14]).toBeNull(); // remoteEventId
+      expect(params[15]).toBeNull(); // etag
+      expect(params[16]).toBeNull(); // icalData
+      expect(params[17]).toBeNull(); // uid
+    });
+
+    it("updates existing event on conflict (same account_id + google_event_id)", async () => {
+      await upsertCalendarEvent({
+        accountId: "acc-1",
+        googleEventId: "gev-1",
+        summary: "Updated standup",
+        description: null,
+        location: null,
+        startTime: 3000,
+        endTime: 4000,
+        isAllDay: false,
+        status: "tentative",
+        organizerEmail: null,
+        attendeesJson: null,
+        htmlLink: null,
+        calendarId: "cal-2",
+        remoteEventId: "remote-2",
+        etag: '"etag-new"',
+        icalData: "BEGIN:VEVENT\nUPDATED\nEND:VEVENT",
+        uid: "uid-456@example.com",
+      });
+
+      const [sql, params] = mockDb.execute.mock.calls[0] as [string, unknown[]];
+      expect(sql).toContain("ON CONFLICT(account_id, google_event_id) DO UPDATE SET");
+      expect(sql).toContain("calendar_id = $14");
+      expect(sql).toContain("remote_event_id = $15");
+      expect(sql).toContain("etag = $16");
+      expect(sql).toContain("ical_data = $17");
+      expect(sql).toContain("uid = $18");
+      expect(sql).toContain("updated_at = unixepoch()");
+      expect(params[3]).toBe("Updated standup");
+      expect(params[6]).toBe(3000);
+      expect(params[7]).toBe(4000);
+      expect(params[9]).toBe("tentative");
+    });
+  });
+
+  describe("getCalendarEventsInRange", () => {
+    it("returns events within the given time range", async () => {
+      const events = [makeEvent(), makeEvent({ id: "evt-2", start_time: 1500 })];
+      mockDb.select.mockResolvedValueOnce(events);
+
+      const result = await getCalendarEventsInRange("acc-1", 500, 2500);
+
+      expect(result).toEqual(events);
+      expect(mockDb.select).toHaveBeenCalledTimes(1);
+      const [sql, params] = mockDb.select.mock.calls[0] as [string, unknown[]];
+      expect(sql).toContain("WHERE account_id = $1 AND start_time < $3 AND end_time > $2");
+      expect(sql).toContain("ORDER BY start_time ASC");
+      expect(params).toEqual(["acc-1", 500, 2500]);
+    });
+
+    it("returns empty array when no events match", async () => {
+      mockDb.select.mockResolvedValueOnce([]);
+
+      const result = await getCalendarEventsInRange("acc-1", 5000, 6000);
+
+      expect(result).toEqual([]);
+    });
+  });
+
+  describe("getCalendarEventsInRangeMulti", () => {
+    it("filters by calendar IDs and includes null calendar_id events", async () => {
+      const events = [
+        makeEvent({ calendar_id: "cal-1" }),
+        makeEvent({ id: "evt-2", calendar_id: null }),
+      ];
+      mockDb.select.mockResolvedValueOnce(events);
+
+      const result = await getCalendarEventsInRangeMulti("acc-1", ["cal-1", "cal-2"], 500, 2500);
+
+      expect(result).toEqual(events);
+      expect(mockDb.select).toHaveBeenCalledTimes(1);
+      const [sql, params] = mockDb.select.mock.calls[0] as [string, unknown[]];
+      expect(sql).toContain("calendar_id IN ($4, $5)");
+      expect(sql).toContain("OR calendar_id IS NULL");
+      expect(params).toEqual(["acc-1", 500, 2500, "cal-1", "cal-2"]);
+    });
+
+    it("falls back to getCalendarEventsInRange when calendarIds is empty", async () => {
+      const events = [makeEvent()];
+      mockDb.select.mockResolvedValueOnce(events);
+
+      const result = await getCalendarEventsInRangeMulti("acc-1", [], 500, 2500);
+
+      expect(result).toEqual(events);
+      expect(mockDb.select).toHaveBeenCalledTimes(1);
+      const [sql, params] = mockDb.select.mock.calls[0] as [string, unknown[]];
+      // Should use the simple range query (no calendar_id filter)
+      expect(sql).not.toContain("calendar_id IN");
+      expect(sql).toContain("WHERE account_id = $1 AND start_time < $3 AND end_time > $2");
+      expect(params).toEqual(["acc-1", 500, 2500]);
+    });
+  });
+
+  describe("deleteEventsForCalendar", () => {
+    it("removes all events for a given calendar_id", async () => {
+      await deleteEventsForCalendar("cal-1");
+
+      expect(mockDb.execute).toHaveBeenCalledTimes(1);
+      const [sql, params] = mockDb.execute.mock.calls[0] as [string, unknown[]];
+      expect(sql).toBe("DELETE FROM calendar_events WHERE calendar_id = $1");
+      expect(params).toEqual(["cal-1"]);
+    });
+  });
+
+  describe("getEventByRemoteId", () => {
+    it("returns event matching calendar_id and remote_event_id", async () => {
+      const event = makeEvent({ calendar_id: "cal-1", remote_event_id: "remote-1" });
+      vi.mocked(selectFirstBy).mockResolvedValueOnce(event);
+
+      const result = await getEventByRemoteId("cal-1", "remote-1");
+
+      expect(result).toEqual(event);
+      expect(selectFirstBy).toHaveBeenCalledTimes(1);
+      const [sql, params] = vi.mocked(selectFirstBy).mock.calls[0] as [string, unknown[]];
+      expect(sql).toContain("WHERE calendar_id = $1 AND remote_event_id = $2");
+      expect(params).toEqual(["cal-1", "remote-1"]);
+    });
+
+    it("returns null when no event matches", async () => {
+      vi.mocked(selectFirstBy).mockResolvedValueOnce(null);
+
+      const result = await getEventByRemoteId("cal-1", "nonexistent");
+
+      expect(result).toBeNull();
+    });
+  });
+
+  describe("deleteEventByRemoteId", () => {
+    it("removes event matching calendar_id and remote_event_id", async () => {
+      await deleteEventByRemoteId("cal-1", "remote-1");
+
+      expect(mockDb.execute).toHaveBeenCalledTimes(1);
+      const [sql, params] = mockDb.execute.mock.calls[0] as [string, unknown[]];
+      expect(sql).toBe("DELETE FROM calendar_events WHERE calendar_id = $1 AND remote_event_id = $2");
+      expect(params).toEqual(["cal-1", "remote-1"]);
+    });
+  });
+
+  describe("deleteCalendarEvent", () => {
+    it("removes event by id", async () => {
+      await deleteCalendarEvent("evt-1");
+
+      expect(mockDb.execute).toHaveBeenCalledTimes(1);
+      const [sql, params] = mockDb.execute.mock.calls[0] as [string, unknown[]];
+      expect(sql).toBe("DELETE FROM calendar_events WHERE id = $1");
+      expect(params).toEqual(["evt-1"]);
+    });
+  });
+});

--- a/src/services/db/calendarEvents.ts
+++ b/src/services/db/calendarEvents.ts
@@ -1,4 +1,4 @@
-import { getDb } from "./connection";
+import { getDb, selectFirstBy } from "./connection";
 
 export interface DbCalendarEvent {
   id: string;
@@ -15,6 +15,12 @@ export interface DbCalendarEvent {
   attendees_json: string | null;
   html_link: string | null;
   updated_at: number;
+  // New CalDAV fields (nullable for backward compat)
+  calendar_id: string | null;
+  remote_event_id: string | null;
+  etag: string | null;
+  ical_data: string | null;
+  uid: string | null;
 }
 
 export async function upsertCalendarEvent(event: {
@@ -30,20 +36,28 @@ export async function upsertCalendarEvent(event: {
   organizerEmail: string | null;
   attendeesJson: string | null;
   htmlLink: string | null;
+  calendarId?: string | null;
+  remoteEventId?: string | null;
+  etag?: string | null;
+  icalData?: string | null;
+  uid?: string | null;
 }): Promise<void> {
   const db = await getDb();
   const id = crypto.randomUUID();
   await db.execute(
-    `INSERT INTO calendar_events (id, account_id, google_event_id, summary, description, location, start_time, end_time, is_all_day, status, organizer_email, attendees_json, html_link)
-     VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13)
+    `INSERT INTO calendar_events (id, account_id, google_event_id, summary, description, location, start_time, end_time, is_all_day, status, organizer_email, attendees_json, html_link, calendar_id, remote_event_id, etag, ical_data, uid)
+     VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18)
      ON CONFLICT(account_id, google_event_id) DO UPDATE SET
        summary = $4, description = $5, location = $6, start_time = $7, end_time = $8,
        is_all_day = $9, status = $10, organizer_email = $11, attendees_json = $12,
-       html_link = $13, updated_at = unixepoch()`,
+       html_link = $13, calendar_id = $14, remote_event_id = $15, etag = $16,
+       ical_data = $17, uid = $18, updated_at = unixepoch()`,
     [
       id, event.accountId, event.googleEventId, event.summary, event.description,
       event.location, event.startTime, event.endTime, event.isAllDay ? 1 : 0,
       event.status, event.organizerEmail, event.attendeesJson, event.htmlLink,
+      event.calendarId ?? null, event.remoteEventId ?? null, event.etag ?? null,
+      event.icalData ?? null, event.uid ?? null,
     ],
   );
 }
@@ -60,4 +74,55 @@ export async function getCalendarEventsInRange(
      ORDER BY start_time ASC`,
     [accountId, startTime, endTime],
   );
+}
+
+export async function getCalendarEventsInRangeMulti(
+  accountId: string,
+  calendarIds: string[],
+  startTime: number,
+  endTime: number,
+): Promise<DbCalendarEvent[]> {
+  if (calendarIds.length === 0) {
+    return getCalendarEventsInRange(accountId, startTime, endTime);
+  }
+  const db = await getDb();
+  const placeholders = calendarIds.map((_, i) => `$${i + 4}`).join(", ");
+  return db.select<DbCalendarEvent[]>(
+    `SELECT * FROM calendar_events
+     WHERE account_id = $1 AND start_time < $3 AND end_time > $2
+       AND (calendar_id IN (${placeholders}) OR calendar_id IS NULL)
+     ORDER BY start_time ASC`,
+    [accountId, startTime, endTime, ...calendarIds],
+  );
+}
+
+export async function deleteEventsForCalendar(calendarId: string): Promise<void> {
+  const db = await getDb();
+  await db.execute("DELETE FROM calendar_events WHERE calendar_id = $1", [calendarId]);
+}
+
+export async function getEventByRemoteId(
+  calendarId: string,
+  remoteEventId: string,
+): Promise<DbCalendarEvent | null> {
+  return selectFirstBy<DbCalendarEvent>(
+    "SELECT * FROM calendar_events WHERE calendar_id = $1 AND remote_event_id = $2",
+    [calendarId, remoteEventId],
+  );
+}
+
+export async function deleteEventByRemoteId(
+  calendarId: string,
+  remoteEventId: string,
+): Promise<void> {
+  const db = await getDb();
+  await db.execute(
+    "DELETE FROM calendar_events WHERE calendar_id = $1 AND remote_event_id = $2",
+    [calendarId, remoteEventId],
+  );
+}
+
+export async function deleteCalendarEvent(eventId: string): Promise<void> {
+  const db = await getDb();
+  await db.execute("DELETE FROM calendar_events WHERE id = $1", [eventId]);
 }

--- a/src/services/db/calendars.test.ts
+++ b/src/services/db/calendars.test.ts
@@ -1,0 +1,248 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+
+const { mockGetDb } = vi.hoisted(() => ({
+  mockGetDb: vi.fn(),
+}));
+
+vi.mock("@/services/db/connection", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/services/db/connection")>();
+  return {
+    ...actual,
+    getDb: mockGetDb,
+    selectFirstBy: async (query: string, params: unknown[] = []) => {
+      const db = await mockGetDb();
+      const rows = await db.select(query, params);
+      return rows[0] ?? null;
+    },
+  };
+});
+
+import { getDb } from "@/services/db/connection";
+import {
+  upsertCalendar,
+  getCalendarsForAccount,
+  getVisibleCalendars,
+  setCalendarVisibility,
+  updateCalendarSyncToken,
+  deleteCalendarsForAccount,
+  getCalendarById,
+} from "./calendars";
+import type { DbCalendar } from "./calendars";
+import { createMockDb } from "@/test/mocks";
+
+const mockDb = createMockDb();
+
+const MOCK_UUID = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee";
+
+describe("calendars service", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(getDb).mockResolvedValue(
+      mockDb as unknown as Awaited<ReturnType<typeof getDb>>,
+    );
+    vi.stubGlobal("crypto", {
+      randomUUID: () => MOCK_UUID,
+    });
+  });
+
+  describe("upsertCalendar", () => {
+    it("inserts a new calendar and returns the id", async () => {
+      // selectFirstBy query returns the newly inserted row
+      mockDb.select.mockResolvedValueOnce([{ id: MOCK_UUID }]);
+
+      const id = await upsertCalendar({
+        accountId: "acc-1",
+        provider: "google",
+        remoteId: "remote-cal-1",
+        displayName: "My Calendar",
+        color: "#4285f4",
+        isPrimary: true,
+      });
+
+      expect(id).toBe(MOCK_UUID);
+      expect(mockDb.execute).toHaveBeenCalledOnce();
+      expect(mockDb.execute).toHaveBeenCalledWith(
+        expect.stringContaining("INSERT INTO calendars"),
+        [MOCK_UUID, "acc-1", "google", "remote-cal-1", "My Calendar", "#4285f4", 1],
+      );
+    });
+
+    it("updates on conflict and returns existing id", async () => {
+      const existingId = "existing-id-123";
+      // selectFirstBy returns the existing row id (conflict path)
+      mockDb.select.mockResolvedValueOnce([{ id: existingId }]);
+
+      const id = await upsertCalendar({
+        accountId: "acc-1",
+        provider: "google",
+        remoteId: "remote-cal-1",
+        displayName: "Updated Name",
+        color: "#0b8043",
+        isPrimary: false,
+      });
+
+      expect(id).toBe(existingId);
+      expect(mockDb.execute).toHaveBeenCalledWith(
+        expect.stringContaining("ON CONFLICT(account_id, remote_id) DO UPDATE"),
+        [MOCK_UUID, "acc-1", "google", "remote-cal-1", "Updated Name", "#0b8043", 0],
+      );
+    });
+
+    it("returns generated id when selectFirstBy finds no row", async () => {
+      mockDb.select.mockResolvedValueOnce([]);
+
+      const id = await upsertCalendar({
+        accountId: "acc-1",
+        provider: "google",
+        remoteId: "remote-cal-1",
+        displayName: null,
+        color: null,
+        isPrimary: false,
+      });
+
+      expect(id).toBe(MOCK_UUID);
+    });
+  });
+
+  describe("getCalendarsForAccount", () => {
+    it("returns calendars for the given account", async () => {
+      const calendars: DbCalendar[] = [
+        makeCal({ id: "cal-1", account_id: "acc-1", is_primary: 1, display_name: "Primary" }),
+        makeCal({ id: "cal-2", account_id: "acc-1", is_primary: 0, display_name: "Work" }),
+      ];
+      mockDb.select.mockResolvedValueOnce(calendars);
+
+      const result = await getCalendarsForAccount("acc-1");
+
+      expect(result).toEqual(calendars);
+      expect(mockDb.select).toHaveBeenCalledWith(
+        expect.stringContaining("WHERE account_id = $1"),
+        ["acc-1"],
+      );
+    });
+
+    it("returns empty array when no calendars exist", async () => {
+      mockDb.select.mockResolvedValueOnce([]);
+
+      const result = await getCalendarsForAccount("acc-none");
+
+      expect(result).toEqual([]);
+    });
+  });
+
+  describe("getVisibleCalendars", () => {
+    it("only returns visible calendars", async () => {
+      const visible = [makeCal({ id: "cal-1", is_visible: 1 })];
+      mockDb.select.mockResolvedValueOnce(visible);
+
+      const result = await getVisibleCalendars("acc-1");
+
+      expect(result).toEqual(visible);
+      expect(mockDb.select).toHaveBeenCalledWith(
+        expect.stringContaining("AND is_visible = 1"),
+        ["acc-1"],
+      );
+    });
+  });
+
+  describe("setCalendarVisibility", () => {
+    it("sets visibility to true", async () => {
+      await setCalendarVisibility("cal-1", true);
+
+      expect(mockDb.execute).toHaveBeenCalledWith(
+        expect.stringContaining("UPDATE calendars SET is_visible = $1"),
+        [1, "cal-1"],
+      );
+    });
+
+    it("sets visibility to false", async () => {
+      await setCalendarVisibility("cal-1", false);
+
+      expect(mockDb.execute).toHaveBeenCalledWith(
+        expect.stringContaining("UPDATE calendars SET is_visible = $1"),
+        [0, "cal-1"],
+      );
+    });
+  });
+
+  describe("updateCalendarSyncToken", () => {
+    it("updates sync_token and ctag", async () => {
+      await updateCalendarSyncToken("cal-1", "sync-abc", "ctag-xyz");
+
+      expect(mockDb.execute).toHaveBeenCalledWith(
+        expect.stringContaining("UPDATE calendars SET sync_token = $1, ctag = $2"),
+        ["sync-abc", "ctag-xyz", "cal-1"],
+      );
+    });
+
+    it("sets ctag to null when not provided", async () => {
+      await updateCalendarSyncToken("cal-1", "sync-abc");
+
+      expect(mockDb.execute).toHaveBeenCalledWith(
+        expect.stringContaining("UPDATE calendars SET sync_token = $1, ctag = $2"),
+        ["sync-abc", null, "cal-1"],
+      );
+    });
+
+    it("allows null sync_token", async () => {
+      await updateCalendarSyncToken("cal-1", null, "ctag-xyz");
+
+      expect(mockDb.execute).toHaveBeenCalledWith(
+        expect.stringContaining("SET sync_token = $1"),
+        [null, "ctag-xyz", "cal-1"],
+      );
+    });
+  });
+
+  describe("deleteCalendarsForAccount", () => {
+    it("deletes all calendars for the given account", async () => {
+      await deleteCalendarsForAccount("acc-1");
+
+      expect(mockDb.execute).toHaveBeenCalledWith(
+        expect.stringContaining("DELETE FROM calendars WHERE account_id = $1"),
+        ["acc-1"],
+      );
+    });
+  });
+
+  describe("getCalendarById", () => {
+    it("returns the calendar when found", async () => {
+      const cal = makeCal({ id: "cal-1" });
+      mockDb.select.mockResolvedValueOnce([cal]);
+
+      const result = await getCalendarById("cal-1");
+
+      expect(result).toEqual(cal);
+      expect(mockDb.select).toHaveBeenCalledWith(
+        expect.stringContaining("WHERE id = $1"),
+        ["cal-1"],
+      );
+    });
+
+    it("returns null when calendar not found", async () => {
+      mockDb.select.mockResolvedValueOnce([]);
+
+      const result = await getCalendarById("nonexistent");
+
+      expect(result).toBeNull();
+    });
+  });
+});
+
+function makeCal(overrides: Partial<DbCalendar> = {}): DbCalendar {
+  return {
+    id: "cal-default",
+    account_id: "acc-1",
+    provider: "google",
+    remote_id: "remote-default",
+    display_name: "Default Calendar",
+    color: "#4285f4",
+    is_primary: 0,
+    is_visible: 1,
+    sync_token: null,
+    ctag: null,
+    created_at: 1700000000,
+    updated_at: 1700000000,
+    ...overrides,
+  };
+}

--- a/src/services/db/calendars.ts
+++ b/src/services/db/calendars.ts
@@ -1,0 +1,89 @@
+import { getDb, selectFirstBy } from "./connection";
+
+export interface DbCalendar {
+  id: string;
+  account_id: string;
+  provider: string;
+  remote_id: string;
+  display_name: string | null;
+  color: string | null;
+  is_primary: number;
+  is_visible: number;
+  sync_token: string | null;
+  ctag: string | null;
+  created_at: number;
+  updated_at: number;
+}
+
+export async function upsertCalendar(calendar: {
+  accountId: string;
+  provider: string;
+  remoteId: string;
+  displayName: string | null;
+  color: string | null;
+  isPrimary: boolean;
+}): Promise<string> {
+  const db = await getDb();
+  const id = crypto.randomUUID();
+  await db.execute(
+    `INSERT INTO calendars (id, account_id, provider, remote_id, display_name, color, is_primary)
+     VALUES ($1, $2, $3, $4, $5, $6, $7)
+     ON CONFLICT(account_id, remote_id) DO UPDATE SET
+       display_name = $5, color = $6, is_primary = $7, updated_at = unixepoch()`,
+    [id, calendar.accountId, calendar.provider, calendar.remoteId, calendar.displayName, calendar.color, calendar.isPrimary ? 1 : 0],
+  );
+  // Return the actual ID (could be existing row on conflict)
+  const existing = await selectFirstBy<{ id: string }>(
+    "SELECT id FROM calendars WHERE account_id = $1 AND remote_id = $2",
+    [calendar.accountId, calendar.remoteId],
+  );
+  return existing?.id ?? id;
+}
+
+export async function getCalendarsForAccount(accountId: string): Promise<DbCalendar[]> {
+  const db = await getDb();
+  return db.select<DbCalendar[]>(
+    "SELECT * FROM calendars WHERE account_id = $1 ORDER BY is_primary DESC, display_name ASC",
+    [accountId],
+  );
+}
+
+export async function getVisibleCalendars(accountId: string): Promise<DbCalendar[]> {
+  const db = await getDb();
+  return db.select<DbCalendar[]>(
+    "SELECT * FROM calendars WHERE account_id = $1 AND is_visible = 1 ORDER BY is_primary DESC, display_name ASC",
+    [accountId],
+  );
+}
+
+export async function setCalendarVisibility(calendarId: string, visible: boolean): Promise<void> {
+  const db = await getDb();
+  await db.execute(
+    "UPDATE calendars SET is_visible = $1, updated_at = unixepoch() WHERE id = $2",
+    [visible ? 1 : 0, calendarId],
+  );
+}
+
+export async function updateCalendarSyncToken(
+  calendarId: string,
+  syncToken: string | null,
+  ctag?: string | null,
+): Promise<void> {
+  const db = await getDb();
+  await db.execute(
+    "UPDATE calendars SET sync_token = $1, ctag = $2, updated_at = unixepoch() WHERE id = $3",
+    [syncToken, ctag ?? null, calendarId],
+  );
+}
+
+export async function deleteCalendarsForAccount(accountId: string): Promise<void> {
+  const db = await getDb();
+  await db.execute("DELETE FROM calendars WHERE account_id = $1", [accountId]);
+}
+
+export async function getCalendarById(calendarId: string): Promise<DbCalendar | null> {
+  return selectFirstBy<DbCalendar>(
+    "SELECT * FROM calendars WHERE id = $1",
+    [calendarId],
+  );
+}

--- a/src/services/email/types.ts
+++ b/src/services/email/types.ts
@@ -1,6 +1,6 @@
 import type { ParsedMessage } from "../gmail/messageParser";
 
-export type AccountProvider = "gmail_api" | "imap";
+export type AccountProvider = "gmail_api" | "imap" | "caldav";
 
 export interface EmailFolder {
   id: string;

--- a/src/services/gmail/syncManager.ts
+++ b/src/services/gmail/syncManager.ts
@@ -7,6 +7,9 @@ import { deleteAllMessagesForAccount } from "../db/messages";
 import { imapInitialSync, imapDeltaSync } from "../imap/imapSync";
 import { clearAllFolderSyncStates } from "../db/folderSyncState";
 import { ensureFreshToken } from "../oauth/oauthTokenManager";
+import { hasCalendarSupport, getCalendarProvider } from "../calendar/providerFactory";
+import { getVisibleCalendars, upsertCalendar, updateCalendarSyncToken } from "../db/calendars";
+import { upsertCalendarEvent, deleteEventByRemoteId } from "../db/calendarEvents";
 
 const SYNC_INTERVAL_MS = 60_000; // 60 seconds — delta syncs are lightweight (single API call when idle)
 
@@ -120,6 +123,80 @@ async function syncImapAccount(accountId: string): Promise<void> {
 }
 
 /**
+ * Sync calendars for a single account via the CalendarProvider abstraction.
+ * Discovers calendars, syncs events for each visible calendar, stores results in DB.
+ */
+async function syncCalendarForAccount(accountId: string): Promise<void> {
+  try {
+    const supported = await hasCalendarSupport(accountId);
+    if (!supported) return;
+
+    const provider = await getCalendarProvider(accountId);
+
+    // Discover/update calendars
+    const calendarInfos = await provider.listCalendars();
+    for (const cal of calendarInfos) {
+      await upsertCalendar({
+        accountId,
+        provider: provider.type,
+        remoteId: cal.remoteId,
+        displayName: cal.displayName,
+        color: cal.color,
+        isPrimary: cal.isPrimary,
+      });
+    }
+
+    // Sync events for each visible calendar
+    const visibleCals = await getVisibleCalendars(accountId);
+    for (const cal of visibleCals) {
+      try {
+        const syncResult = await provider.syncEvents(cal.remote_id, cal.sync_token ?? undefined);
+
+        // Upsert created/updated events
+        for (const event of [...syncResult.created, ...syncResult.updated]) {
+          await upsertCalendarEvent({
+            accountId,
+            googleEventId: event.remoteEventId,
+            summary: event.summary,
+            description: event.description,
+            location: event.location,
+            startTime: event.startTime,
+            endTime: event.endTime,
+            isAllDay: event.isAllDay,
+            status: event.status,
+            organizerEmail: event.organizerEmail,
+            attendeesJson: event.attendeesJson,
+            htmlLink: event.htmlLink,
+            calendarId: cal.id,
+            remoteEventId: event.remoteEventId,
+            etag: event.etag,
+            icalData: event.icalData,
+            uid: event.uid,
+          });
+        }
+
+        // Delete removed events
+        for (const remoteId of syncResult.deletedRemoteIds) {
+          await deleteEventByRemoteId(cal.id, remoteId);
+        }
+
+        // Update sync token
+        if (syncResult.newSyncToken || syncResult.newCtag) {
+          await updateCalendarSyncToken(cal.id, syncResult.newSyncToken, syncResult.newCtag);
+        }
+      } catch (err) {
+        console.warn(`[syncManager] Calendar sync failed for ${cal.display_name ?? cal.remote_id}:`, err);
+      }
+    }
+
+    // Emit event for UI update
+    window.dispatchEvent(new CustomEvent("velo-calendar-sync-done"));
+  } catch (err) {
+    console.warn(`[syncManager] Calendar sync failed for account ${accountId}:`, err);
+  }
+}
+
+/**
  * Run a sync for a single account (initial or delta).
  * Routes to Gmail or IMAP sync based on account provider.
  */
@@ -141,6 +218,13 @@ async function syncAccountInternal(accountId: string): Promise<void> {
 
     console.log(`[syncManager] Syncing account ${accountId} (provider=${account.provider}, history_id=${account.history_id ?? "null"})`);
 
+    if (account.provider === "caldav") {
+      // CalDAV-only accounts — skip email sync, only sync calendar
+      await syncCalendarForAccount(accountId);
+      statusCallback?.(accountId, "done");
+      return;
+    }
+
     if (account.provider === "imap") {
       await syncImapAccount(accountId);
     } else {
@@ -151,6 +235,11 @@ async function syncAccountInternal(accountId: string): Promise<void> {
     // Also emit for delta syncs that fell back to initial (recovery re-sync)
     // since those emit progress via statusCallback inside syncImapAccount.
     statusCallback?.(accountId, "done");
+
+    // Sync calendar alongside email (non-blocking — calendar errors don't affect email sync)
+    syncCalendarForAccount(accountId).catch((err) => {
+      console.warn(`[syncManager] Calendar sync error for ${accountId}:`, err);
+    });
   } catch (err) {
     const message = err instanceof Error ? err.message : "Unknown error";
     console.error(`[syncManager] Sync failed for account ${accountId}:`, message);

--- a/src/stores/accountStore.ts
+++ b/src/stores/accountStore.ts
@@ -7,6 +7,7 @@ export interface Account {
   displayName: string | null;
   avatarUrl: string | null;
   isActive: boolean;
+  provider?: string;
 }
 
 interface AccountState {

--- a/src/test/mocks/entities.mock.ts
+++ b/src/test/mocks/entities.mock.ts
@@ -117,6 +117,12 @@ export function createMockGmailAccount(
     oauth_client_id: null,
     oauth_client_secret: null,
     imap_username: null,
+    caldav_url: null,
+    caldav_username: null,
+    caldav_password: null,
+    caldav_principal_url: null,
+    caldav_home_url: null,
+    calendar_provider: null,
     ...overrides,
   };
 }
@@ -150,6 +156,12 @@ export function createMockImapAccount(
     oauth_client_id: null,
     oauth_client_secret: null,
     imap_username: null,
+    caldav_url: null,
+    caldav_username: null,
+    caldav_password: null,
+    caldav_principal_url: null,
+    caldav_home_url: null,
+    calendar_provider: null,
     ...overrides,
   };
 }
@@ -183,6 +195,12 @@ export function createMockDbAccount(
     oauth_client_id: null,
     oauth_client_secret: null,
     imap_username: null,
+    caldav_url: null,
+    caldav_username: null,
+    caldav_password: null,
+    caldav_principal_url: null,
+    caldav_home_url: null,
+    calendar_provider: null,
     ...overrides,
   };
 }


### PR DESCRIPTION
## Summary
- Add CalDAV protocol support (via `tsdav`) enabling calendar access for IMAP users and standalone CalDAV accounts (iCloud, Fastmail, Nextcloud, Zoho, GMX)
- Introduce `CalendarProvider` abstraction that unifies Google Calendar API and CalDAV behind a single interface with provider factory and caching
- Add multi-calendar support with per-calendar visibility toggles, color indicators, and a new CalendarList sidebar
- Add standalone CalDAV account setup wizard with auto-discovery for major providers
- Add IMAP account CalDAV add-on configuration in Settings
- Split Settings accounts section into separate Mail Accounts and Calendar Accounts lists
- Add EventDetailModal for viewing, editing, and deleting calendar events
- Integrate calendar sync into the background sync manager (60s interval)
- 118 new tests across 8 test files covering all new services and components

Closes #113

## Test plan
- [ ] Verify existing Gmail calendar still works (regression)
- [ ] Add standalone CalDAV account via Add Account wizard
- [ ] Configure CalDAV on an existing IMAP account via Settings
- [ ] Verify multi-calendar list with visibility toggles
- [ ] Create, view, edit, and delete events on a CalDAV calendar
- [ ] Verify background calendar sync runs alongside email sync
- [ ] Run full test suite: `npm run test`
- [ ] Type check: `npx tsc --noEmit`