### PR TITLE
feat: add local AI support via Ollama and LMStudio

### DIFF
--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -39,7 +39,7 @@
       }
     ],
     "security": {
-      "csp": "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; connect-src https://www.googleapis.com https://oauth2.googleapis.com https://api.anthropic.com https://api.openai.com https://generativelanguage.googleapis.com https://www.gravatar.com https://login.microsoftonline.com https://graph.microsoft.com https://api.login.yahoo.com; img-src 'self' data: https://www.gravatar.com https://lh3.googleusercontent.com https://*.googleusercontent.com; font-src 'self' data:; frame-src 'self'"
+      "csp": "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; connect-src https://www.googleapis.com https://oauth2.googleapis.com https://api.anthropic.com https://api.openai.com https://generativelanguage.googleapis.com https://www.gravatar.com https://login.microsoftonline.com https://graph.microsoft.com https://api.login.yahoo.com http://localhost:11434 http://localhost:1234 http://127.0.0.1:11434 http://127.0.0.1:1234; img-src 'self' data: https://www.gravatar.com https://lh3.googleusercontent.com https://*.googleusercontent.com; font-src 'self' data:; frame-src 'self'"
     },
     "trayIcon": null
   },

--- a/src/services/ai/providers/ollamaProvider.test.ts
+++ b/src/services/ai/providers/ollamaProvider.test.ts
@@ -1,0 +1,127 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+
+const mockCreate = vi.fn();
+
+vi.mock("openai", () => {
+  const MockOpenAI = vi.fn(function () {
+    return { chat: { completions: { create: mockCreate } } };
+  });
+  return { default: MockOpenAI };
+});
+
+import OpenAI from "openai";
+import { createOllamaProvider, clearOllamaProvider } from "./ollamaProvider";
+
+describe("ollamaProvider", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    clearOllamaProvider();
+  });
+
+  describe("createOllamaProvider", () => {
+    it("creates OpenAI client with custom baseURL and dummy API key", () => {
+      createOllamaProvider("http://localhost:11434", "llama3.2");
+
+      expect(OpenAI).toHaveBeenCalledWith({
+        baseURL: "http://localhost:11434/v1",
+        apiKey: "ollama",
+        dangerouslyAllowBrowser: true,
+      });
+    });
+
+    it("strips trailing slashes from server URL", () => {
+      createOllamaProvider("http://localhost:11434///", "llama3.2");
+
+      expect(OpenAI).toHaveBeenCalledWith({
+        baseURL: "http://localhost:11434/v1",
+        apiKey: "ollama",
+        dangerouslyAllowBrowser: true,
+      });
+    });
+  });
+
+  describe("complete", () => {
+    it("calls chat.completions.create with correct model and messages", async () => {
+      mockCreate.mockResolvedValue({
+        choices: [{ message: { content: "Hello!" } }],
+      });
+
+      const provider = createOllamaProvider("http://localhost:11434", "llama3.2");
+      const result = await provider.complete({
+        systemPrompt: "You are helpful",
+        userContent: "Hi",
+      });
+
+      expect(result).toBe("Hello!");
+      expect(mockCreate).toHaveBeenCalledWith({
+        model: "llama3.2",
+        max_tokens: 1024,
+        messages: [
+          { role: "system", content: "You are helpful" },
+          { role: "user", content: "Hi" },
+        ],
+      });
+    });
+
+    it("returns empty string when no content in response", async () => {
+      mockCreate.mockResolvedValue({ choices: [{ message: { content: null } }] });
+
+      const provider = createOllamaProvider("http://localhost:11434", "llama3.2");
+      const result = await provider.complete({
+        systemPrompt: "sys",
+        userContent: "user",
+      });
+
+      expect(result).toBe("");
+    });
+  });
+
+  describe("testConnection", () => {
+    it("returns true on successful completion", async () => {
+      mockCreate.mockResolvedValue({
+        choices: [{ message: { content: "hi" } }],
+      });
+
+      const provider = createOllamaProvider("http://localhost:11434", "llama3.2");
+      expect(await provider.testConnection()).toBe(true);
+    });
+
+    it("returns false when completion throws", async () => {
+      mockCreate.mockRejectedValue(new Error("Connection refused"));
+
+      const provider = createOllamaProvider("http://localhost:11434", "llama3.2");
+      expect(await provider.testConnection()).toBe(false);
+    });
+  });
+
+  describe("factory caching", () => {
+    it("reuses client for same url+model", () => {
+      createOllamaProvider("http://localhost:11434", "llama3.2");
+      createOllamaProvider("http://localhost:11434", "llama3.2");
+
+      expect(OpenAI).toHaveBeenCalledTimes(1);
+    });
+
+    it("creates new client when url changes", () => {
+      createOllamaProvider("http://localhost:11434", "llama3.2");
+      createOllamaProvider("http://localhost:1234", "llama3.2");
+
+      expect(OpenAI).toHaveBeenCalledTimes(2);
+    });
+
+    it("creates new client when model changes", () => {
+      createOllamaProvider("http://localhost:11434", "llama3.2");
+      createOllamaProvider("http://localhost:11434", "mistral");
+
+      expect(OpenAI).toHaveBeenCalledTimes(2);
+    });
+
+    it("creates new client after clearOllamaProvider", () => {
+      createOllamaProvider("http://localhost:11434", "llama3.2");
+      clearOllamaProvider();
+      createOllamaProvider("http://localhost:11434", "llama3.2");
+
+      expect(OpenAI).toHaveBeenCalledTimes(2);
+    });
+  });
+});

--- a/src/services/ai/providers/ollamaProvider.ts
+++ b/src/services/ai/providers/ollamaProvider.ts
@@ -1,0 +1,55 @@
+import OpenAI from "openai";
+import type { AiProviderClient, AiCompletionRequest } from "../types";
+
+let instance: OpenAI | null = null;
+let cachedKey: string | null = null;
+
+function getClient(serverUrl: string, model: string): OpenAI {
+  const cacheKey = `${serverUrl}|${model}`;
+  if (!instance || cachedKey !== cacheKey) {
+    instance = new OpenAI({
+      baseURL: `${serverUrl.replace(/\/+$/, "")}/v1`,
+      apiKey: "ollama",
+      dangerouslyAllowBrowser: true,
+    });
+    cachedKey = cacheKey;
+  }
+  return instance;
+}
+
+export function createOllamaProvider(serverUrl: string, model: string): AiProviderClient {
+  const client = getClient(serverUrl, model);
+
+  return {
+    async complete(req: AiCompletionRequest): Promise<string> {
+      const response = await client.chat.completions.create({
+        model,
+        max_tokens: req.maxTokens ?? 1024,
+        messages: [
+          { role: "system", content: req.systemPrompt },
+          { role: "user", content: req.userContent },
+        ],
+      });
+
+      return response.choices[0]?.message?.content ?? "";
+    },
+
+    async testConnection(): Promise<boolean> {
+      try {
+        await client.chat.completions.create({
+          model,
+          max_tokens: 10,
+          messages: [{ role: "user", content: "Say hi" }],
+        });
+        return true;
+      } catch {
+        return false;
+      }
+    },
+  };
+}
+
+export function clearOllamaProvider(): void {
+  instance = null;
+  cachedKey = null;
+}

--- a/src/services/ai/types.ts
+++ b/src/services/ai/types.ts
@@ -1,4 +1,4 @@
-export type AiProvider = "claude" | "openai" | "gemini";
+export type AiProvider = "claude" | "openai" | "gemini" | "ollama";
 
 export interface AiCompletionRequest {
   systemPrompt: string;
@@ -15,4 +15,5 @@ export const DEFAULT_MODELS: Record<AiProvider, string> = {
   claude: "claude-haiku-4-5-20251001",
   openai: "gpt-4o-mini",
   gemini: "gemini-2.0-flash",
+  ollama: "llama3.2",
 };


### PR DESCRIPTION
## Summary
- Added "Local AI (Ollama / LMStudio)" as a new AI provider option, allowing users to run AI features against a local server with no API key required
- Reuses the existing `openai` npm package with a custom `baseURL`, so no new dependencies are needed
- Settings UI shows Server URL and Model Name fields (instead of API key) when the local provider is selected
- Added localhost ports (11434 for Ollama, 1234 for LMStudio) to the CSP `connect-src`

Closes #98

## Test plan
- [x] `npx tsc --noEmit` passes
- [x] All 1387 tests pass (121 test files), including 10 new ollamaProvider tests and 6 new providerManager tests
- [ ] Manual: Select "Local AI (Ollama / LMStudio)" in Settings → AI → Provider, enter server URL, test connection against a running Ollama instance