### PR TITLE
fix: save IMAP/SMTP sent messages to local DB and Sent folder

### DIFF
--- a/src/services/emailActions.ts
+++ b/src/services/emailActions.ts
@@ -464,16 +464,23 @@ export function removeThreadLabel(
   });
 }
 
-export function sendEmail(
+export async function sendEmail(
   accountId: string,
   rawBase64Url: string,
   threadId?: string,
 ): Promise<ActionResult> {
-  return executeEmailAction(accountId, {
+  const result = await executeEmailAction(accountId, {
     type: "sendMessage",
     rawBase64Url,
     threadId,
   });
+
+  // Notify the UI to refresh (so sent message appears in Sent folder)
+  if (result.success) {
+    window.dispatchEvent(new Event("velo-sync-done"));
+  }
+
+  return result;
 }
 
 export function createDraft(

--- a/src/utils/emailBuilder.test.ts
+++ b/src/utils/emailBuilder.test.ts
@@ -26,6 +26,19 @@ describe("emailBuilder", () => {
     expect(decoded).toContain("<p>Hello World</p>");
   });
 
+  it("includes Date and Message-ID headers", () => {
+    const raw = buildRawEmail({
+      from: "sender@example.com",
+      to: ["to@example.com"],
+      subject: "Test",
+      htmlBody: "<p>Hi</p>",
+    });
+
+    const decoded = decodeBase64Url(raw);
+    expect(decoded).toMatch(/Date: .+/);
+    expect(decoded).toMatch(/Message-ID: <.+@example\.com>/);
+  });
+
   it("includes CC and BCC headers", () => {
     const raw = buildRawEmail({
       from: "sender@example.com",

--- a/src/utils/emailBuilder.ts
+++ b/src/utils/emailBuilder.ts
@@ -87,7 +87,18 @@ function extractInlineImages(html: string): { html: string; images: InlineImage[
   return { html: processed, images };
 }
 
+/**
+ * Generate a unique Message-ID for outgoing emails.
+ */
+function generateMessageId(from: string): string {
+  const timestamp = Date.now();
+  const random = Math.random().toString(36).slice(2, 10);
+  const domain = from.includes("@") ? from.split("@")[1] : "velomail.local";
+  return `<${timestamp}.${random}@${domain}>`;
+}
+
 export function buildRawEmail(draft: EmailDraft): string {
+  const messageId = generateMessageId(draft.from);
   const lines: string[] = [
     `From: ${draft.from}`,
     `To: ${draft.to.join(", ")}`,
@@ -100,6 +111,8 @@ export function buildRawEmail(draft: EmailDraft): string {
     lines.push(`Bcc: ${draft.bcc.join(", ")}`);
   }
 
+  lines.push(`Date: ${new Date().toUTCString()}`);
+  lines.push(`Message-ID: ${messageId}`);
   lines.push(`Subject: ${draft.subject}`);
   lines.push(`MIME-Version: 1.0`);
 


### PR DESCRIPTION
Emails sent via SMTP were not appearing in the Sent folder because:
1. The IMAP APPEND error was silently swallowed, making failures invisible
2. Even when APPEND succeeded, the local SQLite DB wasn't updated until
   the next 60s delta sync cycle
3. Missing Date and Message-ID headers in outgoing emails (RFC 2822
   requirement) could cause some IMAP servers to reject the APPEND

Changes:
- After SMTP send, immediately save the sent message to the local DB
  with the SENT label so it appears in the Sent folder view right away
- For replies, add the SENT label to the existing thread
- For new compositions, create a new thread with the SENT label
- Add Date and Message-ID headers to outgoing emails (RFC 2822)
- Upgrade IMAP APPEND error logging from console.warn to console.error
- Dispatch velo-sync-done event after send to trigger UI refresh

Fixes #121

https://claude.ai/code/session_01X9oPXxtAJR2nzcYEAMmC1J