### PR TITLE
fix: resolve context menu bugs on attachment preview and submenus

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -134,8 +134,10 @@ export default function App() {
   }, []);
 
   // Suppress default browser context menu globally (Tauri app should feel native)
+  // Elements with data-native-context-menu opt out so the browser menu is available
   useEffect(() => {
     const handler = (e: MouseEvent) => {
+      if ((e.target as HTMLElement).closest?.("[data-native-context-menu]")) return;
       e.preventDefault();
     };
     document.addEventListener("contextmenu", handler);

--- a/src/components/email/AttachmentList.tsx
+++ b/src/components/email/AttachmentList.tsx
@@ -210,7 +210,8 @@ export function AttachmentPreview({
       panelClassName="max-w-[90vw] max-h-[85vh] flex flex-col"
       renderHeader={header}
     >
-      <div className="flex-1 overflow-auto min-h-[200px] flex items-center justify-center p-4">
+      {/* Allow native right-click in preview (save image, copy, etc.) */}
+      <div className="flex-1 overflow-auto min-h-[200px] flex items-center justify-center p-4" data-native-context-menu>
         {loading && (
           <p className="text-sm text-text-tertiary">Loading preview...</p>
         )}

--- a/src/components/ui/ContextMenu.tsx
+++ b/src/components/ui/ContextMenu.tsx
@@ -28,8 +28,14 @@ export function ContextMenu({ items, position, onClose }: ContextMenuProps) {
   const [submenuOpenId, setSubmenuOpenId] = useState<string | null>(null);
   const submenuTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const [adjustedPosition, setAdjustedPosition] = useState(position);
+  // Track rects of items that have submenus for positioning
+  const itemRectsRef = useRef<Map<string, DOMRect>>(new Map());
 
-  useClickOutside(menuRef, onClose);
+  useClickOutside(menuRef, () => {
+    // Don't close if click is inside a submenu (which is portalled outside menuRef)
+    // The submenu handles its own outside clicks
+    if (!submenuOpenId) onClose();
+  });
 
   // Measure and clamp position to viewport
   useEffect(() => {
@@ -117,34 +123,54 @@ export function ContextMenu({ items, position, onClose }: ContextMenuProps) {
     return () => window.removeEventListener("keydown", handleKeyDown, true);
   }, [items, focusedIndex, onClose]);
 
-  const handleMouseEnter = useCallback((index: number, item: ContextMenuItem) => {
-    setFocusedIndex(index);
-
+  const cancelSubmenuTimer = useCallback(() => {
     if (submenuTimerRef.current) {
       clearTimeout(submenuTimerRef.current);
       submenuTimerRef.current = null;
     }
+  }, []);
+
+  const handleMouseEnter = useCallback((index: number, item: ContextMenuItem) => {
+    setFocusedIndex(index);
+    cancelSubmenuTimer();
 
     if (item.children && !item.disabled) {
       submenuTimerRef.current = setTimeout(() => {
         setSubmenuOpenId(item.id);
-      }, 150);
+      }, 100);
     } else {
+      // Longer delay before closing to allow mouse to travel to submenu
       submenuTimerRef.current = setTimeout(() => {
         setSubmenuOpenId(null);
-      }, 150);
+      }, 300);
     }
-  }, []);
+  }, [cancelSubmenuTimer]);
 
   const handleItemClick = useCallback((item: ContextMenuItem) => {
     if (item.disabled || item.separator) return;
     if (item.children) {
-      setSubmenuOpenId(item.id);
+      setSubmenuOpenId((prev) => prev === item.id ? null : item.id);
       return;
     }
     item.action?.();
     onClose();
   }, [onClose]);
+
+  // Close submenu when clicking outside both menu and submenu
+  useEffect(() => {
+    if (!submenuOpenId) return;
+    const handleMouseDown = (e: MouseEvent) => {
+      const target = e.target as Node;
+      // If click is inside the main menu, let normal handlers deal with it
+      if (menuRef.current?.contains(target)) return;
+      // If click is inside a submenu portal, let it handle itself
+      if ((target as HTMLElement).closest?.("[data-submenu-portal]")) return;
+      // Click is outside everything — close all
+      onClose();
+    };
+    document.addEventListener("mousedown", handleMouseDown);
+    return () => document.removeEventListener("mousedown", handleMouseDown);
+  }, [submenuOpenId, onClose]);
 
   // Clean up timers
   useEffect(() => {
@@ -153,133 +179,143 @@ export function ContextMenu({ items, position, onClose }: ContextMenuProps) {
     };
   }, []);
 
+  // Compute submenu anchor position from the parent item's rect
+  const openItem = submenuOpenId ? items.find((i) => i.id === submenuOpenId) : null;
+  const submenuAnchor = submenuOpenId ? itemRectsRef.current.get(submenuOpenId) : undefined;
+
   return (
-    <div
-      ref={menuRef}
-      role="menu"
-      className="fixed z-[100] bg-bg-primary border border-border-primary rounded-md shadow-lg py-1 min-w-[200px]"
-      style={{ left: adjustedPosition.x, top: adjustedPosition.y }}
-    >
-      {items.map((item, index) => {
-        if (item.separator) {
-          return (
-            <div
-              key={item.id}
-              role="separator"
-              className="my-1 border-t border-border-secondary"
-            />
-          );
-        }
-
-        const Icon = item.icon;
-        const isFocused = focusedIndex === index;
-        const hasSubmenu = !!item.children;
-        const isSubmenuOpen = submenuOpenId === item.id;
-
-        return (
-          <div key={item.id} className="relative">
-            <button
-              role="menuitem"
-              disabled={item.disabled}
-              onClick={() => handleItemClick(item)}
-              onMouseEnter={() => handleMouseEnter(index, item)}
-              className={`flex items-center gap-2 w-full px-3 py-1.5 text-xs text-left transition-colors ${
-                item.disabled
-                  ? "text-text-tertiary cursor-default"
-                  : item.danger
-                    ? `text-danger ${isFocused ? "bg-bg-hover" : ""}`
-                    : `text-text-primary ${isFocused ? "bg-bg-hover" : ""}`
-              }`}
-            >
-              {/* Checkmark or icon column */}
-              <span className="w-4 h-4 flex items-center justify-center shrink-0">
-                {item.checked != null ? (
-                  item.checked ? <Check size={12} /> : null
-                ) : Icon ? (
-                  <Icon size={12} />
-                ) : null}
-              </span>
-
-              <span className="flex-1">{item.label}</span>
-
-              {hasSubmenu && (
-                <ChevronRight size={12} className="text-text-tertiary shrink-0" />
-              )}
-
-              {item.shortcut && !hasSubmenu && (
-                <span className="text-text-tertiary ml-4 shrink-0">
-                  {item.shortcut}
-                </span>
-              )}
-            </button>
-
-            {/* Submenu */}
-            {hasSubmenu && isSubmenuOpen && item.children && (
-              <Submenu
-                items={item.children}
-                parentRef={menuRef}
-                itemIndex={index}
-                onClose={onClose}
+    <>
+      <div
+        ref={menuRef}
+        role="menu"
+        className="fixed z-[100] bg-bg-primary border border-border-primary rounded-md shadow-lg py-1 min-w-[200px]"
+        style={{ left: adjustedPosition.x, top: adjustedPosition.y }}
+      >
+        {items.map((item, index) => {
+          if (item.separator) {
+            return (
+              <div
+                key={item.id}
+                role="separator"
+                className="my-1 border-t border-border-secondary"
               />
-            )}
-          </div>
-        );
-      })}
-    </div>
+            );
+          }
+
+          const Icon = item.icon;
+          const isFocused = focusedIndex === index;
+          const hasSubmenu = !!item.children;
+          const isSubmenuOpen = submenuOpenId === item.id;
+
+          return (
+            <div key={item.id}>
+              <button
+                role="menuitem"
+                ref={(el) => {
+                  if (el && hasSubmenu) {
+                    itemRectsRef.current.set(item.id, el.getBoundingClientRect());
+                  }
+                }}
+                disabled={item.disabled}
+                onClick={() => handleItemClick(item)}
+                onMouseEnter={() => handleMouseEnter(index, item)}
+                className={`flex items-center gap-2 w-full px-3 py-1.5 text-xs text-left transition-colors ${
+                  item.disabled
+                    ? "text-text-tertiary cursor-default"
+                    : item.danger
+                      ? `text-danger ${isFocused || isSubmenuOpen ? "bg-bg-hover" : ""}`
+                      : `text-text-primary ${isFocused || isSubmenuOpen ? "bg-bg-hover" : ""}`
+                }`}
+              >
+                {/* Checkmark or icon column */}
+                <span className="w-4 h-4 flex items-center justify-center shrink-0">
+                  {item.checked != null ? (
+                    item.checked ? <Check size={12} /> : null
+                  ) : Icon ? (
+                    <Icon size={12} />
+                  ) : null}
+                </span>
+
+                <span className="flex-1">{item.label}</span>
+
+                {hasSubmenu && (
+                  <ChevronRight size={12} className="text-text-tertiary shrink-0" />
+                )}
+
+                {item.shortcut && !hasSubmenu && (
+                  <span className="text-text-tertiary ml-4 shrink-0">
+                    {item.shortcut}
+                  </span>
+                )}
+              </button>
+            </div>
+          );
+        })}
+      </div>
+
+      {/* Render submenu as a fixed-position sibling to avoid overflow clipping */}
+      {openItem?.children && submenuAnchor && (
+        <Submenu
+          items={openItem.children}
+          anchorRect={submenuAnchor}
+          onClose={onClose}
+          onMouseEnter={cancelSubmenuTimer}
+        />
+      )}
+    </>
   );
 }
 
 function Submenu({
   items,
-  parentRef,
-  itemIndex,
+  anchorRect,
   onClose,
+  onMouseEnter,
 }: {
   items: ContextMenuItem[];
-  parentRef: React.RefObject<HTMLDivElement | null>;
-  itemIndex: number;
+  anchorRect: DOMRect;
   onClose: () => void;
+  onMouseEnter?: () => void;
 }) {
   const submenuRef = useRef<HTMLDivElement | null>(null);
-  const [position, setPosition] = useState<{ left: string; top: string }>({ left: "100%", top: "0" });
+  const [position, setPosition] = useState<{ left: number; top: number }>({
+    left: anchorRect.right,
+    top: anchorRect.top,
+  });
 
   useEffect(() => {
-    const parent = parentRef.current;
     const submenu = submenuRef.current;
-    if (!parent || !submenu) return;
+    if (!submenu) return;
 
-    const parentRect = parent.getBoundingClientRect();
     const submenuRect = submenu.getBoundingClientRect();
     const vw = window.innerWidth;
     const vh = window.innerHeight;
 
-    // Check if submenu fits to the right
-    const fitsRight = parentRect.right + submenuRect.width <= vw;
-    const left = fitsRight ? "100%" : `-${submenuRect.width}px`;
-
-    // Vertical: align with the parent item, but clamp to viewport
-    const itemElements = parent.querySelectorAll('[role="menuitem"], [role="separator"]');
-    const itemEl = itemElements[itemIndex];
-    let top = "0";
-    if (itemEl) {
-      const itemRect = itemEl.getBoundingClientRect();
-      const submenuTop = itemRect.top - parentRect.top;
-      const clampedTop = Math.min(
-        submenuTop,
-        vh - parentRect.top - submenuRect.height - 4,
-      );
-      top = `${Math.max(0, clampedTop)}px`;
+    // Prefer right side, fall back to left
+    let left = anchorRect.right;
+    if (left + submenuRect.width > vw) {
+      left = anchorRect.left - submenuRect.width;
     }
+    if (left < 4) left = 4;
+
+    // Align top with anchor, clamp to viewport
+    let top = anchorRect.top;
+    if (top + submenuRect.height > vh) {
+      top = vh - submenuRect.height - 4;
+    }
+    if (top < 4) top = 4;
 
     setPosition({ left, top });
-  }, [parentRef, itemIndex]);
+  }, [anchorRect]);
 
   return (
     <div
       ref={submenuRef}
       role="menu"
-      className="absolute z-[101] bg-bg-primary border border-border-primary rounded-md shadow-lg py-1 min-w-[180px]"
+      data-submenu-portal
+      className="fixed z-[101] bg-bg-primary border border-border-primary rounded-md shadow-lg py-1 min-w-[180px]"
       style={{ left: position.left, top: position.top }}
+      onMouseEnter={onMouseEnter}
     >
       {items.map((item) => {
         const Icon = item.icon;

--- a/src/components/ui/Modal.tsx
+++ b/src/components/ui/Modal.tsx
@@ -39,7 +39,7 @@ export function Modal({
 
   return createPortal(
     <CSSTransition in={isOpen} timeout={150} classNames="modal" unmountOnExit nodeRef={nodeRef}>
-      <div ref={nodeRef} className={`fixed inset-0 ${zIndex} flex items-center justify-center`}>
+      <div ref={nodeRef} className={`fixed inset-0 ${zIndex} flex items-center justify-center`} onContextMenu={(e) => e.stopPropagation()}>
         <div className="absolute inset-0 bg-black/20 glass-backdrop" onClick={onClose} />
         <div
           className={`relative bg-bg-primary border border-border-primary rounded-lg glass-modal ${width}${panelClassName ? ` ${panelClassName}` : ""}`}


### PR DESCRIPTION
## Summary
- Fix attachment preview modal incorrectly showing the message context menu on right-click (React portal event bubbling)
- Enable native browser context menu in attachment preview for save image/copy actions
- Fix context menu submenus (Apply Label, Move to Category, Quick Steps) not opening by rendering them as fixed-position elements instead of absolute-positioned children

## Test plan
- [ ] Right-click an image in the attachment preview modal — should show browser native menu (Save Image, Copy, etc.), not the message context menu
- [ ] Right-click on an email item — context menu opens with all items working
- [ ] Hover or click "Apply Label" / "Move to Category" / "Quick Steps" in thread context menu — submenu opens and stays open while interacting
- [ ] Keyboard navigation (arrow keys) still works for context menu and submenus
- [ ] Clicking outside the context menu or submenu closes everything