### PR TITLE
fix: use Tauri native fetch for local AI to bypass CORS

### DIFF
--- a/src/services/ai/providers/ollamaProvider.test.ts
+++ b/src/services/ai/providers/ollamaProvider.test.ts
@@ -9,6 +9,10 @@ vi.mock("openai", () => {
   return { default: MockOpenAI };
 });
 
+vi.mock("@tauri-apps/plugin-http", () => ({
+  fetch: vi.fn(),
+}));
+
 import OpenAI from "openai";
 import { createOllamaProvider, clearOllamaProvider } from "./ollamaProvider";
 
@@ -25,7 +29,7 @@ describe("ollamaProvider", () => {
       expect(OpenAI).toHaveBeenCalledWith({
         baseURL: "http://localhost:11434/v1",
         apiKey: "ollama",
-        dangerouslyAllowBrowser: true,
+        fetch: expect.any(Function),
       });
     });
 
@@ -35,7 +39,7 @@ describe("ollamaProvider", () => {
       expect(OpenAI).toHaveBeenCalledWith({
         baseURL: "http://localhost:11434/v1",
         apiKey: "ollama",
-        dangerouslyAllowBrowser: true,
+        fetch: expect.any(Function),
       });
     });
   });

--- a/src/services/ai/providers/ollamaProvider.ts
+++ b/src/services/ai/providers/ollamaProvider.ts
@@ -1,4 +1,5 @@
 import OpenAI from "openai";
+import { fetch } from "@tauri-apps/plugin-http";
 import type { AiProviderClient, AiCompletionRequest } from "../types";
 
 let instance: OpenAI | null = null;
@@ -10,7 +11,7 @@ function getClient(serverUrl: string, model: string): OpenAI {
     instance = new OpenAI({
       baseURL: `${serverUrl.replace(/\/+$/, "")}/v1`,
       apiKey: "ollama",
-      dangerouslyAllowBrowser: true,
+      fetch,
     });
     cachedKey = cacheKey;
   }


### PR DESCRIPTION
## Summary
- Replace `dangerouslyAllowBrowser: true` with Tauri's native `fetch` from `@tauri-apps/plugin-http` in the Ollama/LMStudio provider
- Tauri's fetch runs in Rust, completely bypassing browser CORS preflight requests that local AI servers can't handle
- Update tests to mock `@tauri-apps/plugin-http` and assert the new `fetch` option

Closes #127

## Test plan
- [x] `ollamaProvider.test.ts` — all 10 tests pass
- [x] Full test suite — all 130 files, 1466 tests pass
- [ ] Manual: connect to LMStudio/Ollama and verify connection test + completions work