### PR TITLE
feat: fix release workflow to upload assets to existing release

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -15,6 +15,7 @@ jobs:
     outputs:
       release_created: ${{ steps.release.outputs.release_created }}
       tag_name: ${{ steps.release.outputs.tag_name }}
+      release_id: ${{ steps.release.outputs.id }}
     steps:
       - uses: googleapis/release-please-action@v4
         id: release
@@ -27,4 +28,5 @@ jobs:
     uses: ./.github/workflows/release.yml
     with:
       tag_name: ${{ needs.release-please.outputs.tag_name }}
+      release_id: ${{ needs.release-please.outputs.release_id }}
     secrets: inherit

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,6 +7,10 @@ on:
         description: "Release tag (e.g. velo-v0.4.3)"
         type: string
         required: false
+      release_id:
+        description: "Existing GitHub release ID to upload assets to"
+        type: string
+        required: false
   workflow_dispatch:
   release:
     types: [created]
@@ -72,7 +76,21 @@ jobs:
 
       - run: npm ci
 
-      - uses: tauri-apps/tauri-action@v0
+      - name: Build and upload to existing release
+        if: inputs.release_id
+        uses: tauri-apps/tauri-action@v0
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
+          TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
+        with:
+          releaseId: ${{ inputs.release_id }}
+          updaterJsonKeepUniversal: true
+          args: ${{ matrix.args }}
+
+      - name: Build and create release
+        if: ${{ !inputs.release_id }}
+        uses: tauri-apps/tauri-action@v0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
@@ -138,8 +156,24 @@ jobs:
             -s -k "$KEYCHAIN_PASSWORD" $KEYCHAIN_PATH
           security list-keychain -d user -s $KEYCHAIN_PATH
 
+      - name: Build and upload (signed + notarized)
+        if: steps.signing-check.outputs.has_signing == 'true' && inputs.release_id
+        uses: tauri-apps/tauri-action@v0
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          APPLE_SIGNING_IDENTITY: ${{ secrets.APPLE_SIGNING_IDENTITY }}
+          APPLE_ID: ${{ secrets.APPLE_ID }}
+          APPLE_PASSWORD: ${{ secrets.APPLE_PASSWORD }}
+          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+          TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
+          TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
+        with:
+          releaseId: ${{ inputs.release_id }}
+          updaterJsonKeepUniversal: true
+          args: --target universal-apple-darwin
+
       - name: Build and release (signed + notarized)
-        if: steps.signing-check.outputs.has_signing == 'true'
+        if: steps.signing-check.outputs.has_signing == 'true' && !inputs.release_id
         uses: tauri-apps/tauri-action@v0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -158,8 +192,20 @@ jobs:
           updaterJsonKeepUniversal: true
           args: --target universal-apple-darwin
 
+      - name: Build and upload (unsigned)
+        if: steps.signing-check.outputs.has_signing != 'true' && inputs.release_id
+        uses: tauri-apps/tauri-action@v0
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
+          TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
+        with:
+          releaseId: ${{ inputs.release_id }}
+          updaterJsonKeepUniversal: true
+          args: --target universal-apple-darwin
+
       - name: Build and release (unsigned)
-        if: steps.signing-check.outputs.has_signing != 'true'
+        if: steps.signing-check.outputs.has_signing != 'true' && !inputs.release_id
         uses: tauri-apps/tauri-action@v0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
- Passes `releaseId` from release-please to `tauri-action` so assets are uploaded to the existing release instead of trying to create a duplicate
- Splits tauri-action steps into `releaseId` (existing release) vs `tagName` (new release) paths with conditional `if` guards
- Fixes macOS, Ubuntu, and Windows builds all failing with "Resource not accessible by integration"

## Test plan
- [ ] Merge to main and verify release-please creates a release PR for v0.5.0
- [ ] Merge the release PR and verify all 3 platform builds upload assets successfully