### PR TITLE
fix: align release pipeline version sync for SRPM and Homebrew

### DIFF
--- a/.github/workflows/packaging.yml
+++ b/.github/workflows/packaging.yml
@@ -68,6 +68,8 @@ jobs:
       - name: Set up RPM build environment
         run: |
           rpmdev-setuptree
+          # Ensure spec version matches the actual release version
+          sed -i "s/^%global app_version.*/%global app_version ${{ env.APP_VERSION }}/" velo.spec
           cp velo.spec ~/rpmbuild/SPECS/
           cp "/tmp/velo-${{ env.APP_VERSION }}.tar.gz" ~/rpmbuild/SOURCES/
 

--- a/.github/workflows/update-homebrew.yml
+++ b/.github/workflows/update-homebrew.yml
@@ -23,23 +23,29 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           if [ -n "${{ inputs.tag_name }}" ]; then
-            VERSION="${{ inputs.tag_name }}"
+            # Called from release-please workflow — tag_name is the full tag (e.g. velo-v0.4.12)
+            TAG="${{ inputs.tag_name }}"
           elif [ -n "${{ inputs.version }}" ]; then
-            VERSION="${{ inputs.version }}"
+            # Manual dispatch with a version — look up the actual tag from releases
+            TAG=$(gh release list --repo ${{ github.repository }} --json tagName -q "[.[] | select(.tagName | test(\"${{ inputs.version }}\"))][0].tagName")
+            if [ -z "$TAG" ]; then
+              TAG="velo-v${{ inputs.version }}"
+            fi
           else
+            # Manual dispatch without version — use latest release
             TAG=$(gh release view --repo ${{ github.repository }} --json tagName -q '.tagName')
-            VERSION="${TAG##*v}"
           fi
-          # Strip any prefix up to and including 'v' (handles velo-v0.4.3, v0.4.3, etc.)
-          VERSION="${VERSION##*v}"
-          echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
-          echo "Using version: ${VERSION}"
+          BARE_VERSION="${TAG##*v}"
+          echo "version=${BARE_VERSION}" >> "$GITHUB_OUTPUT"
+          echo "tag=${TAG}" >> "$GITHUB_OUTPUT"
+          echo "Using version: ${BARE_VERSION} (tag: ${TAG})"
 
       - name: Wait for DMG and compute SHA256
         id: sha
         run: |
           VERSION="${{ steps.version.outputs.version }}"
-          DMG_URL="https://github.com/${{ github.repository }}/releases/download/v${VERSION}/Velo_${VERSION}_universal.dmg"
+          TAG="${{ steps.version.outputs.tag }}"
+          DMG_URL="https://github.com/${{ github.repository }}/releases/download/${TAG}/Velo_${VERSION}_universal.dmg"
 
           echo "Downloading DMG from: ${DMG_URL}"
           for i in 1 2 3 4 5; do
@@ -78,7 +84,7 @@ jobs:
             version "${VERSION}"
             sha256 "${SHA256}"
 
-            url "https://github.com/avihaymenahem/velo/releases/download/v#{version}/Velo_#{version}_universal.dmg",
+            url "https://github.com/avihaymenahem/velo/releases/download/velo-v#{version}/Velo_#{version}_universal.dmg",
                 verified: "github.com/avihaymenahem/velo/"
 
             name "Velo"

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -6776,7 +6776,7 @@ checksum = "f1bddf1187be692e79c5ffeab891132dfb0f236ed36a43c7ed39f1165ee20191"
 
 [[package]]
 name = "velo"
-version = "0.4.4"
+version = "0.4.12"
 dependencies = [
  "async-imap",
  "base64 0.22.1",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "velo"
-# x-release-please-version
-version = "0.4.4"
+version = "0.4.12" # x-release-please-version
 description = "Email at the speed of thought"
 authors = ["Avihay"]
 license = "Apache-2.0"

--- a/velo.spec
+++ b/velo.spec
@@ -1,6 +1,7 @@
 %global app_name velo
-# x-release-please-version
-%global app_version 0.4.11
+# x-release-please-start-version
+%global app_version 0.4.12
+# x-release-please-end
 %global app_release 1
 
 Name:    %{app_name}


### PR DESCRIPTION
## Summary
- **SRPM build fix**: `velo.spec` version was stuck at 0.4.11 because the `# x-release-please-version` annotation on a preceding line doesn't work with the generic updater. Switched to block annotations (`x-release-please-start-version` / `x-release-please-end`) and added a `sed` safety net in the packaging workflow that injects the version from `tauri.conf.json` at build time.
- **Homebrew fix**: DMG download URL used `v0.4.12` but the actual release tag is `velo-v0.4.12`. Now uses the full tag from release-please outputs. Also fixed the cask template URL for `brew install` users.
- **Cargo.toml sync**: Was stuck at 0.4.4 — same annotation issue. Moved to inline format which works in TOML.

## Test plan
- [ ] Merge and trigger a new release — verify SRPM and Homebrew jobs succeed
- [ ] Manually dispatch `update-homebrew.yml` for 0.4.12 to backfill the Homebrew tap