### PR TITLE
fix: add TCP timeouts and keepalive to IMAP client

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2343,7 +2343,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2",
+ "socket2 0.6.2",
  "system-configuration",
  "tokio",
  "tower-service",
@@ -2729,7 +2729,7 @@ dependencies = [
  "nom 8.0.0",
  "percent-encoding",
  "quoted_printable",
- "socket2",
+ "socket2 0.6.2",
  "tokio",
  "tokio-native-tls",
  "url",
@@ -4112,7 +4112,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash",
  "rustls",
- "socket2",
+ "socket2 0.6.2",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -4149,7 +4149,7 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2",
+ "socket2 0.6.2",
  "tracing",
  "windows-sys 0.60.2",
 ]
@@ -5100,6 +5100,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 dependencies = [
  "serde",
+]
+
+[[package]]
+name = "socket2"
+version = "0.5.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e22376abed350d73dd1cd119b57ffccad95b4e585a7cda43e286245ce23c0678"
+dependencies = [
+ "libc",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -6297,7 +6307,7 @@ dependencies = [
  "libc",
  "mio",
  "pin-project-lite",
- "socket2",
+ "socket2 0.6.2",
  "tokio-macros",
  "windows-sys 0.61.2",
 ]
@@ -6776,7 +6786,7 @@ checksum = "f1bddf1187be692e79c5ffeab891132dfb0f236ed36a43c7ed39f1165ee20191"
 
 [[package]]
 name = "velo"
-version = "0.4.12"
+version = "0.4.13"
 dependencies = [
  "async-imap",
  "base64 0.22.1",
@@ -6788,6 +6798,7 @@ dependencies = [
  "reqwest 0.12.28",
  "serde",
  "serde_json",
+ "socket2 0.5.10",
  "tauri",
  "tauri-build",
  "tauri-plugin-autostart",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -43,6 +43,7 @@ mail-parser = "0.9"
 lettre = { version = "0.11", default-features = false, features = ["smtp-transport", "tokio1-native-tls", "builder"] }
 base64 = "0.22"
 utf7-imap = "0.3"
+socket2 = "0.5"
 reqwest = { version = "0.12", default-features = false, features = ["native-tls", "json"] }
 
 [target.'cfg(windows)'.dependencies]


### PR DESCRIPTION
## Summary
- Add TCP connect (30s), TLS handshake (30s), auth (30s), command (30s), fetch (120s), and search (60s) timeouts to all IMAP operations — previously relied on OS defaults (60-120s)
- Configure TCP keepalive (60s idle + 60s probe interval) and `TCP_NODELAY` on all connections via `socket2` to prevent firewalls/NATs from silently dropping idle connections
- Wrap the entire connect+auth sequence in a 60s overall timeout with descriptive error messages

Closes #147

## Test plan
- [x] `cargo build` compiles cleanly
- [x] `cargo test` — 6/6 Rust tests pass
- [x] `npm run test` — 130 test files, 1471 tests pass (no TS changes)
- [ ] Manual: test with a valid IMAP account to confirm normal sync works
- [ ] Manual: test with unreachable server to verify 30s timeout fires (not 60-120s OS default)