### PR TITLE
fix: resolve local AI (Ollama/LMStudio) connection failures

### DIFF
--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -62,7 +62,19 @@
     "global-shortcut:allow-is-registered",
     "deep-link:default",
     "core:window:allow-set-badge-count",
-    "http:default",
+    {
+      "identifier": "http:default",
+      "allow": [
+        { "url": "http://localhost:*" },
+        { "url": "http://localhost:*/*" },
+        { "url": "http://127.0.0.1:*" },
+        { "url": "http://127.0.0.1:*/*" },
+        { "url": "http://0.0.0.0:*" },
+        { "url": "http://0.0.0.0:*/*" },
+        { "url": "https://*" },
+        { "url": "https://*/*" }
+      ]
+    },
     "updater:default",
     "process:allow-restart",
     "os:default"

--- a/src/services/ai/providers/ollamaProvider.test.ts
+++ b/src/services/ai/providers/ollamaProvider.test.ts
@@ -29,6 +29,7 @@ describe("ollamaProvider", () => {
       expect(OpenAI).toHaveBeenCalledWith({
         baseURL: "http://localhost:11434/v1",
         apiKey: "ollama",
+        dangerouslyAllowBrowser: true,
         fetch: expect.any(Function),
       });
     });
@@ -39,6 +40,7 @@ describe("ollamaProvider", () => {
       expect(OpenAI).toHaveBeenCalledWith({
         baseURL: "http://localhost:11434/v1",
         apiKey: "ollama",
+        dangerouslyAllowBrowser: true,
         fetch: expect.any(Function),
       });
     });

--- a/src/services/ai/providers/ollamaProvider.ts
+++ b/src/services/ai/providers/ollamaProvider.ts
@@ -11,6 +11,7 @@ function getClient(serverUrl: string, model: string): OpenAI {
     instance = new OpenAI({
       baseURL: `${serverUrl.replace(/\/+$/, "")}/v1`,
       apiKey: "ollama",
+      dangerouslyAllowBrowser: true,
       fetch,
     });
     cachedKey = cacheKey;


### PR DESCRIPTION
## Summary
- Add `dangerouslyAllowBrowser: true` to Ollama provider's OpenAI SDK constructor — the SDK was throwing during construction in Tauri's WebView before any HTTP request was made
- Add URL scope to Tauri HTTP plugin capabilities — `http:default` grants fetch commands but blocks all URLs without explicit scope patterns
- Allow localhost/127.0.0.1/0.0.0.0 on any port (covers Ollama :11434, LM Studio :1234, custom ports) and all HTTPS origins (cloud APIs, unsubscribe)

## Test plan
- [x] Unit tests updated and passing
- [x] Configure LM Studio on `http://127.0.0.1:1234` in Settings → AI → Local AI
- [x] Verify "Test Connection" shows "Connected!"
- [x] Verify AI features (summarize, smart replies, etc.) work with local model
- [x] Verify cloud AI providers (Claude, OpenAI, Gemini) still work

Closes #145