### PR TITLE
feat: accept self-signed certificates for IMAP/SMTP

### DIFF
--- a/src-tauri/src/imap/types.rs
+++ b/src-tauri/src/imap/types.rs
@@ -8,6 +8,8 @@ pub struct ImapConfig {
     pub username: String,
     pub password: String, // plaintext password or OAuth2 access token
     pub auth_method: String, // "password" or "oauth2"
+    #[serde(default)]
+    pub accept_invalid_certs: bool,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/src-tauri/src/smtp/types.rs
+++ b/src-tauri/src/smtp/types.rs
@@ -8,6 +8,8 @@ pub struct SmtpConfig {
     pub username: String,
     pub password: String,    // plaintext password or OAuth2 access token
     pub auth_method: String, // "password" or "oauth2"
+    #[serde(default)]
+    pub accept_invalid_certs: bool,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/src/components/accounts/AddImapAccount.tsx
+++ b/src/components/accounts/AddImapAccount.tsx
@@ -46,6 +46,7 @@ interface FormState {
   password: string;
   smtpPassword: string;
   samePassword: boolean;
+  acceptInvalidCerts: boolean;
   // OAuth2 fields
   authMode: AuthMode;
   oauthProvider: string | null;
@@ -70,6 +71,7 @@ const initialFormState: FormState = {
   password: "",
   smtpPassword: "",
   samePassword: true,
+  acceptInvalidCerts: false,
   authMode: "password",
   oauthProvider: null,
   oauthClientId: "",
@@ -153,6 +155,7 @@ export function AddImapAccount({
         smtpHost: result.settings.smtpHost,
         smtpPort: result.settings.smtpPort,
         smtpSecurity: result.settings.smtpSecurity,
+        acceptInvalidCerts: result.acceptInvalidCerts ?? false,
         // Auto-select OAuth2 if it's the only option (e.g. Outlook)
         authMode: result.authMethods[0] === "oauth2" ? "oauth2" : prev.authMode,
         oauthProvider: result.oauthProviderId ?? null,
@@ -291,6 +294,7 @@ export function AddImapAccount({
             username: form.imapUsername || (isOAuth ? (form.oauthEmail ?? form.email) : form.email),
             password: isOAuth ? (form.oauthAccessToken ?? "") : form.password,
             auth_method: isOAuth ? "oauth2" : "password",
+            accept_invalid_certs: form.acceptInvalidCerts,
           },
         },
       );
@@ -319,6 +323,7 @@ export function AddImapAccount({
             username: form.imapUsername || (isOAuth ? (form.oauthEmail ?? form.email) : form.email),
             password: smtpPassword,
             auth_method: isOAuth ? "oauth2" : "password",
+            accept_invalid_certs: form.acceptInvalidCerts,
           },
         },
       );
@@ -364,6 +369,7 @@ export function AddImapAccount({
           oauthClientId: form.oauthClientId.trim(),
           oauthClientSecret: form.oauthClientSecret.trim() || null,
           imapUsername,
+          acceptInvalidCerts: form.acceptInvalidCerts,
         });
       } else {
         await insertImapAccount({
@@ -380,6 +386,7 @@ export function AddImapAccount({
           authMethod: "password",
           password: form.samePassword ? form.password : form.password,
           imapUsername,
+          acceptInvalidCerts: form.acceptInvalidCerts,
         });
       }
 
@@ -699,6 +706,24 @@ export function AddImapAccount({
           </select>
         </div>
       </div>
+      <div className="flex items-center gap-2">
+        <input
+          id="accept-invalid-certs"
+          type="checkbox"
+          checked={form.acceptInvalidCerts}
+          onChange={(e) => updateForm("acceptInvalidCerts", e.target.checked)}
+          className="rounded border-border-primary text-accent focus:ring-accent"
+        />
+        <label
+          htmlFor="accept-invalid-certs"
+          className="text-sm text-text-secondary"
+        >
+          Accept self-signed certificates
+        </label>
+      </div>
+      <p className="text-xs text-text-tertiary -mt-2 ml-6">
+        Enable for local mail bridges like ProtonMail Bridge
+      </p>
     </div>
   );
 

--- a/src/services/db/accounts.test.ts
+++ b/src/services/db/accounts.test.ts
@@ -171,6 +171,7 @@ describe("accounts", () => {
         "password",
         "enc:my-app-password", // encrypted
         null, // imap_username
+        0, // accept_invalid_certs
       ]);
     });
 

--- a/src/services/db/accounts.ts
+++ b/src/services/db/accounts.ts
@@ -33,6 +33,7 @@ export interface DbAccount {
   caldav_principal_url: string | null;
   caldav_home_url: string | null;
   calendar_provider: string | null;
+  accept_invalid_certs: number;
 }
 
 async function decryptAccountTokens(account: DbAccount): Promise<DbAccount> {
@@ -193,12 +194,13 @@ export async function insertImapAccount(account: {
   authMethod: string;
   password: string;
   imapUsername?: string | null;
+  acceptInvalidCerts?: boolean;
 }): Promise<void> {
   const db = await getDb();
   const encPassword = await encryptValue(account.password);
   await db.execute(
-    `INSERT INTO accounts (id, email, display_name, avatar_url, access_token, refresh_token, provider, imap_host, imap_port, imap_security, smtp_host, smtp_port, smtp_security, auth_method, imap_password, imap_username)
-     VALUES ($1, $2, $3, $4, NULL, NULL, 'imap', $5, $6, $7, $8, $9, $10, $11, $12, $13)`,
+    `INSERT INTO accounts (id, email, display_name, avatar_url, access_token, refresh_token, provider, imap_host, imap_port, imap_security, smtp_host, smtp_port, smtp_security, auth_method, imap_password, imap_username, accept_invalid_certs)
+     VALUES ($1, $2, $3, $4, NULL, NULL, 'imap', $5, $6, $7, $8, $9, $10, $11, $12, $13, $14)`,
     [
       account.id,
       account.email,
@@ -213,6 +215,7 @@ export async function insertImapAccount(account: {
       account.authMethod,
       encPassword,
       account.imapUsername || null,
+      account.acceptInvalidCerts ? 1 : 0,
     ],
   );
 }
@@ -292,6 +295,7 @@ export async function insertOAuthImapAccount(account: {
   oauthClientId: string;
   oauthClientSecret: string | null;
   imapUsername?: string | null;
+  acceptInvalidCerts?: boolean;
 }): Promise<void> {
   const db = await getDb();
   const encAccessToken = await encryptValue(account.accessToken);
@@ -300,8 +304,8 @@ export async function insertOAuthImapAccount(account: {
     ? await encryptValue(account.oauthClientSecret)
     : null;
   await db.execute(
-    `INSERT INTO accounts (id, email, display_name, avatar_url, access_token, refresh_token, token_expires_at, provider, imap_host, imap_port, imap_security, smtp_host, smtp_port, smtp_security, auth_method, imap_password, oauth_provider, oauth_client_id, oauth_client_secret, imap_username)
-     VALUES ($1, $2, $3, $4, $5, $6, $7, 'imap', $8, $9, $10, $11, $12, $13, 'oauth2', NULL, $14, $15, $16, $17)`,
+    `INSERT INTO accounts (id, email, display_name, avatar_url, access_token, refresh_token, token_expires_at, provider, imap_host, imap_port, imap_security, smtp_host, smtp_port, smtp_security, auth_method, imap_password, oauth_provider, oauth_client_id, oauth_client_secret, imap_username, accept_invalid_certs)
+     VALUES ($1, $2, $3, $4, $5, $6, $7, 'imap', $8, $9, $10, $11, $12, $13, 'oauth2', NULL, $14, $15, $16, $17, $18)`,
     [
       account.id,
       account.email,
@@ -320,6 +324,7 @@ export async function insertOAuthImapAccount(account: {
       account.oauthClientId,
       encClientSecret,
       account.imapUsername || null,
+      account.acceptInvalidCerts ? 1 : 0,
     ],
   );
 }

--- a/src/services/db/migrations.ts
+++ b/src/services/db/migrations.ts
@@ -770,6 +770,11 @@ const MIGRATIONS = [
       CREATE INDEX idx_smart_label_rules_account ON smart_label_rules(account_id);
     `,
   },
+  {
+    version: 23,
+    description: "Accept self-signed certificates for IMAP/SMTP",
+    sql: `ALTER TABLE accounts ADD COLUMN accept_invalid_certs INTEGER DEFAULT 0;`,
+  },
 ];
 
 /**

--- a/src/services/imap/autoDiscovery.test.ts
+++ b/src/services/imap/autoDiscovery.test.ts
@@ -86,6 +86,19 @@ describe("findWellKnownProvider", () => {
     expect(result).not.toBeNull();
     expect(result!.settings.imapHost).toBe("127.0.0.1");
     expect(result!.settings.imapPort).toBe(1143);
+    expect(result!.acceptInvalidCerts).toBe(true);
+  });
+
+  it("returns acceptInvalidCerts true for proton.me", () => {
+    const result = findWellKnownProvider("proton.me");
+    expect(result).not.toBeNull();
+    expect(result!.acceptInvalidCerts).toBe(true);
+  });
+
+  it("does not set acceptInvalidCerts for regular providers", () => {
+    const result = findWellKnownProvider("outlook.com");
+    expect(result).not.toBeNull();
+    expect(result!.acceptInvalidCerts).toBeUndefined();
   });
 
   it("returns null for unknown domain", () => {

--- a/src/services/imap/autoDiscovery.ts
+++ b/src/services/imap/autoDiscovery.ts
@@ -17,6 +17,8 @@ interface WellKnownProvider {
   authMethods: AuthMethod[];
   /** OAuth provider ID (matches oauth/providers.ts registry) */
   oauthProviderId?: string;
+  /** Accept self-signed TLS certificates (for local mail bridges) */
+  acceptInvalidCerts?: boolean;
 }
 
 const wellKnownProviders: WellKnownProvider[] = [
@@ -112,6 +114,7 @@ const wellKnownProviders: WellKnownProvider[] = [
       smtpSecurity: "starttls",
     },
     authMethods: ["password"],
+    acceptInvalidCerts: true,
   },
   {
     domains: ["gmx.com", "gmx.net", "gmx.de"],
@@ -166,6 +169,7 @@ export interface WellKnownProviderResult {
   settings: ServerSettings;
   authMethods: AuthMethod[];
   oauthProviderId?: string;
+  acceptInvalidCerts?: boolean;
 }
 
 /**
@@ -182,6 +186,7 @@ export function findWellKnownProvider(
         settings: { ...provider.settings },
         authMethods: provider.authMethods,
         oauthProviderId: provider.oauthProviderId,
+        acceptInvalidCerts: provider.acceptInvalidCerts,
       };
     }
   }

--- a/src/services/imap/imapConfigBuilder.test.ts
+++ b/src/services/imap/imapConfigBuilder.test.ts
@@ -14,6 +14,7 @@ describe("buildImapConfig", () => {
       username: "user@example.com",
       password: "secret123",
       auth_method: "password",
+      accept_invalid_certs: false,
     });
   });
 
@@ -90,6 +91,7 @@ describe("buildSmtpConfig", () => {
       username: "user@example.com",
       password: "secret123",
       auth_method: "password",
+      accept_invalid_certs: false,
     });
   });
 
@@ -141,5 +143,23 @@ describe("imap_username override", () => {
     const account = createMockDbAccount({ imap_username: "" as string | null });
     const config = buildImapConfig(account);
     expect(config.username).toBe("user@example.com");
+  });
+});
+
+describe("accept_invalid_certs", () => {
+  it("defaults to false when account flag is 0", () => {
+    const account = createMockDbAccount({ accept_invalid_certs: 0 });
+    const imapConfig = buildImapConfig(account);
+    const smtpConfig = buildSmtpConfig(account);
+    expect(imapConfig.accept_invalid_certs).toBe(false);
+    expect(smtpConfig.accept_invalid_certs).toBe(false);
+  });
+
+  it("sets to true when account flag is 1", () => {
+    const account = createMockDbAccount({ accept_invalid_certs: 1 });
+    const imapConfig = buildImapConfig(account);
+    const smtpConfig = buildSmtpConfig(account);
+    expect(imapConfig.accept_invalid_certs).toBe(true);
+    expect(smtpConfig.accept_invalid_certs).toBe(true);
   });
 });

--- a/src/services/imap/imapConfigBuilder.ts
+++ b/src/services/imap/imapConfigBuilder.ts
@@ -50,6 +50,7 @@ export function buildImapConfig(
     username: account.imap_username || account.email,
     password,
     auth_method: authMethod,
+    accept_invalid_certs: !!account.accept_invalid_certs,
   };
 }
 
@@ -81,5 +82,6 @@ export function buildSmtpConfig(
     username: account.imap_username || account.email,
     password,
     auth_method: authMethod,
+    accept_invalid_certs: !!account.accept_invalid_certs,
   };
 }

--- a/src/services/imap/tauriCommands.ts
+++ b/src/services/imap/tauriCommands.ts
@@ -9,6 +9,7 @@ export interface ImapConfig {
   username: string;
   password: string; // plaintext password or OAuth2 access token
   auth_method: 'password' | 'oauth2';
+  accept_invalid_certs?: boolean;
 }
 
 export interface ImapFolder {
@@ -94,6 +95,7 @@ export interface SmtpConfig {
   username: string;
   password: string;
   auth_method: 'password' | 'oauth2';
+  accept_invalid_certs?: boolean;
 }
 
 export interface SmtpSendResult {

--- a/src/test/mocks/entities.mock.ts
+++ b/src/test/mocks/entities.mock.ts
@@ -123,6 +123,7 @@ export function createMockGmailAccount(
     caldav_principal_url: null,
     caldav_home_url: null,
     calendar_provider: null,
+    accept_invalid_certs: 0,
     ...overrides,
   };
 }
@@ -162,6 +163,7 @@ export function createMockImapAccount(
     caldav_principal_url: null,
     caldav_home_url: null,
     calendar_provider: null,
+    accept_invalid_certs: 0,
     ...overrides,
   };
 }
@@ -201,6 +203,7 @@ export function createMockDbAccount(
     caldav_principal_url: null,
     caldav_home_url: null,
     calendar_provider: null,
+    accept_invalid_certs: 0,
     ...overrides,
   };
 }


### PR DESCRIPTION
## Summary
- Add `accept_invalid_certs` option for IMAP/SMTP connections to support local mail bridges (e.g. ProtonMail Bridge) that use self-signed TLS certificates
- Rust: `build_tls_connector()` helper with `danger_accept_invalid_certs` + `danger_accept_invalid_hostnames`; SMTP uses custom `TlsParameters` with the same flags
- DB migration v23 adds `accept_invalid_certs` column to accounts table
- Auto-discovery auto-enables for ProtonMail/Proton.me/pm.me domains
- UI checkbox in the IMAP settings step of Add Account wizard, with auto-set from discovery

## Changes
- **Rust** (4 files): `ImapConfig`/`SmtpConfig` types, IMAP TLS connector (3 call sites), SMTP TLS parameters (2 branches)
- **DB** (2 files): Migration v23, `DbAccount` interface + insert functions
- **Config** (3 files): `tauriCommands.ts` types, `imapConfigBuilder.ts` propagation, `autoDiscovery.ts` ProtonMail flag
- **UI** (1 file): `AddImapAccount.tsx` form state, checkbox, auto-discovery, test connection, save
- **Tests** (4 files): Updated existing assertions, added 7 new tests for flag propagation and auto-discovery

## Test plan
- [x] `cargo build` — Rust compiles
- [x] `npx tsc --noEmit` — TypeScript compiles
- [x] `npm run test` — All 1475 tests pass (130 files)
- [ ] Manual: Add ProtonMail Bridge account → checkbox auto-enabled → test connection succeeds with self-signed cert

Closes #148