### PR TITLE
feat: add model selection dropdowns for AI providers

### DIFF
--- a/src/services/ai/providers/claudeProvider.ts
+++ b/src/services/ai/providers/claudeProvider.ts
@@ -1,19 +1,18 @@
 import Anthropic from "@anthropic-ai/sdk";
 import type { AiProviderClient, AiCompletionRequest } from "../types";
-import { DEFAULT_MODELS } from "../types";
 import { createProviderFactory } from "../providerFactory";
 
 const factory = createProviderFactory(
   (apiKey) => new Anthropic({ apiKey, dangerouslyAllowBrowser: true }),
 );
 
-export function createClaudeProvider(apiKey: string): AiProviderClient {
+export function createClaudeProvider(apiKey: string, model: string): AiProviderClient {
   const client = factory.getClient(apiKey);
 
   return {
     async complete(req: AiCompletionRequest): Promise<string> {
       const response = await client.messages.create({
-        model: DEFAULT_MODELS.claude,
+        model,
         max_tokens: req.maxTokens ?? 1024,
         system: req.systemPrompt,
         messages: [{ role: "user", content: req.userContent }],
@@ -26,7 +25,7 @@ export function createClaudeProvider(apiKey: string): AiProviderClient {
     async testConnection(): Promise<boolean> {
       try {
         await client.messages.create({
-          model: DEFAULT_MODELS.claude,
+          model,
           max_tokens: 10,
           messages: [{ role: "user", content: "Say hi" }],
         });

--- a/src/services/ai/providers/geminiProvider.ts
+++ b/src/services/ai/providers/geminiProvider.ts
@@ -1,19 +1,18 @@
 import { GoogleGenerativeAI } from "@google/generative-ai";
 import type { AiProviderClient, AiCompletionRequest } from "../types";
-import { DEFAULT_MODELS } from "../types";
 import { createProviderFactory } from "../providerFactory";
 
 const factory = createProviderFactory(
   (apiKey) => new GoogleGenerativeAI(apiKey),
 );
 
-export function createGeminiProvider(apiKey: string): AiProviderClient {
+export function createGeminiProvider(apiKey: string, modelId: string): AiProviderClient {
   const client = factory.getClient(apiKey);
 
   return {
     async complete(req: AiCompletionRequest): Promise<string> {
       const model = client.getGenerativeModel({
-        model: DEFAULT_MODELS.gemini,
+        model: modelId,
         systemInstruction: req.systemPrompt,
       });
 
@@ -24,7 +23,7 @@ export function createGeminiProvider(apiKey: string): AiProviderClient {
     async testConnection(): Promise<boolean> {
       try {
         const model = client.getGenerativeModel({
-          model: DEFAULT_MODELS.gemini,
+          model: modelId,
         });
         await model.generateContent("Say hi");
         return true;

--- a/src/services/ai/providers/openaiProvider.ts
+++ b/src/services/ai/providers/openaiProvider.ts
@@ -1,19 +1,18 @@
 import OpenAI from "openai";
 import type { AiProviderClient, AiCompletionRequest } from "../types";
-import { DEFAULT_MODELS } from "../types";
 import { createProviderFactory } from "../providerFactory";
 
 const factory = createProviderFactory(
   (apiKey) => new OpenAI({ apiKey, dangerouslyAllowBrowser: true }),
 );
 
-export function createOpenAIProvider(apiKey: string): AiProviderClient {
+export function createOpenAIProvider(apiKey: string, model: string): AiProviderClient {
   const client = factory.getClient(apiKey);
 
   return {
     async complete(req: AiCompletionRequest): Promise<string> {
       const response = await client.chat.completions.create({
-        model: DEFAULT_MODELS.openai,
+        model,
         max_tokens: req.maxTokens ?? 1024,
         messages: [
           { role: "system", content: req.systemPrompt },
@@ -27,7 +26,7 @@ export function createOpenAIProvider(apiKey: string): AiProviderClient {
     async testConnection(): Promise<boolean> {
       try {
         await client.chat.completions.create({
-          model: DEFAULT_MODELS.openai,
+          model,
           max_tokens: 10,
           messages: [{ role: "user", content: "Say hi" }],
         });

--- a/src/services/ai/types.ts
+++ b/src/services/ai/types.ts
@@ -14,6 +14,36 @@ export interface AiProviderClient {
 export const DEFAULT_MODELS: Record<AiProvider, string> = {
   claude: "claude-haiku-4-5-20251001",
   openai: "gpt-4o-mini",
-  gemini: "gemini-2.0-flash",
+  gemini: "gemini-2.5-flash-preview-05-20",
   ollama: "llama3.2",
+};
+
+export interface ModelOption {
+  id: string;
+  label: string;
+}
+
+export const PROVIDER_MODELS: Record<Exclude<AiProvider, "ollama">, ModelOption[]> = {
+  claude: [
+    { id: "claude-haiku-4-5-20251001", label: "Claude Haiku 4.5" },
+    { id: "claude-sonnet-4-20250514", label: "Claude Sonnet 4" },
+    { id: "claude-opus-4-20250514", label: "Claude Opus 4" },
+  ],
+  openai: [
+    { id: "gpt-4o-mini", label: "GPT-4o Mini" },
+    { id: "gpt-4o", label: "GPT-4o" },
+    { id: "gpt-4.1-nano", label: "GPT-4.1 Nano" },
+    { id: "gpt-4.1-mini", label: "GPT-4.1 Mini" },
+    { id: "gpt-4.1", label: "GPT-4.1" },
+  ],
+  gemini: [
+    { id: "gemini-2.5-flash-preview-05-20", label: "Gemini 2.5 Flash" },
+    { id: "gemini-2.5-pro-preview-05-06", label: "Gemini 2.5 Pro" },
+  ],
+};
+
+export const MODEL_SETTINGS: Record<Exclude<AiProvider, "ollama">, string> = {
+  claude: "claude_model",
+  openai: "openai_model",
+  gemini: "gemini_model",
 };


### PR DESCRIPTION
## Summary
- **Fixes #158**: Updates Gemini default from `gemini-2.0-flash` (404 for new users) to `gemini-2.5-flash-preview-05-20`
- Adds model selection dropdowns in Settings → AI for Claude, OpenAI, and Gemini providers
- Provider factories now accept a `model` parameter instead of using hardcoded defaults, future-proofing against model deprecations

## Changes
| File | Change |
|------|--------|
| `src/services/ai/types.ts` | Added `ModelOption` interface, `PROVIDER_MODELS` lists, `MODEL_SETTINGS` keys, updated Gemini default |
| `src/services/ai/providers/*.ts` | Accept `model` param instead of using `DEFAULT_MODELS.*` |
| `src/services/ai/providerManager.ts` | Reads model setting from DB, includes in cache key, passes to factories |
| `src/components/settings/SettingsPage.tsx` | Model dropdown UI between API key and Save button, dynamic description text |
| `src/services/ai/providerManager.test.ts` | Updated assertions, added custom model + cache invalidation tests |

## Available Models
- **Claude**: Haiku 4.5 (default), Sonnet 4, Opus 4
- **OpenAI**: GPT-4o Mini (default), GPT-4o, GPT-4.1 Nano, GPT-4.1 Mini, GPT-4.1
- **Gemini**: Gemini 2.5 Flash (default), Gemini 2.5 Pro

## Test plan
- [x] `npx vitest run src/services/ai/providerManager.test.ts` — 22 tests pass
- [x] `npx vitest run src/services/ai/` — all 63 AI service tests pass
- [x] `npx tsc --noEmit` — no type errors
- [ ] Manual: Settings → AI → verify model dropdown appears for Claude/OpenAI/Gemini, saves, and persists on reload