### PR TITLE
fix: animated background strobe effect on Windows

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -96,6 +96,7 @@ export default function App() {
   const theme = useUIStore((s) => s.theme);
   const fontScale = useUIStore((s) => s.fontScale);
   const colorTheme = useUIStore((s) => s.colorTheme);
+  const reduceMotion = useUIStore((s) => s.reduceMotion);
   const sidebarCollapsed = useUIStore((s) => s.sidebarCollapsed);
   const [showAddAccount, setShowAddAccount] = useState(false);
   const [initialized, setInitialized] = useState(false);
@@ -259,6 +260,12 @@ export default function App() {
         const savedViewMode = await getSetting("inbox_view_mode");
         if (savedViewMode === "unified" || savedViewMode === "split") {
           ui.setInboxViewMode(savedViewMode);
+        }
+
+        // Restore reduce motion preference
+        const savedReduceMotion = await getSetting("reduce_motion");
+        if (savedReduceMotion === "true") {
+          ui.setReduceMotion(true);
         }
 
         // Restore task sidebar visibility
@@ -433,6 +440,12 @@ export default function App() {
     root.classList.remove("font-scale-small", "font-scale-default", "font-scale-large", "font-scale-xlarge");
     root.classList.add(`font-scale-${fontScale}`);
   }, [fontScale]);
+
+  // Sync reduce-motion class to <html> element
+  useEffect(() => {
+    const root = document.documentElement;
+    root.classList.toggle("reduce-motion", reduceMotion);
+  }, [reduceMotion]);
 
   // Apply color theme CSS custom properties to <html>
   useEffect(() => {

--- a/src/components/settings/SettingsPage.tsx
+++ b/src/components/settings/SettingsPage.tsx
@@ -94,6 +94,8 @@ export function SettingsPage() {
   const setSendAndArchive = useUIStore((s) => s.setSendAndArchive);
   const inboxViewMode = useUIStore((s) => s.inboxViewMode);
   const setInboxViewMode = useUIStore((s) => s.setInboxViewMode);
+  const reduceMotion = useUIStore((s) => s.reduceMotion);
+  const setReduceMotion = useUIStore((s) => s.setReduceMotion);
   const accounts = useAccountStore((s) => s.accounts);
   const removeAccountFromStore = useAccountStore((s) => s.removeAccount);
   const { tab } = useParams({ strict: false }) as { tab?: string };
@@ -497,6 +499,12 @@ export function SettingsPage() {
                         <option value="split">Split (Categories)</option>
                       </select>
                     </SettingRow>
+                    <ToggleRow
+                      label="Reduce motion"
+                      description="Disable animated background effects (fixes flickering on some GPUs)"
+                      checked={reduceMotion}
+                      onToggle={() => setReduceMotion(!reduceMotion)}
+                    />
                   </Section>
 
                   <SidebarNavEditor />

--- a/src/stores/uiStore.test.ts
+++ b/src/stores/uiStore.test.ts
@@ -198,4 +198,18 @@ describe("uiStore", () => {
     expect(useUIStore.getState().inboxViewMode).toBe("unified");
   });
 
+  it("reduceMotion should default to false", () => {
+    expect(useUIStore.getState().reduceMotion).toBe(false);
+  });
+
+  it("setReduceMotion should persist to DB and update state", () => {
+    useUIStore.getState().setReduceMotion(true);
+    expect(setSetting).toHaveBeenCalledWith("reduce_motion", "true");
+    expect(useUIStore.getState().reduceMotion).toBe(true);
+
+    useUIStore.getState().setReduceMotion(false);
+    expect(setSetting).toHaveBeenCalledWith("reduce_motion", "false");
+    expect(useUIStore.getState().reduceMotion).toBe(false);
+  });
+
 });

--- a/src/stores/uiStore.ts
+++ b/src/stores/uiStore.ts
@@ -32,6 +32,7 @@ interface UIState {
   inboxViewMode: InboxViewMode;
   taskSidebarVisible: boolean;
   sidebarNavConfig: SidebarNavItem[] | null;
+  reduceMotion: boolean;
   isOnline: boolean;
   pendingOpsCount: number;
   isSyncingFolder: string | null;
@@ -54,6 +55,7 @@ interface UIState {
   setTaskSidebarVisible: (visible: boolean) => void;
   setSidebarNavConfig: (config: SidebarNavItem[]) => void;
   restoreSidebarNavConfig: (config: SidebarNavItem[]) => void;
+  setReduceMotion: (reduce: boolean) => void;
   setOnline: (online: boolean) => void;
   setPendingOpsCount: (count: number) => void;
   setSyncingFolder: (folder: string | null) => void;
@@ -75,6 +77,7 @@ export const useUIStore = create<UIState>((set) => ({
   inboxViewMode: "unified",
   taskSidebarVisible: false,
   sidebarNavConfig: null,
+  reduceMotion: false,
   isOnline: true,
   pendingOpsCount: 0,
   isSyncingFolder: null,
@@ -146,6 +149,10 @@ export const useUIStore = create<UIState>((set) => ({
     set({ sidebarNavConfig });
   },
   restoreSidebarNavConfig: (sidebarNavConfig) => set({ sidebarNavConfig }),
+  setReduceMotion: (reduceMotion) => {
+    setSetting("reduce_motion", String(reduceMotion)).catch(() => {});
+    set({ reduceMotion });
+  },
   setOnline: (isOnline) => set({ isOnline }),
   setPendingOpsCount: (pendingOpsCount) => set({ pendingOpsCount }),
   setSyncingFolder: (isSyncingFolder) => set({ isSyncingFolder }),

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -116,8 +116,11 @@ body {
   filter: blur(80px);
   opacity: 0.5;
   animation: blobMove 20s ease-in-out infinite alternate;
-  will-change: transform;
-  transform: translateZ(0);
+}
+
+/* When user enables "Reduce motion" in settings, hide animated blobs entirely */
+.reduce-motion .animated-bg {
+  display: none;
 }
 
 .animated-bg .blob:nth-child(1) {
@@ -420,8 +423,11 @@ body {
   *,
   *::before,
   *::after {
-    animation-duration: 0.01ms !important;
-    animation-delay: 0ms !important;
+    animation: none !important;
     transition-duration: 0.01ms !important;
+  }
+
+  .animated-bg {
+    display: none;
   }
 }


### PR DESCRIPTION
## Summary
- Adds a **Reduce motion** toggle in Settings → Appearance that disables the animated gradient background blobs entirely
- Fixes `prefers-reduced-motion` media query to use `animation: none` instead of `animation-duration: 0.01ms` (which caused near-instant cycling rather than stopping)
- Removes `will-change: transform` from blob elements to reduce unnecessary GPU layer promotion

Closes #156

## Root cause
The 5 animated gradient blobs (300-500px each with `filter: blur(80px)`) create heavy GPU compositing load. On systems with integrated GPUs or certain WebView2 configurations, this causes rapid frame-level flickering that appears as a high-speed strobe effect.

## Test plan
- [x] All 1480 tests pass (130 test files)
- [x] TypeScript compiles clean
- [ ] Toggle "Reduce motion" in Settings → Appearance — animated blobs should disappear
- [ ] OS-level "Reduce motion" preference should also hide the blobs