### PR TITLE
feat: add GitHub Copilot (GitHub Models) as 5th AI provider

### DIFF
--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -65,12 +65,8 @@
     {
       "identifier": "http:default",
       "allow": [
-        { "url": "http://localhost:*" },
-        { "url": "http://localhost:*/*" },
-        { "url": "http://127.0.0.1:*" },
-        { "url": "http://127.0.0.1:*/*" },
-        { "url": "http://0.0.0.0:*" },
-        { "url": "http://0.0.0.0:*/*" },
+        { "url": "http://*" },
+        { "url": "http://*/*" },
         { "url": "https://*" },
         { "url": "https://*/*" }
       ]

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -39,7 +39,7 @@
       }
     ],
     "security": {
-      "csp": "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; connect-src https://www.googleapis.com https://oauth2.googleapis.com https://api.anthropic.com https://api.openai.com https://generativelanguage.googleapis.com https://www.gravatar.com https://login.microsoftonline.com https://graph.microsoft.com https://api.login.yahoo.com http://localhost:11434 http://localhost:1234 http://127.0.0.1:11434 http://127.0.0.1:1234; img-src 'self' data: https://www.gravatar.com https://lh3.googleusercontent.com https://*.googleusercontent.com; font-src 'self' data:; frame-src 'self'"
+      "csp": "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; connect-src https://www.googleapis.com https://oauth2.googleapis.com https://api.anthropic.com https://api.openai.com https://generativelanguage.googleapis.com https://www.gravatar.com https://login.microsoftonline.com https://graph.microsoft.com https://api.login.yahoo.com http://localhost:11434 http://localhost:1234 http://127.0.0.1:11434 http://127.0.0.1:1234 https://models.github.ai; img-src 'self' data: https://www.gravatar.com https://lh3.googleusercontent.com https://*.googleusercontent.com; font-src 'self' data:; frame-src 'self'"
     },
     "trayIcon": null
   },

--- a/src/services/ai/providerManager.ts
+++ b/src/services/ai/providerManager.ts
@@ -6,18 +6,20 @@ import { createClaudeProvider, clearClaudeProvider } from "./providers/claudePro
 import { createOpenAIProvider, clearOpenAIProvider } from "./providers/openaiProvider";
 import { createGeminiProvider, clearGeminiProvider } from "./providers/geminiProvider";
 import { createOllamaProvider, clearOllamaProvider } from "./providers/ollamaProvider";
+import { createCopilotProvider, clearCopilotProvider } from "./providers/copilotProvider";
 
 const API_KEY_SETTINGS: Record<Exclude<AiProvider, "ollama">, string> = {
   claude: "claude_api_key",
   openai: "openai_api_key",
   gemini: "gemini_api_key",
+  copilot: "copilot_api_key",
 };
 
 let cachedProvider: { name: AiProvider; key: string; client: AiProviderClient } | null = null;
 
 export async function getActiveProviderName(): Promise<AiProvider> {
   const setting = await getSetting("ai_provider");
-  if (setting === "openai" || setting === "gemini" || setting === "ollama") return setting;
+  if (setting === "openai" || setting === "gemini" || setting === "ollama" || setting === "copilot") return setting;
   return "claude";
 }
 
@@ -63,6 +65,9 @@ export async function getActiveProvider(): Promise<AiProviderClient> {
     case "gemini":
       client = createGeminiProvider(apiKey, model);
       break;
+    case "copilot":
+      client = createCopilotProvider(apiKey, model);
+      break;
   }
 
   cachedProvider = { name: providerName, key: cacheKey, client };
@@ -94,4 +99,5 @@ export function clearProviderClients(): void {
   clearOpenAIProvider();
   clearGeminiProvider();
   clearOllamaProvider();
+  clearCopilotProvider();
 }

--- a/src/services/ai/providers/copilotProvider.test.ts
+++ b/src/services/ai/providers/copilotProvider.test.ts
@@ -1,0 +1,128 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+
+const mockCreate = vi.fn();
+
+vi.mock("openai", () => {
+  const MockOpenAI = vi.fn(function () {
+    return { chat: { completions: { create: mockCreate } } };
+  });
+  return { default: MockOpenAI };
+});
+
+import OpenAI from "openai";
+import { createCopilotProvider, clearCopilotProvider } from "./copilotProvider";
+
+describe("copilotProvider", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    clearCopilotProvider();
+  });
+
+  describe("createCopilotProvider", () => {
+    it("creates OpenAI client with GitHub Models baseURL and custom headers", () => {
+      createCopilotProvider("ghp_test123", "openai/gpt-4o-mini");
+
+      expect(OpenAI).toHaveBeenCalledWith({
+        apiKey: "ghp_test123",
+        baseURL: "https://models.github.ai/inference",
+        defaultHeaders: { "X-GitHub-Api-Version": "2022-11-28" },
+        dangerouslyAllowBrowser: true,
+      });
+    });
+  });
+
+  describe("complete", () => {
+    it("calls chat.completions.create with correct model and messages", async () => {
+      mockCreate.mockResolvedValue({
+        choices: [{ message: { content: "Hello!" } }],
+      });
+
+      const provider = createCopilotProvider("ghp_test123", "openai/gpt-4o-mini");
+      const result = await provider.complete({
+        systemPrompt: "You are helpful",
+        userContent: "Hi",
+      });
+
+      expect(result).toBe("Hello!");
+      expect(mockCreate).toHaveBeenCalledWith({
+        model: "openai/gpt-4o-mini",
+        max_tokens: 1024,
+        messages: [
+          { role: "system", content: "You are helpful" },
+          { role: "user", content: "Hi" },
+        ],
+      });
+    });
+
+    it("uses custom maxTokens when provided", async () => {
+      mockCreate.mockResolvedValue({
+        choices: [{ message: { content: "OK" } }],
+      });
+
+      const provider = createCopilotProvider("ghp_test123", "openai/gpt-4o-mini");
+      await provider.complete({
+        systemPrompt: "sys",
+        userContent: "user",
+        maxTokens: 2048,
+      });
+
+      expect(mockCreate).toHaveBeenCalledWith(
+        expect.objectContaining({ max_tokens: 2048 }),
+      );
+    });
+
+    it("returns empty string when no content in response", async () => {
+      mockCreate.mockResolvedValue({ choices: [{ message: { content: null } }] });
+
+      const provider = createCopilotProvider("ghp_test123", "openai/gpt-4o-mini");
+      const result = await provider.complete({
+        systemPrompt: "sys",
+        userContent: "user",
+      });
+
+      expect(result).toBe("");
+    });
+  });
+
+  describe("testConnection", () => {
+    it("returns true on successful completion", async () => {
+      mockCreate.mockResolvedValue({
+        choices: [{ message: { content: "hi" } }],
+      });
+
+      const provider = createCopilotProvider("ghp_test123", "openai/gpt-4o-mini");
+      expect(await provider.testConnection()).toBe(true);
+    });
+
+    it("returns false when completion throws", async () => {
+      mockCreate.mockRejectedValue(new Error("Unauthorized"));
+
+      const provider = createCopilotProvider("ghp_test123", "openai/gpt-4o-mini");
+      expect(await provider.testConnection()).toBe(false);
+    });
+  });
+
+  describe("factory caching", () => {
+    it("reuses client for same API key", () => {
+      createCopilotProvider("ghp_test123", "openai/gpt-4o-mini");
+      createCopilotProvider("ghp_test123", "openai/gpt-4o");
+
+      expect(OpenAI).toHaveBeenCalledTimes(1);
+    });
+
+    it("creates new client when API key changes", () => {
+      createCopilotProvider("ghp_test123", "openai/gpt-4o-mini");
+      createCopilotProvider("ghp_different", "openai/gpt-4o-mini");
+
+      expect(OpenAI).toHaveBeenCalledTimes(2);
+    });
+
+    it("creates new client after clearCopilotProvider", () => {
+      createCopilotProvider("ghp_test123", "openai/gpt-4o-mini");
+      clearCopilotProvider();
+      createCopilotProvider("ghp_test123", "openai/gpt-4o-mini");
+
+      expect(OpenAI).toHaveBeenCalledTimes(2);
+    });
+  });
+});

--- a/src/services/ai/providers/copilotProvider.ts
+++ b/src/services/ai/providers/copilotProvider.ts
@@ -1,0 +1,49 @@
+import OpenAI from "openai";
+import type { AiProviderClient, AiCompletionRequest } from "../types";
+import { createProviderFactory } from "../providerFactory";
+
+const factory = createProviderFactory(
+  (apiKey) =>
+    new OpenAI({
+      apiKey,
+      baseURL: "https://models.github.ai/inference",
+      defaultHeaders: { "X-GitHub-Api-Version": "2022-11-28" },
+      dangerouslyAllowBrowser: true,
+    }),
+);
+
+export function createCopilotProvider(apiKey: string, model: string): AiProviderClient {
+  const client = factory.getClient(apiKey);
+
+  return {
+    async complete(req: AiCompletionRequest): Promise<string> {
+      const response = await client.chat.completions.create({
+        model,
+        max_tokens: req.maxTokens ?? 1024,
+        messages: [
+          { role: "system", content: req.systemPrompt },
+          { role: "user", content: req.userContent },
+        ],
+      });
+
+      return response.choices[0]?.message?.content ?? "";
+    },
+
+    async testConnection(): Promise<boolean> {
+      try {
+        await client.chat.completions.create({
+          model,
+          max_tokens: 10,
+          messages: [{ role: "user", content: "Say hi" }],
+        });
+        return true;
+      } catch {
+        return false;
+      }
+    },
+  };
+}
+
+export function clearCopilotProvider(): void {
+  factory.clear();
+}

--- a/src/services/ai/types.ts
+++ b/src/services/ai/types.ts
@@ -1,4 +1,4 @@
-export type AiProvider = "claude" | "openai" | "gemini" | "ollama";
+export type AiProvider = "claude" | "openai" | "gemini" | "ollama" | "copilot";
 
 export interface AiCompletionRequest {
   systemPrompt: string;
@@ -16,6 +16,7 @@ export const DEFAULT_MODELS: Record<AiProvider, string> = {
   openai: "gpt-4o-mini",
   gemini: "gemini-2.5-flash-preview-05-20",
   ollama: "llama3.2",
+  copilot: "openai/gpt-4o-mini",
 };
 
 export interface ModelOption {
@@ -40,10 +41,18 @@ export const PROVIDER_MODELS: Record<Exclude<AiProvider, "ollama">, ModelOption[
     { id: "gemini-2.5-flash-preview-05-20", label: "Gemini 2.5 Flash" },
     { id: "gemini-2.5-pro-preview-05-06", label: "Gemini 2.5 Pro" },
   ],
+  copilot: [
+    { id: "openai/gpt-4o-mini", label: "GPT-4o Mini (Low)" },
+    { id: "openai/gpt-4.1-nano", label: "GPT-4.1 Nano (Low)" },
+    { id: "openai/gpt-4.1-mini", label: "GPT-4.1 Mini (High)" },
+    { id: "openai/gpt-4o", label: "GPT-4o (High)" },
+    { id: "openai/gpt-4.1", label: "GPT-4.1 (High)" },
+  ],
 };
 
 export const MODEL_SETTINGS: Record<Exclude<AiProvider, "ollama">, string> = {
   claude: "claude_model",
   openai: "openai_model",
   gemini: "gemini_model",
+  copilot: "copilot_model",
 };


### PR DESCRIPTION
## Summary
- Adds **GitHub Copilot** as a new AI provider using the OpenAI-compatible [GitHub Models API](https://github.com/marketplace/models) (`https://models.github.ai/inference`), authenticated via GitHub PAT with `models:read` permission
- 5 model options: GPT-4o Mini, GPT-4.1 Nano (Low tier, 150 req/day free), GPT-4.1 Mini, GPT-4o, GPT-4.1 (High tier, 50 req/day free)
- **Fixes #167 (Ollama on LAN)**: Broadens Tauri HTTP plugin scope from localhost-only to all HTTP URLs, so Ollama/LMStudio on Docker/LAN IPs (e.g. `http://192.168.x.x:11434`) now works

### Files changed
- `src/services/ai/types.ts` — Added `"copilot"` to `AiProvider` union, models, defaults
- `src/services/ai/providers/copilotProvider.ts` — **New** — OpenAI SDK with GitHub Models baseURL + `X-GitHub-Api-Version` header
- `src/services/ai/providerManager.ts` — Wired copilot into provider resolution
- `src/components/settings/SettingsPage.tsx` — Settings UI: dropdown, PAT input (`ghp_...`), model selector
- `src-tauri/tauri.conf.json` — Added `https://models.github.ai` to CSP
- `src-tauri/capabilities/default.json` — Broadened HTTP scope to `http://*` (fixes LAN Ollama)
- `src/services/ai/providers/copilotProvider.test.ts` — **New** — 9 tests
- `src/services/ai/providerManager.test.ts` — Added copilot test cases

Closes #160, mitigates #167

## Test plan
- [x] `npx tsc --noEmit` — zero type errors
- [x] `npm run test` — 131 test files, 1496 tests, all passing
- [ ] Manual: Settings → AI → GitHub Copilot → enter PAT → select model → Test Connection
- [ ] Manual: Settings → AI → Ollama with LAN IP → Test Connection