### PR TITLE
fix: use server-side IMAP SINCE date filter to prevent sync timeouts

### DIFF
--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -246,9 +246,10 @@ pub async fn imap_sync_folder(
     config: ImapConfig,
     folder: String,
     batch_size: u32,
+    since_date: Option<String>,
 ) -> Result<ImapFolderSyncResult, String> {
     let mut session = imap_client::connect(&config).await?;
-    let result = imap_client::sync_folder(&mut session, &folder, batch_size).await;
+    let result = imap_client::sync_folder(&mut session, &folder, batch_size, since_date).await;
     let _ = session.logout().await;
     result
 }

--- a/src/services/gmail/syncManager.ts
+++ b/src/services/gmail/syncManager.ts
@@ -90,7 +90,7 @@ async function syncImapAccount(accountId: string): Promise<void> {
 
   if (account.history_id) {
     // Delta sync — IMAP uses folder-level UID tracking
-    const result = await imapDeltaSync(accountId);
+    const result = await imapDeltaSync(accountId, syncDays);
 
     // Recovery: if delta sync found nothing new but the DB has no threads,
     // the previous initial sync likely failed or stored data incorrectly.

--- a/src/services/imap/tauriCommands.ts
+++ b/src/services/imap/tauriCommands.ts
@@ -273,16 +273,17 @@ export async function imapDeltaCheck(
 }
 
 /**
- * Sync a folder in a single IMAP connection: SELECT → UID SEARCH ALL → batched UID FETCH.
- * Returns all UIDs and fetched messages in one round-trip, avoiding the connection storm
- * caused by separate imapSearchAllUids + imapFetchMessages calls.
+ * Sync a folder in a single IMAP connection: SELECT → UID SEARCH → batched UID FETCH.
+ * When `sinceDate` is provided (format `DD-Mon-YYYY`), uses `UID SEARCH SINCE <date>`
+ * to only fetch messages from that date onward, avoiding timeouts on large folders.
  */
 export async function imapSyncFolder(
   config: ImapConfig,
   folder: string,
   batchSize: number,
+  sinceDate?: string | null,
 ): Promise<ImapFolderSyncResult> {
-  return invoke<ImapFolderSyncResult>('imap_sync_folder', { config, folder, batchSize });
+  return invoke<ImapFolderSyncResult>('imap_sync_folder', { config, folder, batchSize, sinceDate: sinceDate ?? null });
 }
 
 /**


### PR DESCRIPTION
## Summary

- Adds `since_date` parameter to Rust `sync_folder` function, using `UID SEARCH SINCE <date>` (RFC 3501 §6.4.4) instead of `UID SEARCH ALL` when provided
- Propagates the date filter through the Tauri command and TypeScript service layers
- Applies server-side filtering in initial sync, delta sync (new folders), and UIDVALIDITY resync paths
- Keeps the existing client-side date filter as a safety net (IMAP SINCE has date-only granularity)

Closes #147

## Test plan

- [x] `npx vitest run src/services/imap/imapSync.test.ts` — 30 tests pass (6 new)
- [x] `npx tsc --noEmit` — clean
- [x] `cargo build` — compiles
- [ ] Manual test with a large IMAP folder (10k+ messages) to confirm sync completes without timeout