### PR TITLE
feat: add Move to Folder/Label shortcut (V key)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -68,9 +68,9 @@ Tauri v2 desktop app: Rust backend + React 19 frontend communicating via Tauri I
 
 ### Component organization
 
-14 groups, ~93 component files:
+14 groups, ~94 component files:
 - `layout/` — Sidebar, EmailList, ReadingPane, TitleBar
-- `email/` — ThreadView, ThreadCard, MessageItem, EmailRenderer, ActionBar, AttachmentList, SnoozeDialog, ContactSidebar, FollowUpDialog, InlineAttachmentPreview, InlineReply, SmartReplySuggestions, ThreadSummary, AuthBadge, AuthWarningBanner, PhishingBanner, LinkConfirmDialog, CategoryTabs
+- `email/` — ThreadView, ThreadCard, MessageItem, EmailRenderer, ActionBar, AttachmentList, SnoozeDialog, ContactSidebar, FollowUpDialog, InlineAttachmentPreview, InlineReply, SmartReplySuggestions, ThreadSummary, AuthBadge, AuthWarningBanner, PhishingBanner, LinkConfirmDialog, CategoryTabs, MoveToFolderDialog
 - `composer/` — Composer (TipTap v3 rich text editor), AddressInput, EditorToolbar, AttachmentPicker, ScheduleSendDialog, SignatureSelector, TemplatePicker, UndoSendToast, AiAssistPanel, FromSelector
 - `search/` — CommandPalette, SearchBar, ShortcutsHelp, AskInbox
 - `settings/` — SettingsPage, FilterEditor, LabelEditor, SignatureEditor, TemplateEditor, ContactEditor, SubscriptionManager, QuickStepEditor, SmartFolderEditor
@@ -105,7 +105,7 @@ Thread pop-out windows via `ThreadWindow.tsx`. Entry point in `main.tsx` checks 
 
 ### Cross-component communication
 
-Custom window events: `velo-sync-done`, `velo-toggle-command-palette`, `velo-toggle-shortcuts-help`, `velo-toggle-ask-inbox`. Tray emits `tray-check-mail` via Tauri event system. `single-instance-args` event for deep link forwarding.
+Custom window events: `velo-sync-done`, `velo-toggle-command-palette`, `velo-toggle-shortcuts-help`, `velo-toggle-ask-inbox`, `velo-move-to-folder`. Tray emits `tray-check-mail` via Tauri event system. `single-instance-args` event for deep link forwarding.
 
 ### Keyboard shortcuts
 
@@ -125,6 +125,7 @@ Custom window events: `velo-sync-done`, `velo-toggle-command-palette`, `velo-tog
 | `f` | Forward |
 | `u` | Unsubscribe |
 | `t` | Create task from email (AI) |
+| `v` | Move to folder/label |
 | `#` / `Delete` / `Backspace` | Trash (permanent delete if already in trash) |
 | `!` | Report spam / Not spam (context-aware) |
 | `/` or `Ctrl+K` | Command palette / search |
@@ -166,7 +167,7 @@ Tailwind CSS v4 — uses `@import "tailwindcss"`, `@theme {}` for custom propert
 
 Vitest + jsdom. Setup file: `src/test/setup.ts` (imports `@testing-library/jest-dom/vitest`). Config: `globals: true` (no imports needed for `describe`, `it`, `expect`). Tests are colocated with source files (e.g., `uiStore.test.ts` next to `uiStore.ts`). Zustand test pattern: `useStore.setState()` in beforeEach, assert via `.getState()`.
 
-130 test files across stores (8), services (70), utils (14), components (31), constants (3), router (1), hooks (2), and config (1).
+132 test files across stores (8), services (70), utils (14), components (32), constants (3), router (1), hooks (2), and config (1).
 
 ## Database
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -50,7 +50,7 @@ Velo follows a **three-layer architecture** with clear separation of concerns.
 ```
 velo/
 ├── src/
-│   ├── components/           # React components (14 groups, ~93 files)
+│   ├── components/           # React components (14 groups, ~94 files)
 │   │   ├── layout/           # Sidebar, EmailList, ReadingPane, TitleBar
 │   │   ├── email/            # ThreadView, MessageItem, EmailRenderer,
 │   │   │                     # ContactSidebar, SmartReplySuggestions,

--- a/docs/keyboard-shortcuts.md
+++ b/docs/keyboard-shortcuts.md
@@ -37,6 +37,7 @@ Velo is designed to be used entirely from the keyboard. All shortcuts are custom
 | `!` | Spam / not spam |
 | `u` | Unsubscribe |
 | `t` | Create task from email (AI) |
+| `v` | Move to folder/label |
 | `Ctrl+Enter` | Send email |
 | `Ctrl+A` | Select all threads |
 | `Ctrl+Shift+A` | Select all from current position |

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -66,6 +66,7 @@ import { useShortcutStore } from "./stores/shortcutStore";
 import { getIncompleteTaskCount } from "./services/db/tasks";
 import { useTaskStore } from "./stores/taskStore";
 import { ContextMenuPortal } from "./components/ui/ContextMenuPortal";
+import { MoveToFolderDialog } from "./components/email/MoveToFolderDialog";
 import { OfflineBanner } from "./components/ui/OfflineBanner";
 import { UpdateToast } from "./components/ui/UpdateToast";
 import { ErrorBoundary } from "./components/ui/ErrorBoundary";
@@ -104,6 +105,7 @@ export default function App() {
   const [showCommandPalette, setShowCommandPalette] = useState(false);
   const [showShortcutsHelp, setShowShortcutsHelp] = useState(false);
   const [showAskInbox, setShowAskInbox] = useState(false);
+  const [moveToFolderState, setMoveToFolderState] = useState<{ open: boolean; threadIds: string[] }>({ open: false, threadIds: [] });
   const deepLinkCleanupRef = useRef<(() => void) | undefined>(undefined);
 
   // Sync bridge: router state → Zustand stores (temporary)
@@ -150,13 +152,19 @@ export default function App() {
     const togglePalette = () => setShowCommandPalette((p) => !p);
     const toggleHelp = () => setShowShortcutsHelp((p) => !p);
     const toggleAskInbox = () => setShowAskInbox((p) => !p);
+    const handleMoveToFolder = (e: Event) => {
+      const detail = (e as CustomEvent<{ threadIds: string[] }>).detail;
+      setMoveToFolderState({ open: true, threadIds: detail.threadIds });
+    };
     window.addEventListener("velo-toggle-command-palette", togglePalette);
     window.addEventListener("velo-toggle-shortcuts-help", toggleHelp);
     window.addEventListener("velo-toggle-ask-inbox", toggleAskInbox);
+    window.addEventListener("velo-move-to-folder", handleMoveToFolder);
     return () => {
       window.removeEventListener("velo-toggle-command-palette", togglePalette);
       window.removeEventListener("velo-toggle-shortcuts-help", toggleHelp);
       window.removeEventListener("velo-toggle-ask-inbox", toggleAskInbox);
+      window.removeEventListener("velo-move-to-folder", handleMoveToFolder);
     };
   }, []);
 
@@ -589,6 +597,11 @@ export default function App() {
         />
       </ErrorBoundary>
       <ContextMenuPortal />
+      <MoveToFolderDialog
+        isOpen={moveToFolderState.open}
+        threadIds={moveToFolderState.threadIds}
+        onClose={() => setMoveToFolderState({ open: false, threadIds: [] })}
+      />
     </div>
   );
 }

--- a/src/components/email/ActionBar.tsx
+++ b/src/components/email/ActionBar.tsx
@@ -10,7 +10,7 @@ import { snoozeThread } from "@/services/snooze/snoozeManager";
 import { getGmailClient } from "@/services/gmail/tokenManager";
 import { SnoozeDialog } from "./SnoozeDialog";
 import { FollowUpDialog } from "./FollowUpDialog";
-import { Archive, Trash2, MailOpen, Mail, Star, Clock, Ban, Pin, MailMinus, BellRing, VolumeX, Reply, ReplyAll, Forward, Printer, Download, ExternalLink, PanelRightClose, PanelRightOpen, ListTodo } from "lucide-react";
+import { Archive, Trash2, MailOpen, Mail, Star, Clock, Ban, Pin, MailMinus, BellRing, VolumeX, Reply, ReplyAll, Forward, FolderInput, Printer, Download, ExternalLink, PanelRightClose, PanelRightOpen, ListTodo } from "lucide-react";
 import type { DbMessage } from "@/services/db/messages";
 import { insertFollowUpReminder, getFollowUpForThread, cancelFollowUpForThread } from "@/services/db/followUpReminders";
 import { Button } from "@/components/ui/Button";
@@ -261,6 +261,16 @@ export function ActionBar({ thread, messages, noReply, defaultReplyMode = "reply
           icon={<Ban size={15} />}
           onClick={handleSpam}
           title={isSpamView ? "Not Spam (!)" : "Report Spam (!)"}
+        />
+        <Button
+          variant="secondary"
+          iconOnly
+          icon={<FolderInput size={15} />}
+          onClick={() => {
+            if (!activeAccountId) return;
+            window.dispatchEvent(new CustomEvent("velo-move-to-folder", { detail: { threadIds: [thread.id] } }));
+          }}
+          title="Move to folder (v)"
         />
         <Button
           variant="secondary"

--- a/src/components/email/MoveToFolderDialog.test.tsx
+++ b/src/components/email/MoveToFolderDialog.test.tsx
@@ -1,0 +1,211 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { MoveToFolderDialog } from "./MoveToFolderDialog";
+
+// Mock dependencies
+vi.mock("@/stores/labelStore", () => ({
+  useLabelStore: vi.fn((selector: (s: { labels: { id: string; name: string; accountId: string; type: string; colorBg: string | null; colorFg: string | null; sortOrder: number }[] }) => unknown) =>
+    selector({
+      labels: [
+        { id: "label-1", name: "Work", accountId: "acc-1", type: "user", colorBg: null, colorFg: null, sortOrder: 0 },
+        { id: "label-2", name: "Personal", accountId: "acc-1", type: "user", colorBg: null, colorFg: null, sortOrder: 1 },
+        { id: "label-3", name: "Finance", accountId: "acc-1", type: "user", colorBg: null, colorFg: null, sortOrder: 2 },
+      ],
+    }),
+  ),
+}));
+
+vi.mock("@/stores/accountStore", () => ({
+  useAccountStore: vi.fn((selector: (s: { activeAccountId: string; accounts: { id: string; provider?: string }[] }) => unknown) =>
+    selector({
+      activeAccountId: "acc-1",
+      accounts: [{ id: "acc-1", provider: "gmail_api" }],
+    }),
+  ),
+}));
+
+vi.mock("@/stores/threadStore", () => ({
+  useThreadStore: Object.assign(
+    vi.fn(() => ({})),
+    {
+      getState: () => ({
+        threads: [{ id: "thread-1", labelIds: ["INBOX"] }],
+      }),
+    },
+  ),
+}));
+
+vi.mock("@/services/emailActions", () => ({
+  archiveThread: vi.fn(() => Promise.resolve({ success: true })),
+  trashThread: vi.fn(() => Promise.resolve({ success: true })),
+  spamThread: vi.fn(() => Promise.resolve({ success: true })),
+  addThreadLabel: vi.fn(() => Promise.resolve({ success: true })),
+  removeThreadLabel: vi.fn(() => Promise.resolve({ success: true })),
+  moveThread: vi.fn(() => Promise.resolve({ success: true })),
+}));
+
+// CSSTransition mock: render children immediately when `in` is true
+vi.mock("react-transition-group", () => ({
+  CSSTransition: ({ in: inProp, children, unmountOnExit, onEntered }: { in: boolean; children: React.ReactNode; unmountOnExit?: boolean; onEntered?: () => void }) => {
+    if (!inProp && unmountOnExit) return null;
+    // Trigger onEntered immediately for testing
+    if (inProp && onEntered) {
+      setTimeout(onEntered, 0);
+    }
+    return <>{children}</>;
+  },
+}));
+
+import { archiveThread, trashThread, spamThread, addThreadLabel, removeThreadLabel } from "@/services/emailActions";
+
+const defaultProps = {
+  isOpen: true,
+  threadIds: ["thread-1"],
+  onClose: vi.fn(),
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("MoveToFolderDialog", () => {
+  it("renders system destinations and user labels when open", () => {
+    render(<MoveToFolderDialog {...defaultProps} />);
+
+    expect(screen.getByText("Inbox")).toBeInTheDocument();
+    expect(screen.getByText("Archive")).toBeInTheDocument();
+    expect(screen.getByText("Trash")).toBeInTheDocument();
+    expect(screen.getByText("Spam")).toBeInTheDocument();
+    expect(screen.getByText("Work")).toBeInTheDocument();
+    expect(screen.getByText("Personal")).toBeInTheDocument();
+    expect(screen.getByText("Finance")).toBeInTheDocument();
+  });
+
+  it("does not render when isOpen is false", () => {
+    render(<MoveToFolderDialog {...defaultProps} isOpen={false} />);
+
+    expect(screen.queryByText("Inbox")).not.toBeInTheDocument();
+  });
+
+  it("filters destinations by search query", () => {
+    render(<MoveToFolderDialog {...defaultProps} />);
+
+    const input = screen.getByPlaceholderText("Move to...");
+    fireEvent.change(input, { target: { value: "work" } });
+
+    expect(screen.getByText("Work")).toBeInTheDocument();
+    expect(screen.queryByText("Personal")).not.toBeInTheDocument();
+    expect(screen.queryByText("Inbox")).not.toBeInTheDocument();
+  });
+
+  it("shows empty state when no matches", () => {
+    render(<MoveToFolderDialog {...defaultProps} />);
+
+    const input = screen.getByPlaceholderText("Move to...");
+    fireEvent.change(input, { target: { value: "nonexistent" } });
+
+    expect(screen.getByText("No matching folders or labels")).toBeInTheDocument();
+  });
+
+  it("calls archiveThread when Archive is selected", async () => {
+    render(<MoveToFolderDialog {...defaultProps} />);
+
+    fireEvent.click(screen.getByText("Archive"));
+
+    expect(defaultProps.onClose).toHaveBeenCalled();
+    expect(archiveThread).toHaveBeenCalledWith("acc-1", "thread-1", []);
+  });
+
+  it("calls trashThread when Trash is selected", async () => {
+    render(<MoveToFolderDialog {...defaultProps} />);
+
+    fireEvent.click(screen.getByText("Trash"));
+
+    expect(defaultProps.onClose).toHaveBeenCalled();
+    expect(trashThread).toHaveBeenCalledWith("acc-1", "thread-1", []);
+  });
+
+  it("calls spamThread when Spam is selected", async () => {
+    render(<MoveToFolderDialog {...defaultProps} />);
+
+    fireEvent.click(screen.getByText("Spam"));
+
+    expect(defaultProps.onClose).toHaveBeenCalled();
+    expect(spamThread).toHaveBeenCalledWith("acc-1", "thread-1", [], true);
+  });
+
+  it("calls addThreadLabel + removeThreadLabel for Gmail label selection", async () => {
+    render(<MoveToFolderDialog {...defaultProps} />);
+
+    fireEvent.click(screen.getByText("Work"));
+
+    expect(defaultProps.onClose).toHaveBeenCalled();
+    expect(addThreadLabel).toHaveBeenCalledWith("acc-1", "thread-1", "label-1");
+    // removeThreadLabel is called after addThreadLabel resolves — wait for microtasks
+    await vi.waitFor(() => {
+      expect(removeThreadLabel).toHaveBeenCalledWith("acc-1", "thread-1", "INBOX");
+    });
+  });
+
+  it("calls addThreadLabel for Inbox (un-archive) on Gmail", async () => {
+    render(<MoveToFolderDialog {...defaultProps} />);
+
+    fireEvent.click(screen.getByText("Inbox"));
+
+    expect(defaultProps.onClose).toHaveBeenCalled();
+    expect(addThreadLabel).toHaveBeenCalledWith("acc-1", "thread-1", "INBOX");
+  });
+
+  it("closes on Escape key", () => {
+    render(<MoveToFolderDialog {...defaultProps} />);
+
+    const input = screen.getByPlaceholderText("Move to...");
+    fireEvent.keyDown(input, { key: "Escape" });
+
+    expect(defaultProps.onClose).toHaveBeenCalled();
+  });
+
+  it("navigates with arrow keys and selects with Enter", () => {
+    render(<MoveToFolderDialog {...defaultProps} />);
+
+    const input = screen.getByPlaceholderText("Move to...");
+
+    // Arrow down to "Archive" (index 1)
+    fireEvent.keyDown(input, { key: "ArrowDown" });
+    fireEvent.keyDown(input, { key: "Enter" });
+
+    expect(defaultProps.onClose).toHaveBeenCalled();
+    expect(archiveThread).toHaveBeenCalledWith("acc-1", "thread-1", []);
+  });
+
+  it("handles multiple threadIds", async () => {
+    render(<MoveToFolderDialog {...defaultProps} threadIds={["thread-1", "thread-2"]} />);
+
+    fireEvent.click(screen.getByText("Archive"));
+
+    await vi.waitFor(() => {
+      expect(archiveThread).toHaveBeenCalledTimes(2);
+    });
+    expect(archiveThread).toHaveBeenCalledWith("acc-1", "thread-1", []);
+    expect(archiveThread).toHaveBeenCalledWith("acc-1", "thread-2", []);
+  });
+
+  it("closes when clicking the backdrop", () => {
+    const { container } = render(<MoveToFolderDialog {...defaultProps} />);
+
+    // The overlay div is the backdrop
+    const overlay = container.querySelector(".fixed.inset-0");
+    if (overlay) {
+      fireEvent.click(overlay);
+      expect(defaultProps.onClose).toHaveBeenCalled();
+    }
+  });
+
+  it("renders keyboard hint footer", () => {
+    render(<MoveToFolderDialog {...defaultProps} />);
+
+    expect(screen.getByText("navigate")).toBeInTheDocument();
+    expect(screen.getByText("select")).toBeInTheDocument();
+    expect(screen.getByText("close")).toBeInTheDocument();
+  });
+});

--- a/src/components/email/MoveToFolderDialog.tsx
+++ b/src/components/email/MoveToFolderDialog.tsx
@@ -1,0 +1,280 @@
+import { useState, useRef, useCallback, useMemo } from "react";
+import { CSSTransition } from "react-transition-group";
+import { useLabelStore } from "@/stores/labelStore";
+import { useAccountStore } from "@/stores/accountStore";
+import { useThreadStore } from "@/stores/threadStore";
+import {
+  archiveThread,
+  trashThread,
+  spamThread,
+  addThreadLabel,
+  removeThreadLabel,
+  moveThread,
+} from "@/services/emailActions";
+import {
+  Inbox,
+  Archive,
+  Trash2,
+  Ban,
+  Search,
+  Tag,
+  Folder,
+} from "lucide-react";
+
+interface MoveToFolderDialogProps {
+  isOpen: boolean;
+  threadIds: string[];
+  onClose: () => void;
+}
+
+interface Destination {
+  id: string;
+  label: string;
+  icon: typeof Inbox;
+  type: "system" | "label";
+  /** For IMAP: the folder path to move to */
+  folderPath?: string;
+}
+
+const SYSTEM_DESTINATIONS: Destination[] = [
+  { id: "INBOX", label: "Inbox", icon: Inbox, type: "system" },
+  { id: "__archive__", label: "Archive", icon: Archive, type: "system" },
+  { id: "TRASH", label: "Trash", icon: Trash2, type: "system" },
+  { id: "SPAM", label: "Spam", icon: Ban, type: "system" },
+];
+
+export function MoveToFolderDialog({
+  isOpen,
+  threadIds,
+  onClose,
+}: MoveToFolderDialogProps) {
+  const [query, setQuery] = useState("");
+  const [selectedIdx, setSelectedIdx] = useState(0);
+  const inputRef = useRef<HTMLInputElement>(null);
+  const overlayRef = useRef<HTMLDivElement>(null);
+  const listRef = useRef<HTMLDivElement>(null);
+  const labels = useLabelStore((s) => s.labels);
+  const activeAccountId = useAccountStore((s) => s.activeAccountId);
+  const accounts = useAccountStore((s) => s.accounts);
+
+  const account = useMemo(
+    () => accounts.find((a) => a.id === activeAccountId),
+    [accounts, activeAccountId],
+  );
+  const isImap = account?.provider === "imap";
+
+  // Build the full destination list: system destinations + user labels
+  const destinations = useMemo(() => {
+    const userLabels: Destination[] = labels.map((l) => ({
+      id: l.id,
+      label: l.name,
+      icon: Tag,
+      type: "label" as const,
+    }));
+    return [...SYSTEM_DESTINATIONS, ...userLabels];
+  }, [labels]);
+
+  // Filter destinations by search query
+  const filtered = useMemo(() => {
+    if (!query.trim()) return destinations;
+    const q = query.toLowerCase();
+    return destinations.filter((d) => d.label.toLowerCase().includes(q));
+  }, [destinations, query]);
+
+  const handleSelect = useCallback(
+    async (dest: Destination) => {
+      if (!activeAccountId || threadIds.length === 0) return;
+      onClose();
+
+      for (const threadId of threadIds) {
+        if (dest.id === "__archive__") {
+          await archiveThread(activeAccountId, threadId, []);
+        } else if (dest.id === "TRASH") {
+          await trashThread(activeAccountId, threadId, []);
+        } else if (dest.id === "SPAM") {
+          await spamThread(activeAccountId, threadId, [], true);
+        } else if (dest.id === "INBOX") {
+          if (isImap) {
+            await moveThread(activeAccountId, threadId, [], "INBOX");
+          } else {
+            // Gmail: add INBOX label (un-archive)
+            await addThreadLabel(activeAccountId, threadId, "INBOX");
+          }
+        } else if (dest.type === "label") {
+          if (isImap) {
+            // IMAP: move to folder. The label's id is the folder path for IMAP accounts.
+            await moveThread(activeAccountId, threadId, [], dest.id);
+          } else {
+            // Gmail: add destination label + remove from current location (archive)
+            await addThreadLabel(activeAccountId, threadId, dest.id);
+            // Remove INBOX to complete the "move" semantics
+            const thread = useThreadStore
+              .getState()
+              .threads.find((t) => t.id === threadId);
+            if (thread?.labelIds.includes("INBOX")) {
+              await removeThreadLabel(activeAccountId, threadId, "INBOX");
+            }
+          }
+        }
+      }
+
+      // Refresh thread list
+      window.dispatchEvent(new Event("velo-sync-done"));
+    },
+    [activeAccountId, threadIds, isImap, onClose],
+  );
+
+  const handleKeyDown = useCallback(
+    (e: React.KeyboardEvent) => {
+      if (e.key === "ArrowDown") {
+        e.preventDefault();
+        setSelectedIdx((prev) => {
+          const next = Math.min(prev + 1, filtered.length - 1);
+          scrollToIndex(next);
+          return next;
+        });
+      } else if (e.key === "ArrowUp") {
+        e.preventDefault();
+        setSelectedIdx((prev) => {
+          const next = Math.max(prev - 1, 0);
+          scrollToIndex(next);
+          return next;
+        });
+      } else if (e.key === "Enter") {
+        e.preventDefault();
+        const dest = filtered[selectedIdx];
+        if (dest) {
+          handleSelect(dest);
+        }
+      } else if (e.key === "Escape") {
+        e.preventDefault();
+        onClose();
+      }
+    },
+    [filtered, selectedIdx, handleSelect, onClose],
+  );
+
+  const scrollToIndex = (index: number) => {
+    const list = listRef.current;
+    if (!list) return;
+    const item = list.children[index] as HTMLElement | undefined;
+    item?.scrollIntoView?.({ block: "nearest" });
+  };
+
+  // Reset state when dialog opens/closes
+  const handleEntered = () => {
+    setQuery("");
+    setSelectedIdx(0);
+    inputRef.current?.focus();
+  };
+
+  return (
+    <CSSTransition
+      in={isOpen}
+      timeout={150}
+      classNames="modal"
+      unmountOnExit
+      nodeRef={overlayRef}
+      onEntered={handleEntered}
+    >
+      <div
+        ref={overlayRef}
+        className="fixed inset-0 z-50 flex items-start justify-center pt-[20vh]"
+        onClick={(e) => {
+          if (e.target === e.currentTarget) onClose();
+        }}
+      >
+        <div className="glass-backdrop absolute inset-0" />
+        <div
+          className="relative bg-bg-primary border border-border-primary rounded-lg glass-modal w-full max-w-md overflow-hidden"
+          onKeyDown={handleKeyDown}
+        >
+          {/* Search input */}
+          <div className="flex items-center gap-2 px-3 py-2.5 border-b border-border-secondary">
+            <Search size={16} className="text-text-tertiary shrink-0" />
+            <input
+              ref={inputRef}
+              type="text"
+              value={query}
+              onChange={(e) => {
+                setQuery(e.target.value);
+                setSelectedIdx(0);
+              }}
+              placeholder="Move to..."
+              className="flex-1 bg-transparent text-sm text-text-primary placeholder:text-text-tertiary outline-none"
+              autoFocus
+            />
+          </div>
+
+          {/* Destination list */}
+          <div
+            ref={listRef}
+            className="max-h-64 overflow-y-auto py-1"
+            role="listbox"
+          >
+            {filtered.length === 0 && (
+              <div className="px-3 py-4 text-center text-xs text-text-tertiary">
+                No matching folders or labels
+              </div>
+            )}
+            {filtered.map((dest, idx) => {
+              const Icon = dest.type === "system" ? dest.icon : Folder;
+              const isSelected = idx === selectedIdx;
+              return (
+                <button
+                  key={dest.id}
+                  role="option"
+                  aria-selected={isSelected}
+                  className={`flex items-center gap-2.5 w-full px-3 py-1.5 text-sm text-left cursor-pointer transition-colors ${
+                    isSelected
+                      ? "bg-bg-selected text-text-primary"
+                      : "text-text-secondary hover:bg-bg-hover"
+                  }`}
+                  onClick={() => handleSelect(dest)}
+                  onMouseEnter={() => setSelectedIdx(idx)}
+                >
+                  <Icon
+                    size={15}
+                    className={
+                      dest.type === "system"
+                        ? "text-text-tertiary"
+                        : "text-accent"
+                    }
+                  />
+                  <span className="truncate">{dest.label}</span>
+                  {dest.type === "system" && (
+                    <span className="ml-auto text-[10px] text-text-tertiary uppercase tracking-wider">
+                      System
+                    </span>
+                  )}
+                </button>
+              );
+            })}
+          </div>
+
+          {/* Footer hint */}
+          <div className="flex items-center gap-3 px-3 py-1.5 border-t border-border-secondary text-[10px] text-text-tertiary">
+            <span>
+              <kbd className="px-1 py-0.5 rounded bg-bg-tertiary text-text-tertiary">
+                ↑↓
+              </kbd>{" "}
+              navigate
+            </span>
+            <span>
+              <kbd className="px-1 py-0.5 rounded bg-bg-tertiary text-text-tertiary">
+                ↵
+              </kbd>{" "}
+              select
+            </span>
+            <span>
+              <kbd className="px-1 py-0.5 rounded bg-bg-tertiary text-text-tertiary">
+                esc
+              </kbd>{" "}
+              close
+            </span>
+          </div>
+        </div>
+      </div>
+    </CSSTransition>
+  );
+}

--- a/src/components/ui/ContextMenuPortal.tsx
+++ b/src/components/ui/ContextMenuPortal.tsx
@@ -29,6 +29,7 @@ import {
   Pin,
   Ban,
   Tag,
+  FolderInput,
   ExternalLink,
   Pencil,
   Copy,
@@ -523,6 +524,15 @@ function ThreadMenu({
           children: labelItems,
         }]
       : []),
+    {
+      id: "move-to-folder",
+      label: "Move to Folder",
+      icon: FolderInput,
+      shortcut: "v",
+      action: () => {
+        window.dispatchEvent(new CustomEvent("velo-move-to-folder", { detail: { threadIds: [...targetIds] } }));
+      },
+    },
     {
       id: "move-to-category",
       label: "Move to Category",

--- a/src/constants/helpContent.ts
+++ b/src/constants/helpContent.ts
@@ -61,6 +61,7 @@ import {
   ListFilter,
   Paperclip,
   Tags,
+  FolderInput,
 } from "lucide-react";
 
 // ---------- Types ----------
@@ -608,6 +609,21 @@ export const HELP_CATEGORIES: HelpCategory[] = [
           { text: "Also works with Delete or Backspace keys." },
           { text: "Deleting from Trash permanently removes the thread." },
           { text: "Archived threads return to inbox when new replies arrive." },
+        ],
+      },
+      {
+        id: "move-to-folder",
+        icon: FolderInput,
+        title: "Move to folder",
+        summary: "Quickly move threads to any folder or label.",
+        description:
+          "Press V to open a searchable popup where you can pick a destination folder or label. Type to filter the list, use arrow keys to navigate, and press Enter to move the thread. For Gmail, moving adds the destination label and removes the thread from your current location. For IMAP accounts, the thread is moved to the selected folder on the server. Works with multi-select — move multiple threads at once.",
+        tips: [
+          { text: "Open the move-to dialog", shortcut: "v" },
+          { text: "Type to search and filter destinations." },
+          { text: "Navigate with arrow keys, select with Enter." },
+          { text: "Also available from the action bar and right-click menu." },
+          { text: "Works with multi-selected threads for batch moves." },
         ],
       },
       {

--- a/src/constants/shortcuts.ts
+++ b/src/constants/shortcuts.ts
@@ -42,6 +42,7 @@ export const SHORTCUTS: ShortcutCategory[] = [
     { id: "action.unsubscribe", keys: "u", desc: "Unsubscribe" },
     { id: "action.mute", keys: "m", desc: "Mute / Unmute" },
     { id: "action.createTaskFromEmail", keys: "t", desc: "Create task from email (AI)" },
+    { id: "action.moveToFolder", keys: "v", desc: "Move to folder/label" },
     { id: "action.selectAll", keys: "Ctrl+A", desc: "Select all" },
     { id: "action.selectFromHere", keys: "Ctrl+Shift+A", desc: "Select all from here" },
   ]},

--- a/src/hooks/useKeyboardShortcuts.ts
+++ b/src/hooks/useKeyboardShortcuts.ts
@@ -453,6 +453,14 @@ async function executeAction(actionId: string): Promise<void> {
       }
       break;
     }
+    case "action.moveToFolder": {
+      const multiMoveIds = useThreadStore.getState().selectedThreadIds;
+      const moveThreadIds = multiMoveIds.size > 0 ? [...multiMoveIds] : selectedId ? [selectedId] : [];
+      if (moveThreadIds.length > 0) {
+        window.dispatchEvent(new CustomEvent("velo-move-to-folder", { detail: { threadIds: moveThreadIds } }));
+      }
+      break;
+    }
     case "app.commandPalette":
       window.dispatchEvent(new Event("velo-toggle-command-palette"));
       break;


### PR DESCRIPTION
## Summary
- Adds a `V` keyboard shortcut to open a searchable "Move to Folder" popup dialog
- Supports Gmail (add label + archive) and IMAP (server-side folder move) semantics
- Dialog features search filtering, arrow key navigation, Enter to select, Escape to close
- Integrated into the action bar (FolderInput icon button), right-click context menu, and keyboard shortcuts
- Works with multi-select for batch moves
- 14 new tests for the MoveToFolderDialog component

Closes #165

## Changes
| File | Change |
|------|--------|
| `src/constants/shortcuts.ts` | Added `action.moveToFolder` shortcut (`v`) |
| `src/hooks/useKeyboardShortcuts.ts` | Added keyboard handler dispatching `velo-move-to-folder` event |
| `src/components/email/MoveToFolderDialog.tsx` | **New** — searchable move-to dialog |
| `src/components/email/MoveToFolderDialog.test.tsx` | **New** — 14 tests |
| `src/App.tsx` | Mounted dialog, added event listener |
| `src/components/ui/ContextMenuPortal.tsx` | Added "Move to Folder" context menu item |
| `src/components/email/ActionBar.tsx` | Added move-to button in action bar |
| `src/constants/helpContent.ts` | Added help card for the feature |
| `docs/keyboard-shortcuts.md` | Added `v` shortcut to docs |
| `CLAUDE.md` | Updated shortcuts table, component counts, event list |

## Test plan
- [x] `npx tsc --noEmit` passes
- [x] All 132 test files pass (1515 tests)
- [ ] Press `V` on a thread → dialog opens → search/select a label → thread moves
- [ ] Right-click thread → "Move to Folder" → same dialog opens
- [ ] Multi-select threads → press `V` → all selected threads move
- [ ] Click FolderInput button in action bar → dialog opens
- [ ] Escape closes the dialog without action
- [ ] IMAP account: moves use server-side folder move