### PR TITLE
fix: allow optional space after colon in search operators

### DIFF
--- a/src/services/search/searchParser.test.ts
+++ b/src/services/search/searchParser.test.ts
@@ -85,6 +85,13 @@ describe("parseSearchQuery", () => {
     expect(result.freeText).toBe("");
   });
 
+  it("allows space after colon in operators", () => {
+    const result = parseSearchQuery("from: tom has: attachment");
+    expect(result.from).toBe("tom");
+    expect(result.hasAttachment).toBe(true);
+    expect(result.freeText).toBe("");
+  });
+
   it("handles empty query", () => {
     const result = parseSearchQuery("");
     expect(result.freeText).toBe("");

--- a/src/services/search/searchParser.ts
+++ b/src/services/search/searchParser.ts
@@ -18,7 +18,7 @@ export interface ParsedSearchQuery {
   label?: string;
 }
 
-const OPERATOR_REGEX = /(?:^|\s)(from|to|subject|has|is|before|after|label):(?:"([^"]+)"|(\S+))/gi;
+const OPERATOR_REGEX = /(?:^|\s)(from|to|subject|has|is|before|after|label):\s*(?:"([^"]+)"|(\S+))/gi;
 
 /**
  * Parse a date string like YYYY/MM/DD or YYYY-MM-DD into a unix timestamp (seconds).


### PR DESCRIPTION
## Summary
Standard email clients (Gmail, Outlook, etc.) accept both `from:tom` and `from: tom` syntax. Our regex required the value immediately after the colon, so `from: tom has:attachment` only matched `has:attachment`.

## Changes
⏺ src/services/search/searchParser.ts

  One-character regex fix — added \s* after the colon to allow optional whitespace between operator and value:

  src/services/search/searchParser.test.ts

  Added one test verifying the fix:
-

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [x] Enhancement (improving existing feature)
- [ ] Refactor (no behavior change)
- [ ] Documentation
- [ ] CI/Build

## Testing
- [x] Existing tests pass (`npm run test`)
- [x] New tests added (if applicable)
- [x] Manually tested

