### PR TITLE
feat: chunked IMAP sync with lightweight UID search

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -6786,7 +6786,7 @@ checksum = "f1bddf1187be692e79c5ffeab891132dfb0f236ed36a43c7ed39f1165ee20191"
 
 [[package]]
 name = "velo"
-version = "0.4.13"
+version = "0.4.18"
 dependencies = [
  "async-imap",
  "base64 0.22.1",

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -1,7 +1,7 @@
 use crate::imap::client as imap_client;
 use crate::imap::types::{
     DeltaCheckRequest, DeltaCheckResult, ImapConfig, ImapFetchResult, ImapFolder,
-    ImapFolderStatus, ImapFolderSyncResult, ImapMessage,
+    ImapFolderSearchResult, ImapFolderStatus, ImapFolderSyncResult, ImapMessage,
 };
 use crate::smtp::client as smtp_client;
 use crate::smtp::types::{SmtpConfig, SmtpSendResult};
@@ -239,6 +239,18 @@ fn base64url_decode(input: &str) -> Result<Vec<u8>, String> {
     engine
         .decode(input)
         .map_err(|e| format!("base64url decode failed: {e}"))
+}
+
+#[tauri::command]
+pub async fn imap_search_folder(
+    config: ImapConfig,
+    folder: String,
+    since_date: Option<String>,
+) -> Result<ImapFolderSearchResult, String> {
+    let mut session = imap_client::connect(&config).await?;
+    let result = imap_client::search_folder(&mut session, &folder, since_date).await;
+    let _ = session.logout().await;
+    result
 }
 
 #[tauri::command]

--- a/src-tauri/src/imap/types.rs
+++ b/src-tauri/src/imap/types.rs
@@ -84,6 +84,12 @@ pub struct ImapFolderSyncResult {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ImapFolderSearchResult {
+    pub uids: Vec<u32>,
+    pub folder_status: ImapFolderStatus,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct DeltaCheckRequest {
     pub folder: String,
     pub last_uid: u32,

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -106,6 +106,7 @@ pub fn run() {
             commands::imap_get_folder_status,
             commands::imap_fetch_attachment,
             commands::imap_append_message,
+            commands::imap_search_folder,
             commands::imap_sync_folder,
             commands::imap_raw_fetch_diagnostic,
             commands::imap_delta_check,

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -387,12 +387,12 @@ export default function App() {
         if (progress) {
           if (progress.phase === "messages") {
             setSyncStatus(
-              `Syncing: ${progress.current}/${progress.total} threads`,
+              `Syncing: ${progress.current}/${progress.total} messages`,
             );
           } else if (progress.phase === "labels") {
             setSyncStatus("Syncing labels...");
           } else if (progress.phase === "threads") {
-            setSyncStatus(`Fetching threads... (${progress.current})`);
+            setSyncStatus(`Building threads... (${progress.current}/${progress.total})`);
           }
         } else {
           setSyncStatus("Syncing...");

--- a/src/services/imap/tauriCommands.ts
+++ b/src/services/imap/tauriCommands.ts
@@ -71,6 +71,13 @@ export interface ImapFetchResult {
   folder_status: ImapFolderStatus;
 }
 
+// ---------- Folder search result (lightweight: UIDs + status only) ----------
+
+export interface ImapFolderSearchResult {
+  uids: number[];
+  folder_status: ImapFolderStatus;
+}
+
 // ---------- Folder sync result (single-connection search + fetch) ----------
 
 export interface ImapFolderSyncResult {
@@ -284,6 +291,19 @@ export async function imapSyncFolder(
   sinceDate?: string | null,
 ): Promise<ImapFolderSyncResult> {
   return invoke<ImapFolderSyncResult>('imap_sync_folder', { config, folder, batchSize, sinceDate: sinceDate ?? null });
+}
+
+/**
+ * Search a folder for UIDs without fetching message bodies.
+ * Returns UIDs and folder status — lightweight alternative to `imapSyncFolder`
+ * for callers that fetch messages in smaller IPC-friendly chunks.
+ */
+export async function imapSearchFolder(
+  config: ImapConfig,
+  folder: string,
+  sinceDate?: string | null,
+): Promise<ImapFolderSearchResult> {
+  return invoke<ImapFolderSearchResult>('imap_search_folder', { config, folder, sinceDate: sinceDate ?? null });
 }
 
 /**


### PR DESCRIPTION
## Summary
- **New `imap_search_folder` Rust command**: Lightweight UID SEARCH that returns only UIDs and folder status without fetching message bodies — avoids sending large payloads over IPC
- **Chunked message fetching**: Initial sync now fetches messages in 200-UID chunks instead of all at once, with per-chunk error recovery (continues to next chunk on failure)
- **Batched DB transactions**: Message storage (Phase 2) and thread creation (Phase 4, 100 thread groups per batch) are wrapped in transactions for faster writes and atomicity
- **New `storing_threads` progress phase**: UI now shows "Building threads... (X/Y)" during Phase 4 for better user feedback
- **Cleaner sync progress mapping**: Extracted `mapImapPhase()` helper in syncManager to map IMAP phases to UI phases

## Test plan
- [x] All 32 IMAP sync tests pass (updated mocks for search+fetch two-step flow)
- [ ] Manual test: IMAP initial sync with a real mailbox
- [ ] Manual test: IMAP delta sync with UIDVALIDITY change (triggers resync)
- [ ] Verify sync progress UI shows correct phase labels