### PR TITLE
fix: add Escape key to close inline reply editor

### DIFF
--- a/src/components/email/InlineReply.tsx
+++ b/src/components/email/InlineReply.tsx
@@ -284,7 +284,7 @@ export function InlineReply({ thread, messages, accountId, noReply, onSent }: In
     };
   }, []);
 
-  // Handle Ctrl+Enter to send
+  // Handle Ctrl+Enter to send, Escape to close
   useEffect(() => {
     if (!mode) return;
     const handler = (e: KeyboardEvent) => {
@@ -292,10 +292,17 @@ export function InlineReply({ thread, messages, accountId, noReply, onSent }: In
         e.preventDefault();
         handleSend();
       }
+      if (e.key === "Escape") {
+        e.preventDefault();
+        editor?.commands.setContent("");
+        setMode(null);
+        setHasAutoDraft(false);
+        autoDraftAbortRef.current = true;
+      }
     };
     window.addEventListener("keydown", handler);
     return () => window.removeEventListener("keydown", handler);
-  }, [mode, handleSend]);
+  }, [mode, handleSend, editor]);
 
   if (!lastMessage) return null;
 


### PR DESCRIPTION
When the TipTap editor was focused, isContentEditable was true causing the global keyboard shortcut handler to skip Escape. Added a local keydown listener in InlineReply so Escape closes the editor, clears the draft, and returns focus to the thread view.

## Summary
  When pressing r/a/f to reply from the thread list, the TipTap editor takes
  focus and isContentEditable becomes true — causing the global keyboard
  shortcut handler to skip all single-key shortcuts, including Escape. Added a
  local keydown listener in InlineReply so Escape closes the editor, clears the
  draft, and aborts any in-flight auto-draft generation.

## Changes
  Changes:
  - Added Escape key handler alongside the existing Ctrl+Enter send handler in
  InlineReply's keydown listener
  - On Escape: clears editor content, resets mode to collapsed state, cancels
  auto-draft
-

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Enhancement (improving existing feature)
- [ ] Refactor (no behavior change)
- [ ] Documentation
- [ ] CI/Build

## Testing
- [x] Existing tests pass (`npm run test`)
- [] New tests added (if applicable)
- [x] Manually tested

## Screenshots
<!-- If applicable, add screenshots -->
