### PR TITLE
fix: resolve SQLite transaction errors during IMAP initial sync

### DIFF
--- a/src/services/db/connection.test.ts
+++ b/src/services/db/connection.test.ts
@@ -1,0 +1,129 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// Mock Database before importing module under test
+const mockExecute = vi.fn();
+const mockSelect = vi.fn();
+const mockDb = { execute: mockExecute, select: mockSelect };
+
+vi.mock("@tauri-apps/plugin-sql", () => ({
+  default: {
+    load: vi.fn(() => Promise.resolve(mockDb)),
+  },
+}));
+
+// Use dynamic import so mocks are in place
+const { withTransaction, getDb } = await import("./connection");
+
+describe("withTransaction", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockExecute.mockResolvedValue(undefined);
+  });
+
+  it("executes BEGIN, callback, COMMIT in order", async () => {
+    const callOrder: string[] = [];
+    mockExecute.mockImplementation(async (sql: string) => {
+      callOrder.push(sql);
+    });
+
+    await withTransaction(async () => {
+      callOrder.push("callback");
+    });
+
+    expect(callOrder).toEqual(["BEGIN TRANSACTION", "callback", "COMMIT"]);
+  });
+
+  it("rolls back on callback error", async () => {
+    const callOrder: string[] = [];
+    mockExecute.mockImplementation(async (sql: string) => {
+      callOrder.push(sql);
+    });
+
+    await expect(
+      withTransaction(async () => {
+        throw new Error("callback failed");
+      }),
+    ).rejects.toThrow("callback failed");
+
+    expect(callOrder).toEqual(["BEGIN TRANSACTION", "ROLLBACK"]);
+  });
+
+  it("handles ROLLBACK failure gracefully (SQLite auto-rollback)", async () => {
+    mockExecute.mockImplementation(async (sql: string) => {
+      if (sql === "ROLLBACK") {
+        throw new Error("cannot rollback - no transaction is active");
+      }
+    });
+
+    // Should still throw the original error, not the ROLLBACK error
+    await expect(
+      withTransaction(async () => {
+        throw new Error("original error");
+      }),
+    ).rejects.toThrow("original error");
+  });
+
+  it("serialises concurrent transactions via mutex", async () => {
+    const executionLog: string[] = [];
+
+    mockExecute.mockImplementation(async (sql: string) => {
+      executionLog.push(sql);
+    });
+
+    // Launch two transactions concurrently
+    const tx1 = withTransaction(async () => {
+      executionLog.push("tx1-work");
+      // Simulate async work
+      await new Promise((r) => setTimeout(r, 10));
+      executionLog.push("tx1-done");
+    });
+
+    const tx2 = withTransaction(async () => {
+      executionLog.push("tx2-work");
+    });
+
+    await Promise.all([tx1, tx2]);
+
+    // tx1 should fully complete (BEGIN, work, done, COMMIT) before tx2 starts
+    const tx1BeginIdx = executionLog.indexOf("BEGIN TRANSACTION");
+    const tx1CommitIdx = executionLog.indexOf("COMMIT");
+    const tx2BeginIdx = executionLog.lastIndexOf("BEGIN TRANSACTION");
+
+    expect(tx1BeginIdx).toBeLessThan(tx1CommitIdx);
+    expect(tx1CommitIdx).toBeLessThan(tx2BeginIdx);
+  });
+
+  it("unblocks next transaction even if current one fails", async () => {
+    mockExecute.mockImplementation(async (sql: string) => {
+      if (sql === "ROLLBACK") {
+        // Simulate auto-rollback already happened
+        throw new Error("cannot rollback - no transaction is active");
+      }
+    });
+
+    // First transaction fails
+    const tx1 = withTransaction(async () => {
+      throw new Error("tx1 failed");
+    }).catch(() => {
+      /* expected */
+    });
+
+    // Second transaction should still run
+    let tx2Ran = false;
+    const tx2 = withTransaction(async () => {
+      tx2Ran = true;
+    });
+
+    await Promise.all([tx1, tx2]);
+
+    expect(tx2Ran).toBe(true);
+  });
+});
+
+describe("getDb", () => {
+  it("returns the same instance on repeated calls", async () => {
+    const db1 = await getDb();
+    const db2 = await getDb();
+    expect(db1).toBe(db2);
+  });
+});

--- a/src/services/imap/imapSync.ts
+++ b/src/services/imap/imapSync.ts
@@ -204,120 +204,133 @@ async function storeThreadsAndMessages(
 ): Promise<ParsedMessage[]> {
   const storedMessages: ParsedMessage[] = [];
 
+  // Pre-check pending ops OUTSIDE any transaction
+  const skippedThreadIds = new Set<string>();
   for (const group of threadGroups) {
-    const messages = group.messageIds
-      .map((id) => parsedByLocalId.get(id))
-      .filter((m): m is ParsedMessage => m !== undefined);
-
-    if (messages.length === 0) continue;
-
-    // Skip metadata overwrite for threads with pending local changes
     const pendingOps = await getPendingOpsForResource(accountId, group.threadId);
     if (pendingOps.length > 0) {
       console.log(`[imapSync] Skipping thread ${group.threadId}: has ${pendingOps.length} pending local ops`);
-      continue;
+      skippedThreadIds.add(group.threadId);
     }
+  }
 
-    // Assign threadId to each message
-    for (const msg of messages) {
-      msg.threadId = group.threadId;
-    }
+  // Process in batches within transactions to avoid long-held locks
+  for (let i = 0; i < threadGroups.length; i += THREAD_BATCH_SIZE) {
+    const batch = threadGroups.slice(i, i + THREAD_BATCH_SIZE);
 
-    // Sort by date ascending
-    messages.sort((a, b) => a.date - b.date);
+    await withTransaction(async () => {
+      for (const group of batch) {
+        if (skippedThreadIds.has(group.threadId)) continue;
 
-    const firstMessage = messages[0]!;
-    const lastMessage = messages[messages.length - 1]!;
+        const messages = group.messageIds
+          .map((id) => parsedByLocalId.get(id))
+          .filter((m): m is ParsedMessage => m !== undefined);
 
-    // Collect all label IDs across messages in this thread.
-    // Also include labels from duplicate folder copies (same RFC Message-ID
-    // in multiple folders) that the threading algorithm may have deduplicated.
-    const allLabelIds = new Set<string>();
-    for (const msg of messages) {
-      for (const lid of msg.labelIds) {
-        allLabelIds.add(lid);
-      }
-      // Merge labels from all folder copies of this message
-      const imapMsg = imapMsgByLocalId.get(msg.id);
-      const rfcId = imapMsg?.message_id;
-      if (rfcId && labelsByRfcId) {
-        const extraLabels = labelsByRfcId.get(rfcId);
-        if (extraLabels) {
-          for (const lid of extraLabels) {
+        if (messages.length === 0) continue;
+
+        // Assign threadId to each message
+        for (const msg of messages) {
+          msg.threadId = group.threadId;
+        }
+
+        // Sort by date ascending
+        messages.sort((a, b) => a.date - b.date);
+
+        const firstMessage = messages[0]!;
+        const lastMessage = messages[messages.length - 1]!;
+
+        // Collect all label IDs across messages in this thread.
+        // Also include labels from duplicate folder copies (same RFC Message-ID
+        // in multiple folders) that the threading algorithm may have deduplicated.
+        const allLabelIds = new Set<string>();
+        for (const msg of messages) {
+          for (const lid of msg.labelIds) {
             allLabelIds.add(lid);
           }
+          // Merge labels from all folder copies of this message
+          const imapMsg = imapMsgByLocalId.get(msg.id);
+          const rfcId = imapMsg?.message_id;
+          if (rfcId && labelsByRfcId) {
+            const extraLabels = labelsByRfcId.get(rfcId);
+            if (extraLabels) {
+              for (const lid of extraLabels) {
+                allLabelIds.add(lid);
+              }
+            }
+          }
+        }
+
+        const isRead = messages.every((m) => m.isRead);
+        const isStarred = messages.some((m) => m.isStarred);
+        const hasAttachments = messages.some((m) => m.hasAttachments);
+
+        await upsertThread({
+          id: group.threadId,
+          accountId,
+          subject: firstMessage.subject,
+          snippet: lastMessage.snippet,
+          lastMessageAt: lastMessage.date,
+          messageCount: messages.length,
+          isRead,
+          isStarred,
+          isImportant: false,
+          hasAttachments,
+        });
+
+        const labelArray = [...allLabelIds];
+        await setThreadLabels(accountId, group.threadId, labelArray);
+
+        // Store messages sequentially to avoid concurrent DB writes
+        for (const parsed of messages) {
+          const imapMsg = imapMsgByLocalId.get(parsed.id);
+
+          await upsertMessage({
+            id: parsed.id,
+            accountId,
+            threadId: parsed.threadId,
+            fromAddress: parsed.fromAddress,
+            fromName: parsed.fromName,
+            toAddresses: parsed.toAddresses,
+            ccAddresses: parsed.ccAddresses,
+            bccAddresses: parsed.bccAddresses,
+            replyTo: parsed.replyTo,
+            subject: parsed.subject,
+            snippet: parsed.snippet,
+            date: parsed.date,
+            isRead: parsed.isRead,
+            isStarred: parsed.isStarred,
+            bodyHtml: parsed.bodyHtml,
+            bodyText: parsed.bodyText,
+            rawSize: parsed.rawSize,
+            internalDate: parsed.internalDate,
+            listUnsubscribe: parsed.listUnsubscribe,
+            listUnsubscribePost: parsed.listUnsubscribePost,
+            authResults: parsed.authResults,
+            messageIdHeader: imapMsg?.message_id ?? null,
+            referencesHeader: imapMsg?.references ?? null,
+            inReplyToHeader: imapMsg?.in_reply_to ?? null,
+            imapUid: imapMsg?.uid ?? null,
+            imapFolder: imapMsg?.folder ?? null,
+          });
+
+          for (const att of parsed.attachments) {
+            await upsertAttachment({
+              id: `${parsed.id}_${att.gmailAttachmentId}`,
+              messageId: parsed.id,
+              accountId,
+              filename: att.filename,
+              mimeType: att.mimeType,
+              size: att.size,
+              gmailAttachmentId: att.gmailAttachmentId,
+              contentId: att.contentId,
+              isInline: att.isInline,
+            });
+          }
+
+          storedMessages.push(parsed);
         }
       }
-    }
-
-    const isRead = messages.every((m) => m.isRead);
-    const isStarred = messages.some((m) => m.isStarred);
-    const hasAttachments = messages.some((m) => m.hasAttachments);
-
-    await upsertThread({
-      id: group.threadId,
-      accountId,
-      subject: firstMessage.subject,
-      snippet: lastMessage.snippet,
-      lastMessageAt: lastMessage.date,
-      messageCount: messages.length,
-      isRead,
-      isStarred,
-      isImportant: false,
-      hasAttachments,
     });
-
-    const labelArray = [...allLabelIds];
-    await setThreadLabels(accountId, group.threadId, labelArray);
-
-    await Promise.all(messages.map(async (parsed) => {
-      const imapMsg = imapMsgByLocalId.get(parsed.id);
-
-      await upsertMessage({
-        id: parsed.id,
-        accountId,
-        threadId: parsed.threadId,
-        fromAddress: parsed.fromAddress,
-        fromName: parsed.fromName,
-        toAddresses: parsed.toAddresses,
-        ccAddresses: parsed.ccAddresses,
-        bccAddresses: parsed.bccAddresses,
-        replyTo: parsed.replyTo,
-        subject: parsed.subject,
-        snippet: parsed.snippet,
-        date: parsed.date,
-        isRead: parsed.isRead,
-        isStarred: parsed.isStarred,
-        bodyHtml: parsed.bodyHtml,
-        bodyText: parsed.bodyText,
-        rawSize: parsed.rawSize,
-        internalDate: parsed.internalDate,
-        listUnsubscribe: parsed.listUnsubscribe,
-        listUnsubscribePost: parsed.listUnsubscribePost,
-        authResults: parsed.authResults,
-        messageIdHeader: imapMsg?.message_id ?? null,
-        referencesHeader: imapMsg?.references ?? null,
-        inReplyToHeader: imapMsg?.in_reply_to ?? null,
-        imapUid: imapMsg?.uid ?? null,
-        imapFolder: imapMsg?.folder ?? null,
-      });
-
-      await Promise.all(parsed.attachments.map((att) =>
-        upsertAttachment({
-          id: `${parsed.id}_${att.gmailAttachmentId}`,
-          messageId: parsed.id,
-          accountId,
-          filename: att.filename,
-          mimeType: att.mimeType,
-          size: att.size,
-          gmailAttachmentId: att.gmailAttachmentId,
-          contentId: att.contentId,
-          isInline: att.isInline,
-        }),
-      ));
-
-      storedMessages.push(parsed);
-    }));
   }
 
   return storedMessages;
@@ -660,20 +673,25 @@ export async function imapInitialSync(
   for (let batchStart = 0; batchStart < threadGroups.length; batchStart += THREAD_BATCH_SIZE) {
     const batch = threadGroups.slice(batchStart, batchStart + THREAD_BATCH_SIZE);
 
+    // Pre-check pending ops OUTSIDE the transaction to avoid nested DB issues
+    const skippedThreadIds = new Set<string>();
+    for (const group of batch) {
+      const pendingOps = await getPendingOpsForResource(accountId, group.threadId);
+      if (pendingOps.length > 0) {
+        console.log(`[imapSync] Skipping thread ${group.threadId}: has ${pendingOps.length} pending local ops`);
+        skippedThreadIds.add(group.threadId);
+      }
+    }
+
     await withTransaction(async () => {
       for (const group of batch) {
+        if (skippedThreadIds.has(group.threadId)) continue;
+
         const messages = group.messageIds
           .map((id) => allMeta.get(id))
           .filter((m): m is MessageMeta => m !== undefined);
 
         if (messages.length === 0) continue;
-
-        // Skip threads with pending local changes
-        const pendingOps = await getPendingOpsForResource(accountId, group.threadId);
-        if (pendingOps.length > 0) {
-          console.log(`[imapSync] Skipping thread ${group.threadId}: has ${pendingOps.length} pending local ops`);
-          continue;
-        }
 
         // Sort by date ascending
         messages.sort((a, b) => a.date - b.date);


### PR DESCRIPTION
## Summary
- Adds a promise-based mutex to `withTransaction()` to serialise concurrent transactions on the singleton SQLite connection, preventing overlapping `BEGIN`/`COMMIT`/`ROLLBACK` calls
- Moves `getPendingOpsForResource()` calls outside transaction blocks (Phase 4 and `storeThreadsAndMessages`) to eliminate nested DB access within active transactions
- Replaces `Promise.all` concurrent message upserts with sequential writes wrapped in batched transactions
- Guards `ROLLBACK` in catch block so SQLite auto-rollback no longer masks the original error

Closes #192

## Test plan
- [x] All 1532 existing tests pass
- [x] TypeScript type check passes (`tsc --noEmit`)
- [x] New `connection.test.ts` covers mutex serialisation, error handling, and ROLLBACK failure resilience (6 tests)
- [ ] Manual: add an IMAP account and verify initial sync completes without DB errors