### PR TITLE
fix: allow remote images to load when block setting is disabled

### DIFF
--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -39,7 +39,7 @@
       }
     ],
     "security": {
-      "csp": "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; connect-src https://www.googleapis.com https://oauth2.googleapis.com https://api.anthropic.com https://api.openai.com https://generativelanguage.googleapis.com https://www.gravatar.com https://login.microsoftonline.com https://graph.microsoft.com https://api.login.yahoo.com http://localhost:11434 http://localhost:1234 http://127.0.0.1:11434 http://127.0.0.1:1234 https://models.github.ai; img-src 'self' data: https://www.gravatar.com https://lh3.googleusercontent.com https://*.googleusercontent.com; font-src 'self' data:; frame-src 'self'"
+      "csp": "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; connect-src https://www.googleapis.com https://oauth2.googleapis.com https://api.anthropic.com https://api.openai.com https://generativelanguage.googleapis.com https://www.gravatar.com https://login.microsoftonline.com https://graph.microsoft.com https://api.login.yahoo.com http://localhost:11434 http://localhost:1234 http://127.0.0.1:11434 http://127.0.0.1:1234 https://models.github.ai; img-src 'self' data: https: http: https://www.gravatar.com https://lh3.googleusercontent.com https://*.googleusercontent.com; font-src 'self' data:; frame-src 'self'"
     },
     "trayIcon": null
   },


### PR DESCRIPTION
## Summary

- Fixes the CSP `img-src` directive that was blocking all remote email images regardless of the "Block Remote Images" setting
- Added `https:` and `http:` to the `img-src` CSP policy so the browser can actually fetch remote images when the application-level setting permits it

**Root cause**: The CSP only whitelisted `'self'`, `data:`, Gravatar, and Google domains. Since email HTML is rendered in an iframe that inherits the parent's CSP, all other remote image requests were blocked at the browser level — even when the user had "Block Remote Images" disabled.

Closes #197

## Test plan

- [x] Disable "Block Remote Images" in Settings → open an email with remote images → images should load
- [x] Enable "Block Remote Images" → images should be blocked with the "Images hidden" banner
- [x] Click "Load images" on the banner → images should appear
- [x] "Always load from sender" should persist across sessions

🤖 Generated with [Claude Code](https://claude.com/claude-code)