### PR TITLE
fix: allow native text-editing shortcuts in focused inputs

### DIFF
--- a/src/hooks/useKeyboardShortcuts.ts
+++ b/src/hooks/useKeyboardShortcuts.ts
@@ -103,8 +103,11 @@ export function useKeyboardShortcuts() {
       const keyMap = useShortcutStore.getState().keyMap;
       const { singleKey, twoKeySequences, ctrlCombos } = getCachedReverseMap(keyMap);
 
-      // Ctrl/Cmd shortcuts work everywhere
+      // Ctrl/Cmd shortcuts
       if (e.ctrlKey || e.metaKey) {
+        // Let native text-editing shortcuts work in inputs (select all, copy, cut, paste, undo, redo)
+        if (isInputFocused && ["a", "c", "x", "v", "z"].includes(e.key.toLowerCase())) return;
+
         for (const [actionId, binding] of ctrlCombos) {
           if (matchesKey(binding, e)) {
             e.preventDefault();


### PR DESCRIPTION
## Summary
Ctrl/Cmd+A (select all) was intercepted by the app's keyboard shortcut handler even when an input/textarea was focused, preventing native text selection in the search box and other inputs.

Now bypasses app shortcut handling for Ctrl/Cmd + A/C/X/V/Z when an input element is focused, letting the browser handle them natively.

## Changes
  - Added input focus check before Ctrl/Cmd shortcut processing in useKeyboardShortcuts.ts

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Enhancement (improving existing feature)
- [ ] Refactor (no behavior change)
- [ ] Documentation
- [ ] CI/Build

## Testing
- [x] Existing tests pass (`npm run test`)
- [] New tests added (if applicable)
- [x] Manually tested

