### PR TITLE
fix: repair migration 14 when marked applied but imap_folder_path column missing

### DIFF
--- a/src/services/db/migrations-repair.test.ts
+++ b/src/services/db/migrations-repair.test.ts
@@ -1,0 +1,131 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+
+vi.mock("@/services/db/connection", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/services/db/connection")>();
+  return {
+    ...actual,
+    getDb: vi.fn(),
+  };
+});
+
+import { getDb } from "@/services/db/connection";
+import { runMigrations } from "./migrations";
+
+const LABELS_BASE_COLUMNS = [
+  "id", "account_id", "name", "type", "color_bg", "color_fg", "visible", "sort_order",
+];
+
+const LABELS_IMAP_COLUMNS = [
+  ...LABELS_BASE_COLUMNS, "imap_folder_path", "imap_special_use",
+];
+
+function createStatefulMockDb(opts: {
+  appliedVersions: number[];
+  labelColumns: string[];
+}) {
+  const migrations = new Set(opts.appliedVersions);
+  const executedSql: string[] = [];
+
+  return {
+    migrations,
+    executedSql,
+    execute: vi.fn(async (sql: string, params?: unknown[]) => {
+      executedSql.push(sql);
+
+      if (sql.includes("INSERT OR IGNORE INTO _migrations") && params) {
+        migrations.add(params[0] as number);
+      }
+      if (sql.includes("DELETE FROM _migrations WHERE version >= 14")) {
+        for (let v = 14; v <= 30; v++) migrations.delete(v);
+      }
+      if (sql.includes("DELETE FROM _migrations WHERE version = 18")) {
+        migrations.delete(18);
+      }
+
+      return { rowsAffected: 1 };
+    }),
+    select: vi.fn(async (sql: string) => {
+      if (sql.includes("SELECT version FROM _migrations")) {
+        return [...migrations].sort((a, b) => a - b).map((v) => ({ version: v }));
+      }
+      if (sql.includes("PRAGMA table_info(labels)")) {
+        return opts.labelColumns.map((name) => ({ name }));
+      }
+      if (sql.includes("sqlite_master") && sql.includes("tasks")) {
+        return [{ name: "tasks" }];
+      }
+      if (sql.includes("imap_attachment_repair_v1")) {
+        return [{ value: "1" }];
+      }
+      return [];
+    }),
+  };
+}
+
+describe("runMigrations v14 repair", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("re-runs migration 14+ when marked applied but imap_folder_path column is missing", async () => {
+    const mockDb = createStatefulMockDb({
+      appliedVersions: Array.from({ length: 23 }, (_, i) => i + 1),
+      labelColumns: LABELS_BASE_COLUMNS,
+    });
+
+    vi.mocked(getDb).mockResolvedValue(mockDb as unknown as Awaited<ReturnType<typeof getDb>>);
+
+    await runMigrations();
+
+    expect(mockDb.executedSql).toContain(
+      "DELETE FROM _migrations WHERE version >= 14",
+    );
+
+    const reRanV14 = mockDb.executedSql.some(
+      (sql) => sql.includes("ALTER TABLE labels ADD COLUMN imap_folder_path"),
+    );
+    expect(reRanV14).toBe(true);
+  });
+
+  it("does not repair when imap_folder_path column already exists", async () => {
+    const mockDb = createStatefulMockDb({
+      appliedVersions: Array.from({ length: 23 }, (_, i) => i + 1),
+      labelColumns: LABELS_IMAP_COLUMNS,
+    });
+
+    vi.mocked(getDb).mockResolvedValue(mockDb as unknown as Awaited<ReturnType<typeof getDb>>);
+
+    await runMigrations();
+
+    const deletedV14 = mockDb.executedSql.some(
+      (sql) => sql.includes("DELETE FROM _migrations WHERE version >= 14"),
+    );
+    expect(deletedV14).toBe(false);
+
+    const ranV14Sql = mockDb.executedSql.some(
+      (sql) => sql.includes("ALTER TABLE labels ADD COLUMN imap_folder_path"),
+    );
+    expect(ranV14Sql).toBe(false);
+  });
+
+  it("does not repair when migration 14 has not been applied yet", async () => {
+    const mockDb = createStatefulMockDb({
+      appliedVersions: Array.from({ length: 13 }, (_, i) => i + 1),
+      labelColumns: LABELS_BASE_COLUMNS,
+    });
+
+    vi.mocked(getDb).mockResolvedValue(mockDb as unknown as Awaited<ReturnType<typeof getDb>>);
+
+    await runMigrations();
+
+    const deletedV14 = mockDb.executedSql.some(
+      (sql) => sql.includes("DELETE FROM _migrations WHERE version >= 14"),
+    );
+    expect(deletedV14).toBe(false);
+
+    const ranV14Sql = mockDb.executedSql.some(
+      (sql) => sql.includes("ALTER TABLE labels ADD COLUMN imap_folder_path"),
+    );
+    expect(ranV14Sql).toBe(true);
+  });
+});

--- a/src/services/db/migrations.ts
+++ b/src/services/db/migrations.ts
@@ -840,6 +840,22 @@ export async function runMigrations(): Promise<void> {
   );
   const appliedVersions = new Set(applied.map((r) => r.version));
 
+  // Repair: if migration 14 is marked applied but imap_folder_path column is
+  // missing from labels, remove v14+ records so they re-run
+  if (appliedVersions.has(14)) {
+    const labelCols = await db.select<{ name: string }[]>(
+      "PRAGMA table_info(labels)",
+    );
+    if (!labelCols.some((c) => c.name === "imap_folder_path")) {
+      console.warn("Migration v14 marked applied but imap_folder_path column missing — re-running");
+      await db.execute("DELETE FROM _migrations WHERE version >= 14");
+      const maxVersion = MIGRATIONS[MIGRATIONS.length - 1]!.version;
+      for (let v = 14; v <= maxVersion; v++) {
+        appliedVersions.delete(v);
+      }
+    }
+  }
+
   // Repair: if migration 18 is marked applied but tasks table is missing,
   // remove the stale record so it re-runs
   if (appliedVersions.has(18)) {


### PR DESCRIPTION
fixes #205

When migration 14 (IMAP/SMTP provider support) is recorded in _migrations but its schema changes didn't persist, sync fails with "table labels has no column named imap_folder_path". This adds a repair check (following the existing pattern used for migration 18) that detects the inconsistency and re-runs migrations 14+ on next startup.

Fixes #205

## Summary
Sync fails for all account types (including Gmail API) with "table labels has no column named imap_folder_path" when migration 14 is marked as applied in the `_migrations` table but the actual schema changes (ALTER TABLE) didn't persist. This PR adds a startup repair check that detects the inconsistency and re-runs migrations 14+, following the same pattern already used for migration 18.

## Changes
- Added a repair check in `runMigrations()` that queries `PRAGMA table_info(labels)` to verify the `imap_folder_path` column exists when migration 14 is marked as applied
- If the column is missing, deletes migration records >= 14 from `_migrations` so they re-run on startup
- Added unit tests covering the repair logic (column missing, column present, migration not yet applied)

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Enhancement (improving existing feature)
- [ ] Refactor (no behavior change)
- [ ] Documentation
- [ ] CI/Build

## Testing
- [x] Existing tests pass (`npm run test`)
- [x] New tests added (if applicable)
- [X] Manually tested

## Screenshots
Imagine a picture of all my emails working after I ran npm run tauri dev
