### PR TITLE
feat: auto-focus To field when composing new email

### DIFF
--- a/src/components/composer/AddressInput.tsx
+++ b/src/components/composer/AddressInput.tsx
@@ -6,6 +6,7 @@ interface AddressInputProps {
   addresses: string[];
   onChange: (addresses: string[]) => void;
   placeholder?: string;
+  autoFocus?: boolean;
 }
 
 export function AddressInput({
@@ -13,6 +14,7 @@ export function AddressInput({
   addresses,
   onChange,
   placeholder = "Add recipients...",
+  autoFocus = false,
 }: AddressInputProps) {
   const [inputValue, setInputValue] = useState("");
   const [suggestions, setSuggestions] = useState<DbContact[]>([]);
@@ -28,6 +30,12 @@ export function AddressInput({
       if (searchTimerRef.current) clearTimeout(searchTimerRef.current);
     };
   }, []);
+
+  useEffect(() => {
+    if (autoFocus) {
+      inputRef.current?.focus();
+    }
+  }, [autoFocus]);
 
   const handleInputChange = useCallback(
     (value: string) => {

--- a/src/components/composer/Composer.tsx
+++ b/src/components/composer/Composer.tsx
@@ -489,7 +489,7 @@ export function Composer() {
             selectedEmail={fromEmail ?? activeAccount?.email ?? ""}
             onChange={(alias) => setFromEmail(alias.email)}
           />
-          <AddressInput label="To" addresses={to} onChange={setTo} />
+          <AddressInput label="To" addresses={to} onChange={setTo} autoFocus={mode === "new"} />
           {showCcBcc ? (
             <>
               <AddressInput label="Cc" addresses={cc} onChange={setCc} />


### PR DESCRIPTION
## Summary
- Adds `autoFocus` prop to `AddressInput` component
- When composing a new email (`c` shortcut), the To field receives focus immediately
- Reply/forward modes are unaffected since recipients are already populated

## Test plan
- [ ] Press `c` to compose — To field should be focused and ready for typing
- [ ] Press `r` to reply — To field should NOT auto-focus (recipients pre-filled)
- [ ] Press `a` to reply all — same as reply
- [ ] Press `f` to forward — same as reply
- [ ] Existing `AddressInput` tests pass (`npm run test`)
- [ ] Type-check passes (`npx tsc --noEmit`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)