### PR TITLE
fix: wire up Cmd/Ctrl+Enter to send in main Composer

### DIFF
--- a/src/components/composer/Composer.tsx
+++ b/src/components/composer/Composer.tsx
@@ -186,6 +186,20 @@ export function Composer() {
     return () => { stopAutoSave(); };
   }, [isOpen, activeAccountId]);
 
+  // Handle Ctrl/Cmd+Enter to send
+  const handleSendRef = useRef<() => void>(() => {});
+  useEffect(() => {
+    if (!isOpen) return;
+    const handler = (e: KeyboardEvent) => {
+      if (e.key === "Enter" && (e.ctrlKey || e.metaKey)) {
+        e.preventDefault();
+        handleSendRef.current();
+      }
+    };
+    window.addEventListener("keydown", handler);
+    return () => window.removeEventListener("keydown", handler);
+  }, [isOpen]);
+
   const handleDragEnter = useCallback((e: React.DragEvent) => {
     e.preventDefault();
     dragCounterRef.current++;
@@ -298,6 +312,7 @@ export function Composer() {
     state.setUndoSendTimer(timer);
     closeComposer();
   }, [activeAccountId, activeAccount, closeComposer, getFullHtml]);
+  handleSendRef.current = handleSend;
 
   const handleSchedule = useCallback(async (scheduledAt: number) => {
     if (!activeAccountId || !activeAccount) return;


### PR DESCRIPTION
## Summary
- The Cmd/Ctrl+Enter send shortcut was **defined** in `shortcuts.ts` and **documented** in `helpContent.ts`, but never actually wired up in the main Composer component
- The global keyboard handler in `useKeyboardShortcuts.ts` (line 125) has a comment `// Send email shortcut handled by composer` and returns early — but the Composer never registered a keydown listener for it
- The `InlineReply` component had the identical pattern working correctly; this was simply missed in the modal Composer

## Fix
Adds a `window`-level keydown listener (matching `InlineReply`'s approach) that triggers `handleSend` on Cmd+Enter / Ctrl+Enter when the composer is open.

## Test plan
- [ ] Open composer (`c`), type a message, press Cmd+Enter (Mac) / Ctrl+Enter — email should send
- [ ] Verify InlineReply (`r` on a thread) Cmd+Enter still works as before
- [ ] Verify Cmd+Enter does nothing when composer is closed
- [ ] `npx tsc --noEmit` passes
- [ ] `npm run test` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)