### PR TITLE
feat: allow Tab to advance focus in composer address fields

### DIFF
--- a/src/components/composer/AddressInput.tsx
+++ b/src/components/composer/AddressInput.tsx
@@ -71,11 +71,14 @@ export function AddressInput({
 
   const handleKeyDown = (e: React.KeyboardEvent) => {
     if (e.key === "Enter" || e.key === "Tab" || e.key === ",") {
-      e.preventDefault();
       if (showSuggestions && selectedIdx >= 0) {
+        e.preventDefault();
         addAddress(suggestions[selectedIdx]!.email);
       } else if (inputValue.trim()) {
+        e.preventDefault();
         addAddress(inputValue);
+      } else if (e.key !== "Tab") {
+        e.preventDefault();
       }
     } else if (e.key === "Backspace" && !inputValue && addresses.length > 0) {
       removeAddress(addresses.length - 1);


### PR DESCRIPTION
## Summary
- Tab with text in the input → converts it to an address bubble (stays in field)
- Tab with empty input → moves focus to the next field (Subject, or Cc/Bcc if shown)
- Previously Tab always called `preventDefault()`, trapping focus in the address field permanently

## Test plan
- [ ] Type an address, press Tab → address becomes a bubble, cursor stays in field
- [ ] Press Tab again (empty input) → focus moves to Subject
- [ ] With Cc/Bcc shown: Tab from To → Cc → Bcc → Subject
- [ ] Enter and comma still work as before to add addresses
- [ ] `npm run test` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)