### PR TITLE
feat: add Cmd+, shortcut to open settings

### DIFF
--- a/src/constants/shortcuts.ts
+++ b/src/constants/shortcuts.ts
@@ -52,6 +52,7 @@ export const SHORTCUTS: ShortcutCategory[] = [
     { id: "app.send", keys: "Ctrl+Enter", desc: "Send email" },
     { id: "app.askInbox", keys: "i", desc: "Ask AI about your inbox" },
     { id: "app.help", keys: "?", desc: "Show keyboard shortcuts" },
+    { id: "app.settings", keys: "Cmd+,", desc: "Open settings" },
     { id: "app.syncFolder", keys: "F5", desc: "Sync current folder" },
   ]},
 ];

--- a/src/hooks/useKeyboardShortcuts.ts
+++ b/src/hooks/useKeyboardShortcuts.ts
@@ -5,7 +5,7 @@ import { useComposerStore } from "@/stores/composerStore";
 import { useAccountStore } from "@/stores/accountStore";
 import { useShortcutStore } from "@/stores/shortcutStore";
 import { useContextMenuStore } from "@/stores/contextMenuStore";
-import { navigateToLabel, navigateToThread, navigateBack, getActiveLabel, getSelectedThreadId } from "@/router/navigate";
+import { navigateToLabel, navigateToThread, navigateBack, getActiveLabel, getSelectedThreadId, navigateToSettings } from "@/router/navigate";
 import { archiveThread, trashThread, permanentDeleteThread, starThread, spamThread } from "@/services/emailActions";
 import { deleteThread as deleteThreadFromDb, pinThread as pinThreadDb, unpinThread as unpinThreadDb, muteThread as muteThreadDb, unmuteThread as unmuteThreadDb } from "@/services/db/threads";
 import { deleteDraftsForThread } from "@/services/gmail/draftDeletion";
@@ -472,6 +472,9 @@ async function executeAction(actionId: string): Promise<void> {
       break;
     case "app.help":
       window.dispatchEvent(new Event("velo-toggle-shortcuts-help"));
+      break;
+    case "app.settings":
+      navigateToSettings();
       break;
     case "app.syncFolder": {
       if (activeAccountId) {


### PR DESCRIPTION
## Summary
- Adds `Cmd+,` (macOS standard) to open Settings
- Works from anywhere, including when an input field is focused
- On Windows/Linux, `Ctrl+,` works equivalently (Velo treats Ctrl and Meta as interchangeable)

## Changes
- `src/constants/shortcuts.ts` — added `app.settings` shortcut definition
- `src/hooks/useKeyboardShortcuts.ts` — added `app.settings` case calling `navigateToSettings()`

## Test plan
- [ ] Press Cmd+, (Mac) / Ctrl+, (Windows/Linux) → Settings page opens
- [ ] Works when focused on inbox, thread view, or any input field
- [ ] Shows up in shortcuts help (`?`)
- [ ] `npm run test` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)