### PR TITLE
fix: auto-advance to next thread after deleting drafts

### DIFF
--- a/src/components/email/ActionBar.tsx
+++ b/src/components/email/ActionBar.tsx
@@ -3,11 +3,9 @@ import type { Thread } from "@/stores/threadStore";
 import { useThreadStore } from "@/stores/threadStore";
 import { useAccountStore } from "@/stores/accountStore";
 import { useActiveLabel } from "@/hooks/useRouteNavigation";
-import { archiveThread, trashThread, permanentDeleteThread, markThreadRead, starThread, spamThread } from "@/services/emailActions";
-import { deleteThread as deleteThreadFromDb, pinThread as pinThreadDb, unpinThread as unpinThreadDb, muteThread as muteThreadDb, unmuteThread as unmuteThreadDb } from "@/services/db/threads";
-import { deleteDraftsForThread } from "@/services/gmail/draftDeletion";
+import { archiveThread, trashThread, permanentDeleteThread, markThreadRead, starThread, spamThread, deleteDraftThread } from "@/services/emailActions";
+import { pinThread as pinThreadDb, unpinThread as unpinThreadDb, muteThread as muteThreadDb, unmuteThread as unmuteThreadDb } from "@/services/db/threads";
 import { snoozeThread } from "@/services/snooze/snoozeManager";
-import { getGmailClient } from "@/services/gmail/tokenManager";
 import { SnoozeDialog } from "./SnoozeDialog";
 import { FollowUpDialog } from "./FollowUpDialog";
 import { Archive, Trash2, MailOpen, Mail, Star, Clock, Ban, Pin, MailMinus, BellRing, VolumeX, Reply, ReplyAll, Forward, FolderInput, Printer, Download, ExternalLink, PanelRightClose, PanelRightOpen, ListTodo } from "lucide-react";
@@ -76,15 +74,8 @@ export function ActionBar({ thread, messages, noReply, defaultReplyMode = "reply
     const isDraftsView = activeLabel === "drafts";
     if (isTrashView) {
       await permanentDeleteThread(activeAccountId, thread.id, []);
-      await deleteThreadFromDb(activeAccountId, thread.id);
     } else if (isDraftsView) {
-      removeThread(thread.id);
-      try {
-        const client = await getGmailClient(activeAccountId);
-        await deleteDraftsForThread(client, activeAccountId, thread.id);
-      } catch (err) {
-        console.error("Failed to delete drafts:", err);
-      }
+      await deleteDraftThread(activeAccountId, thread.id);
     } else {
       await trashThread(activeAccountId, thread.id, []);
     }

--- a/src/components/ui/ContextMenuPortal.tsx
+++ b/src/components/ui/ContextMenuPortal.tsx
@@ -6,10 +6,8 @@ import { useAccountStore } from "@/stores/accountStore";
 import { getActiveLabel } from "@/router/navigate";
 import { useComposerStore } from "@/stores/composerStore";
 import { useLabelStore } from "@/stores/labelStore";
-import { archiveThread, trashThread, permanentDeleteThread, markThreadRead, starThread, spamThread, addThreadLabel, removeThreadLabel } from "@/services/emailActions";
-import { deleteThread as deleteThreadFromDb, pinThread as pinThreadDb, unpinThread as unpinThreadDb, muteThread as muteThreadDb, unmuteThread as unmuteThreadDb } from "@/services/db/threads";
-import { deleteDraftsForThread } from "@/services/gmail/draftDeletion";
-import { getGmailClient } from "@/services/gmail/tokenManager";
+import { archiveThread, trashThread, permanentDeleteThread, markThreadRead, starThread, spamThread, addThreadLabel, removeThreadLabel, deleteDraftThread } from "@/services/emailActions";
+import { pinThread as pinThreadDb, unpinThread as unpinThreadDb, muteThread as muteThreadDb, unmuteThread as unmuteThreadDb } from "@/services/db/threads";
 import { getMessagesForThread } from "@/services/db/messages";
 import { snoozeThread } from "@/services/snooze/snoozeManager";
 import { getEnabledQuickStepsForAccount, type DbQuickStep } from "@/services/db/quickSteps";
@@ -305,15 +303,8 @@ function ThreadMenu({
     for (const id of targetIds) {
       if (isTrashView) {
         await permanentDeleteThread(activeAccountId, id, []);
-        await deleteThreadFromDb(activeAccountId, id);
       } else if (isDraftsView) {
-        useThreadStore.getState().removeThread(id);
-        try {
-          const client = await getGmailClient(activeAccountId);
-          await deleteDraftsForThread(client, activeAccountId, id);
-        } catch (err) {
-          console.error("Failed to delete drafts:", err);
-        }
+        await deleteDraftThread(activeAccountId, id);
       } else {
         await trashThread(activeAccountId, id, []);
       }

--- a/src/hooks/useKeyboardShortcuts.ts
+++ b/src/hooks/useKeyboardShortcuts.ts
@@ -6,10 +6,8 @@ import { useAccountStore } from "@/stores/accountStore";
 import { useShortcutStore } from "@/stores/shortcutStore";
 import { useContextMenuStore } from "@/stores/contextMenuStore";
 import { navigateToLabel, navigateToThread, navigateBack, getActiveLabel, getSelectedThreadId } from "@/router/navigate";
-import { archiveThread, trashThread, permanentDeleteThread, starThread, spamThread } from "@/services/emailActions";
-import { deleteThread as deleteThreadFromDb, pinThread as pinThreadDb, unpinThread as unpinThreadDb, muteThread as muteThreadDb, unmuteThread as unmuteThreadDb } from "@/services/db/threads";
-import { deleteDraftsForThread } from "@/services/gmail/draftDeletion";
-import { getGmailClient } from "@/services/gmail/tokenManager";
+import { archiveThread, trashThread, permanentDeleteThread, starThread, spamThread, deleteDraftThread } from "@/services/emailActions";
+import { pinThread as pinThreadDb, unpinThread as unpinThreadDb, muteThread as muteThreadDb, unmuteThread as unmuteThreadDb } from "@/services/db/threads";
 import { getMessagesForThread } from "@/services/db/messages";
 import { parseUnsubscribeUrl } from "@/components/email/MessageItem";
 import { openUrl } from "@tauri-apps/plugin-opener";
@@ -320,15 +318,8 @@ async function executeAction(actionId: string): Promise<void> {
         for (const id of ids) {
           if (isTrashView) {
             await permanentDeleteThread(activeAccountId, id, []);
-            await deleteThreadFromDb(activeAccountId, id);
           } else if (isDraftsView) {
-            try {
-              const client = await getGmailClient(activeAccountId);
-              await deleteDraftsForThread(client, activeAccountId, id);
-              useThreadStore.getState().removeThread(id);
-            } catch (err) {
-              console.error("Draft delete failed:", err);
-            }
+            await deleteDraftThread(activeAccountId, id);
           } else {
             await trashThread(activeAccountId, id, []);
           }
@@ -336,15 +327,8 @@ async function executeAction(actionId: string): Promise<void> {
       } else if (selectedId && activeAccountId) {
         if (isTrashView) {
           await permanentDeleteThread(activeAccountId, selectedId, []);
-          await deleteThreadFromDb(activeAccountId, selectedId);
         } else if (isDraftsView) {
-          try {
-            const client = await getGmailClient(activeAccountId);
-            await deleteDraftsForThread(client, activeAccountId, selectedId);
-            useThreadStore.getState().removeThread(selectedId);
-          } catch (err) {
-            console.error("Draft delete failed:", err);
-          }
+          await deleteDraftThread(activeAccountId, selectedId);
         } else {
           await trashThread(activeAccountId, selectedId, []);
         }

--- a/src/services/emailActions.ts
+++ b/src/services/emailActions.ts
@@ -534,3 +534,22 @@ export function deleteDraft(
 ): Promise<ActionResult> {
   return executeEmailAction(accountId, { type: "deleteDraft", draftId });
 }
+
+/**
+ * Delete all drafts for a thread via the Gmail Drafts API.
+ * Handles optimistic UI removal with auto-advance, then performs the API call.
+ */
+export async function deleteDraftThread(
+  accountId: string,
+  threadId: string,
+): Promise<void> {
+  const { getGmailClient } = await import("@/services/gmail/tokenManager");
+  const { deleteDraftsForThread } = await import("@/services/gmail/draftDeletion");
+
+  const nextId = getNextThreadId(threadId);
+  useThreadStore.getState().removeThread(threadId);
+  if (nextId) navigateToThread(nextId);
+
+  const client = await getGmailClient(accountId);
+  await deleteDraftsForThread(client, accountId, threadId);
+}


### PR DESCRIPTION
## Summary
- Centralizes draft thread deletion in `emailActions.ts` with optimistic UI removal and auto-advance to the next thread (matching archive/trash/spam behavior)
- Draft deletion previously bypassed `emailActions.ts` because it requires the Gmail Drafts API, so it lacked auto-advance
- Removes redundant `deleteThreadFromDb` calls after `permanentDeleteThread` in trash deletion paths
- Cleans up unused imports (`getGmailClient`, `deleteDraftsForThread`, `deleteThreadFromDb`) from 3 call sites

## Test plan
- [ ] Delete a draft from the drafts view — focus should advance to the next thread
- [ ] Delete the last draft — should return to empty state
- [ ] Permanently delete from trash view — should advance to next thread
- [ ] Right-click delete drafts via context menu — same auto-advance behavior
- [ ] Archive/trash from inbox — existing auto-advance still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)