### PR TITLE
fix: use UTC methods in iCal all-day date formatting

### DIFF
--- a/src/services/calendar/icalHelper.ts
+++ b/src/services/calendar/icalHelper.ts
@@ -153,9 +153,9 @@ function formatDateTimeUTC(date: Date): string {
 }
 
 function formatDateOnly(date: Date): string {
-  const y = date.getFullYear();
-  const m = String(date.getMonth() + 1).padStart(2, "0");
-  const d = String(date.getDate()).padStart(2, "0");
+  const y = date.getUTCFullYear();
+  const m = String(date.getUTCMonth() + 1).padStart(2, "0");
+  const d = String(date.getUTCDate()).padStart(2, "0");
   return `${y}${m}${d}`;
 }
 


### PR DESCRIPTION
## Summary
- `formatDateOnly()` used local time methods (`getDate`, `getMonth`, `getFullYear`), causing all-day CalDAV events to be off by one day in negative UTC offset timezones
- Switched to UTC methods (`getUTCFullYear`, `getUTCMonth`, `getUTCDate`)

## Test plan
- [x] Existing `icalHelper.test.ts` all-day event test now passes (30/30 tests green)

🤖 Generated with [Claude Code](https://claude.com/claude-code)