### PR TITLE
fix: aggregate sync status across accounts

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -102,7 +102,6 @@ export default function App() {
   const sidebarCollapsed = useUIStore((s) => s.sidebarCollapsed);
   const [showAddAccount, setShowAddAccount] = useState(false);
   const [initialized, setInitialized] = useState(false);
-  const [syncStatus, setSyncStatus] = useState<string | null>(null);
   const [showCommandPalette, setShowCommandPalette] = useState(false);
   const [showShortcutsHelp, setShowShortcutsHelp] = useState(false);
   const [showAskInbox, setShowAskInbox] = useState(false);
@@ -380,31 +379,47 @@ export default function App() {
     // eslint-disable-next-line react-hooks/exhaustive-deps -- store setters are stable references
   }, []);
 
-  // Listen for sync status updates
+  // Listen for sync status updates, aggregated across all accounts.
+  // batch-start fires once per sync round with the total account count.
+  // The status bar stays visible until every account in the batch finishes.
   const backfillDoneRef = useRef(false);
   useEffect(() => {
-    const unsub = onSyncStatus((accountId, status, progress, error) => {
+    let expected = 0;
+    let finished = 0;
+    let clearTimer: ReturnType<typeof setTimeout> | null = null;
+
+    const unsub = onSyncStatus((accountId, status, progress, error, totalAccounts) => {
+      const ui = useUIStore.getState();
+
+      if (status === "batch-start") {
+        expected = totalAccounts ?? 0;
+        finished = 0;
+        if (clearTimer) { clearTimeout(clearTimer); clearTimer = null; }
+        ui.setSyncStatus("Syncing...", 0);
+        return;
+      }
+
       if (status === "syncing") {
-        if (progress) {
-          if (progress.phase === "messages") {
-            setSyncStatus(
-              `Syncing: ${progress.current}/${progress.total} messages`,
-            );
-          } else if (progress.phase === "labels") {
-            setSyncStatus("Syncing labels...");
-          } else if (progress.phase === "threads") {
-            setSyncStatus(`Building threads... (${progress.current}/${progress.total})`);
-          }
-        } else {
-          setSyncStatus("Syncing...");
+        if (expected === 0) expected = 1;
+        if (progress?.phase === "messages" && progress.total > 0) {
+          const accountFraction = progress.current / progress.total;
+          const overall = (finished + accountFraction) / expected;
+          ui.setSyncStatus(`Syncing: ${progress.current}/${progress.total} messages`, overall);
+        } else if (progress?.phase === "labels") {
+          ui.setSyncStatus("Syncing labels...", finished / expected);
+        } else if (progress?.phase === "threads") {
+          ui.setSyncStatus(`Building threads... (${progress.current}/${progress.total})`, finished / expected);
         }
       } else if (status === "done") {
-        setSyncStatus("Sync complete");
-        setTimeout(() => setSyncStatus(null), 2_000);
+        finished++;
+        if (finished >= expected) {
+          ui.setSyncStatus("Sync complete", 1);
+          clearTimer = setTimeout(() => { ui.setSyncStatus(null); clearTimer = null; }, 2_000);
+        } else {
+          ui.setSyncStatus(`Syncing (${finished}/${expected})...`, finished / expected);
+        }
         window.dispatchEvent(new Event("velo-sync-done"));
         updateBadgeCount();
-
-        // Backfill uncategorized threads after first successful sync
         if (!backfillDoneRef.current) {
           backfillDoneRef.current = true;
           import("./services/categorization/backfillService")
@@ -412,11 +427,12 @@ export default function App() {
             .catch((err) => console.error("Backfill error:", err));
         }
       } else if (status === "error") {
-        setSyncStatus(error ? `Sync failed: ${formatSyncError(error)}` : "Sync failed");
-        // Still dispatch sync-done so the UI refreshes with any partially stored data
+        finished++;
+        ui.setSyncStatus(error ? `Sync failed: ${formatSyncError(error)}` : "Sync failed");
         window.dispatchEvent(new Event("velo-sync-done"));
-        // Auto-clear the error after 8 seconds
-        setTimeout(() => setSyncStatus(null), 8_000);
+        if (finished >= expected) {
+          clearTimer = setTimeout(() => { ui.setSyncStatus(null); clearTimer = null; }, 8_000);
+        }
       }
     });
     return unsub;
@@ -562,17 +578,6 @@ export default function App() {
           <Outlet />
         </DndProvider>
       </div>
-
-      {/* Sync status bar */}
-      {syncStatus && (
-        <div
-          className={`fixed bottom-0 left-0 right-0 glass-panel text-white text-xs px-4 py-1.5 text-center z-40 animate-[slideUp_200ms_ease-out,fadeIn_200ms_ease-out] ${
-            syncStatus.startsWith("Sync failed") ? "bg-danger/90" : "bg-accent/90"
-          }`}
-        >
-          {syncStatus}
-        </div>
-      )}
 
       {showAddAccount && (
         <AddAccount

--- a/src/components/layout/Sidebar.tsx
+++ b/src/components/layout/Sidebar.tsx
@@ -656,9 +656,45 @@ export function Sidebar({ collapsed, onAddAccount }: SidebarProps) {
         ]}
       />
 
+      <SyncIndicator collapsed={collapsed} />
+
       {/* Pending operations indicator */}
       <PendingOpsIndicator collapsed={collapsed} />
     </aside>
+  );
+}
+
+function SyncIndicator({ collapsed }: { collapsed: boolean }) {
+  const syncStatus = useUIStore((s) => s.syncStatus);
+  const syncProgress = useUIStore((s) => s.syncProgress);
+  if (!syncStatus) return null;
+
+  const isError = syncStatus.startsWith("Sync failed");
+  const isDone = syncStatus === "Sync complete";
+  const progressWidth = syncProgress != null ? `${Math.round(syncProgress * 100)}%` : undefined;
+
+  return (
+    <div className="px-3 pb-1">
+      {!collapsed && (
+        <div className={`text-[0.6875rem] mb-1 truncate ${isError ? "text-danger" : "text-text-tertiary"}`}>
+          {syncStatus}
+        </div>
+      )}
+      <div className={`h-1 rounded-full overflow-hidden ${isError ? "bg-danger/20" : "bg-accent/20"}`}>
+        {progressWidth ? (
+          <div
+            className={`h-full rounded-full transition-[width] duration-300 ease-out ${
+              isError ? "bg-danger" : isDone ? "bg-success" : "bg-accent"
+            }`}
+            style={{ width: progressWidth }}
+          />
+        ) : (
+          <div
+            className={`h-full w-1/3 rounded-full ${isError ? "bg-danger" : "bg-accent"} animate-[indeterminate_1.5s_ease-in-out_infinite]`}
+          />
+        )}
+      </div>
+    </div>
   );
 }
 

--- a/src/services/gmail/syncManager.ts
+++ b/src/services/gmail/syncManager.ts
@@ -28,9 +28,10 @@ let pendingAccountIds: string[] | null = null;
 
 export type SyncStatusCallback = (
   accountId: string,
-  status: "syncing" | "done" | "error",
+  status: "syncing" | "done" | "error" | "batch-start",
   progress?: SyncProgress,
   error?: string,
+  totalAccounts?: number,
 ) => void;
 
 let statusCallback: SyncStatusCallback | null = null;
@@ -261,6 +262,7 @@ async function runSync(accountIds: string[]): Promise<void> {
 
   syncPromise = (async () => {
     try {
+      statusCallback?.("", "batch-start", undefined, undefined, accountIds.length);
       for (const id of accountIds) {
         await syncAccountInternal(id);
       }

--- a/src/stores/uiStore.ts
+++ b/src/stores/uiStore.ts
@@ -36,6 +36,8 @@ interface UIState {
   isOnline: boolean;
   pendingOpsCount: number;
   isSyncingFolder: string | null;
+  syncStatus: string | null;
+  syncProgress: number | null;
   setTheme: (theme: Theme) => void;
   toggleSidebar: () => void;
   setSidebarCollapsed: (collapsed: boolean) => void;
@@ -59,6 +61,7 @@ interface UIState {
   setOnline: (online: boolean) => void;
   setPendingOpsCount: (count: number) => void;
   setSyncingFolder: (folder: string | null) => void;
+  setSyncStatus: (status: string | null, progress?: number | null) => void;
 }
 
 export const useUIStore = create<UIState>((set) => ({
@@ -81,6 +84,8 @@ export const useUIStore = create<UIState>((set) => ({
   isOnline: true,
   pendingOpsCount: 0,
   isSyncingFolder: null,
+  syncStatus: null,
+  syncProgress: null,
 
   setTheme: (theme) => set({ theme }),
   toggleSidebar: () =>
@@ -156,4 +161,5 @@ export const useUIStore = create<UIState>((set) => ({
   setOnline: (isOnline) => set({ isOnline }),
   setPendingOpsCount: (pendingOpsCount) => set({ pendingOpsCount }),
   setSyncingFolder: (isSyncingFolder) => set({ isSyncingFolder }),
+  setSyncStatus: (syncStatus, syncProgress = null) => set({ syncStatus, syncProgress }),
 }));

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -330,6 +330,11 @@ body {
   100% { transform: scale(1); }
 }
 
+@keyframes indeterminate {
+  0% { transform: translateX(-100%); }
+  100% { transform: translateX(300%); }
+}
+
 /* CSSTransition: modal (scale + fade overlay, scale panel) */
 .modal-enter { opacity: 0; }
 .modal-enter .modal-panel { transform: scale(0.95); }


### PR DESCRIPTION
## Summary
- Move sync indicator from bottom status bar to sidebar progress bar
- Emit `batch-start` event with total account count so the UI knows how many accounts to expect upfront
- Progress bar stays visible until all accounts finish, preventing the flash-on/flash-off cycle with multi-account setups
- Show aggregated progress: `Syncing (1/3)...` with weighted progress bar across accounts

## Test plan
- [ ] Single account: sync shows progress bar, "Sync complete" for 2s, then clears
- [ ] Multi-account: bar stays visible through all accounts, no flashing
- [ ] Error during sync: shows error state, auto-clears after 8s
- [ ] Collapsed sidebar: only shows progress bar, no text

🤖 Generated with [Claude Code](https://claude.com/claude-code)