### PR TITLE
Add install.cat installer scripts and quick install docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,29 @@ Google Calendar sync with month, week, and day views. Create events without leav
 
 ## Installation
 
+### Quick Install
+
+#### macOS and Linux
+
+```bash
+curl -fsSL https://install.cat/avihaymenahem/velo | sh
+```
+
+The installer downloads the latest Velo release and installs:
+
+- **macOS**: the universal `.dmg`, copies `Velo.app`, and runs `xattr -cr` automatically
+- **Linux**: the latest `.deb` on Debian-like systems, with AppImage fallback elsewhere
+
+#### Windows PowerShell
+
+```powershell
+irm https://install.cat/avihaymenahem/velo | iex
+```
+
+The PowerShell installer downloads the latest Windows release and prefers the MSI installer when available.
+
+### Manual Download
+
 Download the latest release for your platform:
 
 **[Download Velo](https://github.com/avihaymenahem/velo/releases/latest)** -- Windows `.msi` / `.exe` &nbsp;&bull;&nbsp; macOS `.dmg` &nbsp;&bull;&nbsp; Linux `.deb` / `.AppImage`

--- a/install.ps1
+++ b/install.ps1
@@ -1,0 +1,57 @@
+[CmdletBinding()]
+param()
+
+$ErrorActionPreference = 'Stop'
+$ProgressPreference = 'SilentlyContinue'
+
+$repoSlug = 'avihaymenahem/velo'
+$apiUrl = "https://api.github.com/repos/$repoSlug/releases/latest"
+$headers = @{
+  Accept = 'application/vnd.github+json'
+  'User-Agent' = 'velo-install-script'
+}
+
+# Prefer the MSI because msiexec has predictable unattended install flags.
+Write-Host 'Fetching latest Velo release metadata...'
+$release = Invoke-RestMethod -Uri $apiUrl -Headers $headers
+$asset = $release.assets | Where-Object { $_.name -like '*_x64_en-US.msi' } | Select-Object -First 1
+$fallback = $release.assets | Where-Object { $_.name -like '*_x64-setup.exe' } | Select-Object -First 1
+
+if (-not $asset -and -not $fallback) {
+  throw 'Could not find a Windows MSI or setup.exe asset in the latest release.'
+}
+
+$selectedAsset = if ($asset) { $asset } else { $fallback }
+$tempDir = if ($env:TEMP) { $env:TEMP } else { [System.IO.Path]::GetTempPath() }
+$tempInstaller = Join-Path $tempDir $selectedAsset.name
+
+try {
+  Write-Host 'Downloading Windows installer...'
+  Invoke-WebRequest -Uri $selectedAsset.browser_download_url -OutFile $tempInstaller
+
+  if ($selectedAsset.name -like '*.msi') {
+    Write-Host 'Running MSI installer...'
+    $process = Start-Process -FilePath 'msiexec.exe' -ArgumentList @('/i', $tempInstaller, '/passive', '/norestart') -PassThru -Wait
+    if ($process.ExitCode -ne 0) {
+      throw "MSI install failed with exit code $($process.ExitCode)."
+    }
+  }
+  else {
+    Write-Host 'Running setup.exe installer...'
+    $process = Start-Process -FilePath $tempInstaller -ArgumentList '/S' -PassThru -Wait
+    if ($process.ExitCode -ne 0) {
+      Write-Warning "Silent install exited with code $($process.ExitCode). Falling back to interactive installer."
+      $interactive = Start-Process -FilePath $tempInstaller -PassThru -Wait
+      if ($interactive.ExitCode -ne 0) {
+        throw "Interactive install failed with exit code $($interactive.ExitCode)."
+      }
+    }
+  }
+
+  Write-Host 'Velo installation completed.'
+}
+finally {
+  if (Test-Path $tempInstaller) {
+    Remove-Item $tempInstaller -Force -ErrorAction SilentlyContinue
+  }
+}

--- a/install.sh
+++ b/install.sh
@@ -8,10 +8,12 @@ TMP_DIR="$(mktemp -d "${TMPDIR:-/tmp}/velo-install.XXXXXX")"
 MOUNT_POINT=""
 
 cleanup() {
+  if [ -n "$TMP_DIR" ]; then
+    rm -rf "$TMP_DIR"
+  fi
   if [ -n "$MOUNT_POINT" ] && command -v hdiutil >/dev/null 2>&1; then
     hdiutil detach "$MOUNT_POINT" >/dev/null 2>&1 || true
   fi
-  rm -rf "$TMP_DIR"
 }
 
 trap cleanup EXIT INT TERM
@@ -31,6 +33,11 @@ need_cmd() {
 
 # Route sudo prompts to the terminal even when the script is piped into `sh`.
 run_sudo() {
+  if [ "$(id -u)" -eq 0 ]; then
+    "$@"
+    return
+  fi
+
   if [ ! -r /dev/tty ]; then
     fail "sudo access is required, but no interactive TTY is available"
   fi
@@ -182,6 +189,11 @@ need_cmd basename
 need_cmd mktemp
 
 RELEASE_JSON="$(release_json)"
+case "$RELEASE_JSON" in
+  *'"message": "API rate limit exceeded"'*)
+    fail "GitHub API rate limit exceeded. Please try again later or download Velo manually from Releases."
+    ;;
+esac
 OS_NAME="$(current_os)"
 ARCH_NAME="$(current_arch)"
 

--- a/install.sh
+++ b/install.sh
@@ -8,11 +8,11 @@ TMP_DIR="$(mktemp -d "${TMPDIR:-/tmp}/velo-install.XXXXXX")"
 MOUNT_POINT=""
 
 cleanup() {
-  if [ -n "$TMP_DIR" ]; then
-    rm -rf "$TMP_DIR"
-  fi
   if [ -n "$MOUNT_POINT" ] && command -v hdiutil >/dev/null 2>&1; then
     hdiutil detach "$MOUNT_POINT" >/dev/null 2>&1 || true
+  fi
+  if [ -n "$TMP_DIR" ]; then
+    rm -rf "$TMP_DIR"
   fi
 }
 

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,200 @@
+#!/bin/sh
+set -eu
+
+REPO_SLUG="avihaymenahem/velo"
+API_URL="https://api.github.com/repos/$REPO_SLUG/releases/latest"
+USER_AGENT="velo-install-script"
+TMP_DIR="$(mktemp -d "${TMPDIR:-/tmp}/velo-install.XXXXXX")"
+MOUNT_POINT=""
+
+cleanup() {
+  if [ -n "$MOUNT_POINT" ] && command -v hdiutil >/dev/null 2>&1; then
+    hdiutil detach "$MOUNT_POINT" >/dev/null 2>&1 || true
+  fi
+  rm -rf "$TMP_DIR"
+}
+
+trap cleanup EXIT INT TERM
+
+info() {
+  printf '%s\n' "$*"
+}
+
+fail() {
+  printf 'Error: %s\n' "$*" >&2
+  exit 1
+}
+
+need_cmd() {
+  command -v "$1" >/dev/null 2>&1 || fail "Missing required command: $1"
+}
+
+# Route sudo prompts to the terminal even when the script is piped into `sh`.
+run_sudo() {
+  if [ ! -r /dev/tty ]; then
+    fail "sudo access is required, but no interactive TTY is available"
+  fi
+
+  sudo "$@" < /dev/tty
+}
+
+# Use conservative retry flags that work on older curl builds.
+download() {
+  url="$1"
+  output="$2"
+  curl -fsSL --retry 3 --connect-timeout 10 -H "User-Agent: $USER_AGENT" "$url" -o "$output"
+}
+
+release_json() {
+  curl -fsSL --retry 3 --connect-timeout 10 -H "Accept: application/vnd.github+json" -H "User-Agent: $USER_AGENT" "$API_URL"
+}
+
+# Restrict asset matching to browser_download_url entries from the GitHub API.
+asset_url_for() {
+  pattern="$1"
+
+  printf '%s' "$RELEASE_JSON" \
+    | grep -o '"browser_download_url"[[:space:]]*:[[:space:]]*"[^"]*"' \
+    | cut -d '"' -f 4 \
+    | sed 's#\\/#/#g' \
+    | grep -E "$pattern" \
+    | head -n 1
+}
+
+current_os() {
+  uname -s
+}
+
+current_arch() {
+  case "$(uname -m)" in
+    x86_64|amd64)
+      printf 'x64\n'
+      ;;
+    arm64|aarch64)
+      printf 'arm64\n'
+      ;;
+    *)
+      printf 'unknown\n'
+      ;;
+  esac
+}
+
+install_macos() {
+  need_cmd hdiutil
+  need_cmd cp
+  need_cmd xattr
+
+  asset_url="$(asset_url_for 'universal\.dmg$')"
+  [ -n "$asset_url" ] || fail "Could not find a macOS universal DMG in the latest release"
+
+  dmg_path="$TMP_DIR/velo.dmg"
+  info "Downloading macOS installer..."
+  download "$asset_url" "$dmg_path"
+
+  info "Mounting disk image..."
+  mount_output="$(hdiutil attach -nobrowse "$dmg_path")"
+  mount_point="$(printf '%s\n' "$mount_output" | awk -F '\t' '/\/Volumes\// {print $NF; exit}')"
+  [ -n "$mount_point" ] || fail "Could not determine mounted volume"
+  MOUNT_POINT="$mount_point"
+
+  set -- "$mount_point"/*.app
+  [ -e "$1" ] || fail "Could not find Velo.app in the mounted disk image"
+  app_path="$1"
+  app_name="$(basename "$app_path")"
+
+  target_root="/Applications"
+  use_sudo=0
+  if [ ! -w "$target_root" ]; then
+    if command -v sudo >/dev/null 2>&1; then
+      use_sudo=1
+    else
+      target_root="$HOME/Applications"
+      mkdir -p "$target_root"
+    fi
+  fi
+  target_path="$target_root/$app_name"
+
+  info "Installing $app_name to $target_root..."
+  if [ "$use_sudo" -eq 1 ]; then
+    run_sudo rm -rf "$target_path"
+    run_sudo cp -R "$app_path" "$target_root/"
+    run_sudo xattr -cr "$target_path"
+  else
+    rm -rf "$target_path"
+    cp -R "$app_path" "$target_root/"
+    xattr -cr "$target_path"
+  fi
+
+  info "Unmounting disk image..."
+  hdiutil detach "$mount_point" >/dev/null
+  MOUNT_POINT=""
+
+  info "Velo installed at $target_path"
+}
+
+# Prefer the Debian package on Debian-like systems, otherwise fall back to AppImage.
+install_linux() {
+  arch="$1"
+  [ "$arch" = "x64" ] || fail "Linux installs currently support x86_64/amd64 release assets only"
+
+  if command -v apt-get >/dev/null 2>&1 && command -v dpkg >/dev/null 2>&1; then
+    asset_url="$(asset_url_for '_amd64\.deb$')"
+    [ -n "$asset_url" ] || fail "Could not find a Linux .deb asset in the latest release"
+    deb_path="$TMP_DIR/velo.deb"
+
+    info "Downloading Debian package..."
+    download "$asset_url" "$deb_path"
+
+    info "Installing Debian package..."
+    run_sudo apt-get install -y "$deb_path"
+    info "Velo installed from the latest .deb release"
+    return
+  fi
+
+  asset_url="$(asset_url_for '_amd64\.AppImage$')"
+  [ -n "$asset_url" ] || fail "Could not find a Linux AppImage asset in the latest release"
+
+  install_dir="$HOME/.local/bin"
+  install_path="$install_dir/velo"
+  mkdir -p "$install_dir"
+
+  info "Downloading AppImage fallback..."
+  download "$asset_url" "$install_path"
+  chmod +x "$install_path"
+
+  info "Velo installed at $install_path"
+  case ":$PATH:" in
+    *":$install_dir:"*)
+      ;;
+    *)
+      info "Add $install_dir to your PATH if it is not already available in new shells."
+      ;;
+  esac
+}
+
+need_cmd curl
+need_cmd grep
+need_cmd awk
+need_cmd cut
+need_cmd sed
+need_cmd head
+need_cmd basename
+need_cmd mktemp
+
+RELEASE_JSON="$(release_json)"
+OS_NAME="$(current_os)"
+ARCH_NAME="$(current_arch)"
+
+[ "$ARCH_NAME" != "unknown" ] || fail "Unsupported architecture: $(uname -m)"
+
+case "$OS_NAME" in
+  Darwin)
+    install_macos
+    ;;
+  Linux)
+    install_linux "$ARCH_NAME"
+    ;;
+  *)
+    fail "Unsupported operating system: $OS_NAME"
+    ;;
+esac


### PR DESCRIPTION
## Summary
Add install.cat-compatible installer scripts so Velo can be installed directly from the repo on macOS, Linux, and Windows.

## Changes
- add root `install.sh` for macOS/Linux with latest-release asset detection, universal DMG handling, Debian package installation, and AppImage fallback
- add root `install.ps1` that downloads the latest Windows release and prefers the MSI installer with setup.exe fallback
- update `README.md` to make install.cat the primary quick-install path while keeping GitHub Releases as the manual fallback

## Type of Change
- [x] New feature
- [x] Documentation

## Testing
- [ ] Existing tests pass (`npm run test`)
- [ ] New tests added (if applicable)
- [x] Manually tested

Validation performed:
- `sh -n install.sh`
- verified live release asset patterns for DMG, MSI, setup.exe, `.deb`, and AppImage
- `pwsh` was not available in this Linux environment, so `install.ps1` was statically reviewed only
- reviewer follow-up fixes were applied for root installs, cleanup order, and clearer rate-limit handling

## Screenshots
Not applicable.