### PR TITLE
feat: add workaround for better support for running on linux with nvidia

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -11,6 +11,37 @@ mod imap;
 mod oauth;
 mod smtp;
 
+#[cfg(desktop)]
+#[cfg(target_os = "linux")]
+mod linux {
+    fn check_nvidia_kernel_module_loaded() -> bool {
+        use std::path::Path;
+        let modules = ["nvidia", "nouveau"];
+        for module in &modules {
+            let path = format!("/sys/module/{}", module);
+            if Path::new(&path).exists() {
+                return true;
+            }
+        }
+        false
+    }
+    fn should_disable_dmabuf() -> Result<bool, ()> {
+        let nvidia_detected = check_nvidia_kernel_module_loaded();
+        if nvidia_detected {
+            eprintln!("Note: NVIDIA or Nouveau detected, disabling dmabuf renderer. Expect degraded renderer performance.");
+        }
+        Ok(nvidia_detected)
+    }
+
+    pub fn disable_webkit_dmabuf_rendering_if_needed() {
+        if let Ok(disable) = should_disable_dmabuf() {
+            if disable {
+                std::env::set_var("WEBKIT_DISABLE_DMABUF_RENDERER", "1");
+            }
+        }
+    }
+}
+
 #[tauri::command]
 fn close_splashscreen(app: tauri::AppHandle) {
     if let Some(w) = app.get_webview_window("splashscreen") {
@@ -59,6 +90,8 @@ pub fn run() {
             let _ = SetCurrentProcessExplicitAppUserModelID(w!("com.velomail.app"));
         }
     }
+    #[cfg(target_os = "linux")]
+    linux::disable_webkit_dmabuf_rendering_if_needed();
 
     tauri::Builder::default()
         // Single instance MUST be first


### PR DESCRIPTION
## Summary
<!-- Brief description of what this PR does and why -->
The workaround disables the dmabuf renderer when running on linux with nvidia or nouvea drivers. Otherwise one can only see an empty splashscreen window for a short period and the application terminates immediately.

See following known issues for more details:
* https://github.com/tauri-apps/tauri/issues/10702
* https://github.com/tauri-apps/tauri/issues/9304

I'm already using the same workaround in my tauri app for a longer period of time.

## Changes
- Added simple detection mechanism whether the app runs on linux with a nvidia card and disables the dmabuf renderer in that case.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Enhancement (improving existing feature)
- [ ] Refactor (no behavior change)
- [ ] Documentation
- [ ] CI/Build

## Testing
- [x] Existing tests pass (`npm run test`)
- [ ] New tests added (if applicable)
- [x] Manually tested

## Screenshots
<!-- If applicable, add screenshots -->
