### PR TITLE
feat: support separate SMTP credentials (username + password)

### DIFF
--- a/src/components/accounts/AddImapAccount.test.tsx
+++ b/src/components/accounts/AddImapAccount.test.tsx
@@ -1,0 +1,1155 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { AddImapAccount } from "./AddImapAccount";
+
+// ── Mocks ──────────────────────────────────────────────────────────────────
+
+const mockInsertImapAccount = vi.fn().mockResolvedValue(undefined);
+const mockInsertOAuthImapAccount = vi.fn().mockResolvedValue(undefined);
+
+vi.mock("@/services/db/accounts", () => ({
+  insertImapAccount: (...args: unknown[]) => mockInsertImapAccount(...args),
+  insertOAuthImapAccount: (...args: unknown[]) =>
+    mockInsertOAuthImapAccount(...args),
+}));
+
+const mockAddAccount = vi.fn();
+
+vi.mock("@/stores/accountStore", () => ({
+  useAccountStore: vi.fn(
+    (
+      selector: (s: { addAccount: typeof mockAddAccount }) => unknown,
+    ) => selector({ addAccount: mockAddAccount }),
+  ),
+}));
+
+const mockDiscoverSettings = vi.fn();
+const mockGetDefaultImapPort = vi.fn(
+  (s: string) => (s === "ssl" ? 993 : s === "starttls" ? 143 : 143),
+);
+const mockGetDefaultSmtpPort = vi.fn(
+  (s: string) => (s === "ssl" ? 465 : s === "starttls" ? 587 : 25),
+);
+
+vi.mock("@/services/imap/autoDiscovery", () => ({
+  discoverSettings: (...args: unknown[]) => mockDiscoverSettings(...args),
+  getDefaultImapPort: (...args: unknown[]) =>
+    mockGetDefaultImapPort(...args),
+  getDefaultSmtpPort: (...args: unknown[]) =>
+    mockGetDefaultSmtpPort(...args),
+}));
+
+vi.mock("@/services/oauth/providers", () => ({
+  getOAuthProvider: vi.fn(() => ({
+    id: "microsoft",
+    name: "Microsoft",
+    authUrl: "https://login.microsoftonline.com/common/oauth2/v2.0/authorize",
+    tokenUrl: "https://login.microsoftonline.com/common/oauth2/v2.0/token",
+    scopes: ["offline_access"],
+    usePkce: true,
+  })),
+}));
+
+const mockStartProviderOAuthFlow = vi.fn();
+
+vi.mock("@/services/oauth/oauthFlow", () => ({
+  startProviderOAuthFlow: (...args: unknown[]) =>
+    mockStartProviderOAuthFlow(...args),
+}));
+
+vi.mock("@tauri-apps/api/core", () => ({
+  invoke: vi.fn(),
+}));
+
+// CSSTransition mock: render children immediately when `in` is true
+vi.mock("react-transition-group", () => ({
+  CSSTransition: ({
+    in: inProp,
+    children,
+    unmountOnExit,
+  }: {
+    in: boolean;
+    children: React.ReactNode;
+    unmountOnExit?: boolean;
+  }) => {
+    if (!inProp && unmountOnExit) return null;
+    return <>{children}</>;
+  },
+}));
+
+import { invoke } from "@tauri-apps/api/core";
+
+// ── Helpers ────────────────────────────────────────────────────────────────
+
+const defaultProps = {
+  onClose: vi.fn(),
+  onSuccess: vi.fn(),
+  onBack: vi.fn(),
+};
+
+function renderComponent(props = {}) {
+  return render(<AddImapAccount {...defaultProps} {...props} />);
+}
+
+/** Fill basic step requirements so Next becomes enabled */
+function fillBasicStep() {
+  fireEvent.change(screen.getByPlaceholderText("you@example.com"), {
+    target: { value: "user@example.com" },
+  });
+  fireEvent.change(
+    screen.getByPlaceholderText("Enter your email password or app password"),
+    { target: { value: "secret123" } },
+  );
+}
+
+/** Navigate to a specific step by filling required fields and clicking Next */
+function navigateToStep(step: "imap" | "smtp" | "test") {
+  fillBasicStep();
+  fireEvent.click(screen.getByText("Next"));
+  if (step === "imap") return;
+
+  // Fill IMAP step
+  fireEvent.change(screen.getByPlaceholderText("imap.example.com"), {
+    target: { value: "imap.test.com" },
+  });
+  fireEvent.click(screen.getByText("Next"));
+  if (step === "smtp") return;
+
+  // Fill SMTP step
+  fireEvent.change(screen.getByPlaceholderText("smtp.example.com"), {
+    target: { value: "smtp.test.com" },
+  });
+  fireEvent.click(screen.getByText("Next"));
+}
+
+// ── Setup ──────────────────────────────────────────────────────────────────
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  crypto.randomUUID = vi.fn(
+    () => "test-uuid-1234",
+  ) as () => `${string}-${string}-${string}-${string}-${string}`;
+  mockDiscoverSettings.mockReturnValue(null);
+});
+
+// ── Phase 1: Tests for existing behavior ───────────────────────────────────
+
+describe("AddImapAccount", () => {
+  // ── 1. Rendering & Initial State ──────────────────────────────────────
+
+  describe("rendering and initial state", () => {
+    it("renders the modal with correct title", () => {
+      renderComponent();
+      expect(
+        screen.getByText("Add IMAP/SMTP Account"),
+      ).toBeInTheDocument();
+    });
+
+    it("renders all 4 step labels", () => {
+      renderComponent();
+      expect(screen.getByText("Account")).toBeInTheDocument();
+      expect(screen.getByText("Incoming")).toBeInTheDocument();
+      expect(screen.getByText("Outgoing")).toBeInTheDocument();
+      expect(screen.getByText("Verify")).toBeInTheDocument();
+    });
+
+    it("starts on basic step with email input", () => {
+      renderComponent();
+      expect(
+        screen.getByPlaceholderText("you@example.com"),
+      ).toBeInTheDocument();
+    });
+
+    it("renders Back, Cancel, and Next buttons", () => {
+      renderComponent();
+      expect(screen.getByText("Back")).toBeInTheDocument();
+      expect(screen.getByText("Cancel")).toBeInTheDocument();
+      expect(screen.getByText("Next")).toBeInTheDocument();
+    });
+
+    it("Next button is disabled when form is empty", () => {
+      renderComponent();
+      const nextBtn = screen.getByText("Next").closest("button")!;
+      expect(nextBtn).toBeDisabled();
+    });
+  });
+
+  // ── 2. Step Navigation ────────────────────────────────────────────────
+
+  describe("step navigation", () => {
+    it("enables Next when email and password are filled", () => {
+      renderComponent();
+      fillBasicStep();
+      const nextBtn = screen.getByText("Next").closest("button")!;
+      expect(nextBtn).not.toBeDisabled();
+    });
+
+    it("navigates from basic to imap step", () => {
+      renderComponent();
+      navigateToStep("imap");
+      expect(
+        screen.getByPlaceholderText("imap.example.com"),
+      ).toBeInTheDocument();
+    });
+
+    it("navigates from imap to smtp step", () => {
+      renderComponent();
+      navigateToStep("smtp");
+      expect(
+        screen.getByPlaceholderText("smtp.example.com"),
+      ).toBeInTheDocument();
+    });
+
+    it("navigates from smtp to test step", () => {
+      renderComponent();
+      navigateToStep("test");
+      expect(screen.getByText("Test Connection")).toBeInTheDocument();
+    });
+
+    it("Back navigates from imap to basic", () => {
+      renderComponent();
+      navigateToStep("imap");
+      fireEvent.click(screen.getByText("Back"));
+      expect(
+        screen.getByPlaceholderText("you@example.com"),
+      ).toBeInTheDocument();
+    });
+
+    it("Back on basic step calls onBack", () => {
+      renderComponent();
+      fireEvent.click(screen.getByText("Back"));
+      expect(defaultProps.onBack).toHaveBeenCalled();
+    });
+
+    it("Cancel calls onClose", () => {
+      renderComponent();
+      fireEvent.click(screen.getByText("Cancel"));
+      expect(defaultProps.onClose).toHaveBeenCalled();
+    });
+  });
+
+  // ── 3. Basic Step ─────────────────────────────────────────────────────
+
+  describe("basic step", () => {
+    it("triggers auto-discovery on email blur", () => {
+      renderComponent();
+      const emailInput = screen.getByPlaceholderText("you@example.com");
+      fireEvent.change(emailInput, {
+        target: { value: "user@fastmail.com" },
+      });
+      fireEvent.blur(emailInput);
+      expect(mockDiscoverSettings).toHaveBeenCalledWith("user@fastmail.com");
+    });
+
+    it("fills IMAP/SMTP settings from auto-discovery", () => {
+      mockDiscoverSettings.mockReturnValue({
+        settings: {
+          imapHost: "imap.fastmail.com",
+          imapPort: 993,
+          imapSecurity: "ssl",
+          smtpHost: "smtp.fastmail.com",
+          smtpPort: 465,
+          smtpSecurity: "ssl",
+        },
+        authMethods: ["password"],
+      });
+      renderComponent();
+      const emailInput = screen.getByPlaceholderText("you@example.com");
+      fireEvent.change(emailInput, {
+        target: { value: "user@fastmail.com" },
+      });
+      fireEvent.blur(emailInput);
+
+      // Fill password and advance to IMAP step to verify settings were applied
+      fireEvent.change(
+        screen.getByPlaceholderText(
+          "Enter your email password or app password",
+        ),
+        { target: { value: "pass" } },
+      );
+      fireEvent.click(screen.getByText("Next"));
+
+      expect(screen.getByDisplayValue("imap.fastmail.com")).toBeInTheDocument();
+    });
+
+    it("does not overwrite manually entered hosts on discovery", () => {
+      mockDiscoverSettings.mockReturnValue({
+        settings: {
+          imapHost: "discovered.com",
+          imapPort: 993,
+          imapSecurity: "ssl",
+          smtpHost: "discovered-smtp.com",
+          smtpPort: 465,
+          smtpSecurity: "ssl",
+        },
+        authMethods: ["password"],
+      });
+      renderComponent();
+
+      // Fill and advance to imap step first, set host manually, then go back
+      fillBasicStep();
+      fireEvent.click(screen.getByText("Next"));
+      fireEvent.change(screen.getByPlaceholderText("imap.example.com"), {
+        target: { value: "my-custom-host.com" },
+      });
+      fireEvent.click(screen.getByText("Back"));
+
+      // Blur email again — discovery should not re-apply since imapHost is already set
+      const emailInput = screen.getByPlaceholderText("you@example.com");
+      fireEvent.blur(emailInput);
+      // Discovery already applied once, so should not apply again (discoveryApplied flag)
+      // Navigate back to IMAP step to verify
+      fireEvent.click(screen.getByText("Next"));
+      expect(
+        screen.getByDisplayValue("my-custom-host.com"),
+      ).toBeInTheDocument();
+    });
+
+    it("accepts input in username field", () => {
+      renderComponent();
+      const usernameInput = screen.getByPlaceholderText(
+        "Leave blank to use your email address",
+      );
+      fireEvent.change(usernameInput, {
+        target: { value: "custom-user" },
+      });
+      expect(screen.getByDisplayValue("custom-user")).toBeInTheDocument();
+    });
+
+    it("accepts input in password field", () => {
+      renderComponent();
+      const pwInput = screen.getByPlaceholderText(
+        "Enter your email password or app password",
+      );
+      fireEvent.change(pwInput, { target: { value: "mypassword" } });
+      expect(screen.getByDisplayValue("mypassword")).toBeInTheDocument();
+    });
+  });
+
+  // ── 4. IMAP Step ──────────────────────────────────────────────────────
+
+  describe("IMAP step", () => {
+    it("renders IMAP host and port inputs", () => {
+      renderComponent();
+      navigateToStep("imap");
+      expect(
+        screen.getByPlaceholderText("imap.example.com"),
+      ).toBeInTheDocument();
+      expect(screen.getByDisplayValue("993")).toBeInTheDocument();
+    });
+
+    it("updates port when security changes", () => {
+      renderComponent();
+      navigateToStep("imap");
+      const securitySelect = document.getElementById(
+        "imap-security",
+      ) as HTMLSelectElement;
+      fireEvent.change(securitySelect, { target: { value: "starttls" } });
+      expect(mockGetDefaultImapPort).toHaveBeenCalledWith("starttls");
+    });
+
+    it("toggles accept-invalid-certs checkbox", () => {
+      renderComponent();
+      navigateToStep("imap");
+      const checkbox = document.getElementById(
+        "accept-invalid-certs",
+      ) as HTMLInputElement;
+      expect(checkbox.checked).toBe(false);
+      fireEvent.click(checkbox);
+      expect(checkbox.checked).toBe(true);
+    });
+
+    it("Next is disabled when IMAP host is empty", () => {
+      renderComponent();
+      navigateToStep("imap");
+      // Clear the host
+      fireEvent.change(screen.getByPlaceholderText("imap.example.com"), {
+        target: { value: "" },
+      });
+      const nextBtn = screen.getByText("Next").closest("button")!;
+      expect(nextBtn).toBeDisabled();
+    });
+  });
+
+  // ── 5. SMTP Step ──────────────────────────────────────────────────────
+
+  describe("SMTP step", () => {
+    it("renders SMTP host and port inputs", () => {
+      renderComponent();
+      navigateToStep("smtp");
+      expect(
+        screen.getByPlaceholderText("smtp.example.com"),
+      ).toBeInTheDocument();
+    });
+
+    it("updates port when security changes", () => {
+      renderComponent();
+      navigateToStep("smtp");
+      const securitySelect = document.getElementById(
+        "smtp-security",
+      ) as HTMLSelectElement;
+      fireEvent.change(securitySelect, { target: { value: "starttls" } });
+      expect(mockGetDefaultSmtpPort).toHaveBeenCalledWith("starttls");
+    });
+
+    it("same-credentials checkbox is checked by default", () => {
+      renderComponent();
+      navigateToStep("smtp");
+      const checkbox = document.getElementById(
+        "smtp-same-credentials",
+      ) as HTMLInputElement;
+      expect(checkbox.checked).toBe(true);
+    });
+
+    it("unchecking same-credentials reveals SMTP credential fields", () => {
+      renderComponent();
+      navigateToStep("smtp");
+      // Initially no SMTP password field
+      expect(screen.queryByPlaceholderText("SMTP password")).not.toBeInTheDocument();
+
+      const checkbox = document.getElementById(
+        "smtp-same-credentials",
+      ) as HTMLInputElement;
+      fireEvent.click(checkbox);
+
+      expect(
+        screen.getByPlaceholderText("SMTP password"),
+      ).toBeInTheDocument();
+    });
+  });
+
+  // ── 6. OAuth Flow ─────────────────────────────────────────────────────
+
+  describe("OAuth flow", () => {
+    function setupOAuthDiscovery() {
+      mockDiscoverSettings.mockReturnValue({
+        settings: {
+          imapHost: "outlook.office365.com",
+          imapPort: 993,
+          imapSecurity: "ssl",
+          smtpHost: "smtp.office365.com",
+          smtpPort: 587,
+          smtpSecurity: "starttls",
+        },
+        authMethods: ["oauth2", "password"],
+        oauthProviderId: "microsoft",
+      });
+    }
+
+    it("shows auth mode selector when discovery detects OAuth", () => {
+      setupOAuthDiscovery();
+      renderComponent();
+      const emailInput = screen.getByPlaceholderText("you@example.com");
+      fireEvent.change(emailInput, {
+        target: { value: "user@outlook.com" },
+      });
+      fireEvent.blur(emailInput);
+
+      expect(screen.getByText("Password")).toBeInTheDocument();
+      expect(screen.getByText("OAuth2")).toBeInTheDocument();
+    });
+
+    it("selecting OAuth2 hides password and shows Client ID", () => {
+      setupOAuthDiscovery();
+      renderComponent();
+      const emailInput = screen.getByPlaceholderText("you@example.com");
+      fireEvent.change(emailInput, {
+        target: { value: "user@outlook.com" },
+      });
+      fireEvent.blur(emailInput);
+
+      fireEvent.click(screen.getByText("OAuth2"));
+
+      expect(
+        screen.queryByPlaceholderText(
+          "Enter your email password or app password",
+        ),
+      ).not.toBeInTheDocument();
+      expect(
+        screen.getByPlaceholderText("Microsoft app Client ID"),
+      ).toBeInTheDocument();
+    });
+
+    it("Connect button is disabled without Client ID", () => {
+      setupOAuthDiscovery();
+      renderComponent();
+      const emailInput = screen.getByPlaceholderText("you@example.com");
+      fireEvent.change(emailInput, {
+        target: { value: "user@outlook.com" },
+      });
+      fireEvent.blur(emailInput);
+      fireEvent.click(screen.getByText("OAuth2"));
+
+      const connectBtn = screen
+        .getByText("Sign in with Microsoft")
+        .closest("button")!;
+      expect(connectBtn).toBeDisabled();
+    });
+
+    it("successful OAuth flow shows Connected message", async () => {
+      setupOAuthDiscovery();
+      mockStartProviderOAuthFlow.mockResolvedValue({
+        tokens: {
+          access_token: "acc-tok",
+          refresh_token: "ref-tok",
+          expires_in: 3600,
+        },
+        userInfo: { email: "user@outlook.com", name: "Test User" },
+      });
+
+      renderComponent();
+      const emailInput = screen.getByPlaceholderText("you@example.com");
+      fireEvent.change(emailInput, {
+        target: { value: "user@outlook.com" },
+      });
+      fireEvent.blur(emailInput);
+      fireEvent.click(screen.getByText("OAuth2"));
+
+      // Enter Client ID
+      fireEvent.change(
+        screen.getByPlaceholderText("Microsoft app Client ID"),
+        { target: { value: "my-client-id" } },
+      );
+      fireEvent.click(
+        screen.getByText("Sign in with Microsoft").closest("button")!,
+      );
+
+      await waitFor(() => {
+        expect(screen.getByText("user@outlook.com")).toBeInTheDocument();
+      });
+    });
+
+    it("displays OAuth error", async () => {
+      setupOAuthDiscovery();
+      mockStartProviderOAuthFlow.mockRejectedValue(
+        new Error("OAuth failed"),
+      );
+
+      renderComponent();
+      const emailInput = screen.getByPlaceholderText("you@example.com");
+      fireEvent.change(emailInput, {
+        target: { value: "user@outlook.com" },
+      });
+      fireEvent.blur(emailInput);
+      fireEvent.click(screen.getByText("OAuth2"));
+
+      fireEvent.change(
+        screen.getByPlaceholderText("Microsoft app Client ID"),
+        { target: { value: "my-client-id" } },
+      );
+      fireEvent.click(
+        screen.getByText("Sign in with Microsoft").closest("button")!,
+      );
+
+      await waitFor(() => {
+        expect(screen.getByText("OAuth failed")).toBeInTheDocument();
+      });
+    });
+  });
+
+  // ── 7. Connection Testing ─────────────────────────────────────────────
+
+  describe("connection testing", () => {
+    it("renders Test Connection button on test step", () => {
+      renderComponent();
+      navigateToStep("test");
+      expect(screen.getByText("Test Connection")).toBeInTheDocument();
+    });
+
+    it("invokes both imap_test_connection and smtp_test_connection", async () => {
+      const mockInvoke = vi.mocked(invoke);
+      mockInvoke.mockResolvedValueOnce("IMAP OK" as never);
+      mockInvoke.mockResolvedValueOnce({
+        success: true,
+        message: "SMTP OK",
+      } as never);
+
+      renderComponent();
+      navigateToStep("test");
+      fireEvent.click(screen.getByText("Test Connection"));
+
+      await waitFor(() => {
+        expect(mockInvoke).toHaveBeenCalledWith(
+          "imap_test_connection",
+          expect.objectContaining({
+            config: expect.objectContaining({ host: "imap.test.com" }),
+          }),
+        );
+        expect(mockInvoke).toHaveBeenCalledWith(
+          "smtp_test_connection",
+          expect.objectContaining({
+            config: expect.objectContaining({ host: "smtp.test.com" }),
+          }),
+        );
+      });
+    });
+
+    it("shows success state for IMAP test", async () => {
+      const mockInvoke = vi.mocked(invoke);
+      mockInvoke.mockImplementation(async (cmd) => {
+        if (cmd === "imap_test_connection") return "IMAP OK" as never;
+        return { success: true, message: "SMTP OK" } as never;
+      });
+
+      renderComponent();
+      navigateToStep("test");
+      fireEvent.click(screen.getByText("Test Connection"));
+
+      await waitFor(() => {
+        expect(screen.getByText("IMAP OK")).toBeInTheDocument();
+      });
+    });
+
+    it("shows error state for failed IMAP test", async () => {
+      const mockInvoke = vi.mocked(invoke);
+      mockInvoke.mockImplementation(async (cmd) => {
+        if (cmd === "imap_test_connection")
+          throw new Error("Connection refused");
+        return { success: true, message: "SMTP OK" } as never;
+      });
+
+      renderComponent();
+      navigateToStep("test");
+      fireEvent.click(screen.getByText("Test Connection"));
+
+      await waitFor(() => {
+        expect(screen.getByText("Connection refused")).toBeInTheDocument();
+      });
+    });
+
+    it("shows error state for failed SMTP test", async () => {
+      const mockInvoke = vi.mocked(invoke);
+      mockInvoke.mockImplementation(async (cmd) => {
+        if (cmd === "imap_test_connection") return "OK" as never;
+        return { success: false, message: "Auth failed" } as never;
+      });
+
+      renderComponent();
+      navigateToStep("test");
+      fireEvent.click(screen.getByText("Test Connection"));
+
+      await waitFor(() => {
+        expect(screen.getByText("Auth failed")).toBeInTheDocument();
+      });
+    });
+
+    it("uses smtpPassword for SMTP test when sameCredentials is false", async () => {
+      const mockInvoke = vi.mocked(invoke);
+      mockInvoke.mockImplementation(async (cmd) => {
+        if (cmd === "imap_test_connection") return "OK" as never;
+        return { success: true, message: "OK" } as never;
+      });
+
+      renderComponent();
+      fillBasicStep();
+      fireEvent.click(screen.getByText("Next"));
+      // IMAP step
+      fireEvent.change(screen.getByPlaceholderText("imap.example.com"), {
+        target: { value: "imap.test.com" },
+      });
+      fireEvent.click(screen.getByText("Next"));
+      // SMTP step — uncheck same password, enter SMTP password
+      fireEvent.change(screen.getByPlaceholderText("smtp.example.com"), {
+        target: { value: "smtp.test.com" },
+      });
+      const checkbox = document.getElementById(
+        "smtp-same-credentials",
+      ) as HTMLInputElement;
+      fireEvent.click(checkbox);
+      fireEvent.change(screen.getByPlaceholderText("SMTP password"), {
+        target: { value: "different-smtp-pass" },
+      });
+      fireEvent.click(screen.getByText("Next"));
+      // Test step
+      fireEvent.click(screen.getByText("Test Connection"));
+
+      await waitFor(() => {
+        expect(mockInvoke).toHaveBeenCalledWith(
+          "smtp_test_connection",
+          expect.objectContaining({
+            config: expect.objectContaining({
+              password: "different-smtp-pass",
+            }),
+          }),
+        );
+      });
+    });
+
+    it("uses imapUsername for SMTP test when set", async () => {
+      const mockInvoke = vi.mocked(invoke);
+      mockInvoke.mockImplementation(async (cmd) => {
+        if (cmd === "imap_test_connection") return "OK" as never;
+        return { success: true, message: "OK" } as never;
+      });
+
+      renderComponent();
+      // Basic step — set custom username
+      fireEvent.change(screen.getByPlaceholderText("you@example.com"), {
+        target: { value: "user@example.com" },
+      });
+      fireEvent.change(
+        screen.getByPlaceholderText("Leave blank to use your email address"),
+        { target: { value: "custom-imap-user" } },
+      );
+      fireEvent.change(
+        screen.getByPlaceholderText(
+          "Enter your email password or app password",
+        ),
+        { target: { value: "pass" } },
+      );
+      fireEvent.click(screen.getByText("Next"));
+      // IMAP step
+      fireEvent.change(screen.getByPlaceholderText("imap.example.com"), {
+        target: { value: "imap.test.com" },
+      });
+      fireEvent.click(screen.getByText("Next"));
+      // SMTP step
+      fireEvent.change(screen.getByPlaceholderText("smtp.example.com"), {
+        target: { value: "smtp.test.com" },
+      });
+      fireEvent.click(screen.getByText("Next"));
+      // Test step
+      fireEvent.click(screen.getByText("Test Connection"));
+
+      await waitFor(() => {
+        expect(mockInvoke).toHaveBeenCalledWith(
+          "smtp_test_connection",
+          expect.objectContaining({
+            config: expect.objectContaining({
+              username: "custom-imap-user",
+            }),
+          }),
+        );
+      });
+    });
+  });
+
+  // ── 8. Save Flow ──────────────────────────────────────────────────────
+
+  describe("save flow", () => {
+    function setupSuccessfulTests() {
+      const mockInvoke = vi.mocked(invoke);
+      mockInvoke.mockImplementation(async (cmd) => {
+        if (cmd === "imap_test_connection") return "OK" as never;
+        return { success: true, message: "OK" } as never;
+      });
+    }
+
+    async function navigateAndPassTests() {
+      navigateToStep("test");
+      fireEvent.click(screen.getByText("Test Connection"));
+      await waitFor(() => {
+        expect(screen.getByText("Add Account")).toBeInTheDocument();
+      });
+    }
+
+    it("Add Account button is disabled until both tests pass", () => {
+      renderComponent();
+      navigateToStep("test");
+      const addBtn = screen.getByText("Add Account").closest("button")!;
+      expect(addBtn).toBeDisabled();
+    });
+
+    it("Add Account button is enabled when both tests pass", async () => {
+      setupSuccessfulTests();
+      renderComponent();
+      await navigateAndPassTests();
+
+      await waitFor(() => {
+        const addBtn = screen.getByText("Add Account").closest("button")!;
+        expect(addBtn).not.toBeDisabled();
+      });
+    });
+
+    it("calls insertImapAccount with correct params", async () => {
+      setupSuccessfulTests();
+      renderComponent();
+      // Fill basic step
+      fireEvent.change(screen.getByPlaceholderText("you@example.com"), {
+        target: { value: "user@example.com" },
+      });
+      fireEvent.change(
+        screen.getByPlaceholderText(
+          "Enter your email password or app password",
+        ),
+        { target: { value: "secret123" } },
+      );
+      fireEvent.click(screen.getByText("Next"));
+      // IMAP step
+      fireEvent.change(screen.getByPlaceholderText("imap.example.com"), {
+        target: { value: "imap.test.com" },
+      });
+      fireEvent.click(screen.getByText("Next"));
+      // SMTP step
+      fireEvent.change(screen.getByPlaceholderText("smtp.example.com"), {
+        target: { value: "smtp.test.com" },
+      });
+      fireEvent.click(screen.getByText("Next"));
+      // Test
+      fireEvent.click(screen.getByText("Test Connection"));
+      await waitFor(() => {
+        expect(
+          screen.getByText("Add Account").closest("button"),
+        ).not.toBeDisabled();
+      });
+      // Save
+      fireEvent.click(screen.getByText("Add Account"));
+
+      await waitFor(() => {
+        expect(mockInsertImapAccount).toHaveBeenCalledWith(
+          expect.objectContaining({
+            id: "test-uuid-1234",
+            email: "user@example.com",
+            imapHost: "imap.test.com",
+            smtpHost: "smtp.test.com",
+            authMethod: "password",
+            password: "secret123",
+          }),
+        );
+      });
+    });
+
+    it("passes smtpPassword separately when sameCredentials is unchecked", async () => {
+      setupSuccessfulTests();
+      renderComponent();
+
+      // Fill basic step
+      fireEvent.change(screen.getByPlaceholderText("you@example.com"), {
+        target: { value: "user@example.com" },
+      });
+      fireEvent.change(
+        screen.getByPlaceholderText(
+          "Enter your email password or app password",
+        ),
+        { target: { value: "imap-pass" } },
+      );
+      fireEvent.click(screen.getByText("Next"));
+      // IMAP step
+      fireEvent.change(screen.getByPlaceholderText("imap.example.com"), {
+        target: { value: "imap.test.com" },
+      });
+      fireEvent.click(screen.getByText("Next"));
+      // SMTP step — uncheck same credentials, enter different SMTP password
+      fireEvent.change(screen.getByPlaceholderText("smtp.example.com"), {
+        target: { value: "smtp.test.com" },
+      });
+      const checkbox = document.getElementById(
+        "smtp-same-credentials",
+      ) as HTMLInputElement;
+      fireEvent.click(checkbox);
+      fireEvent.change(screen.getByPlaceholderText("SMTP password"), {
+        target: { value: "smtp-pass-different" },
+      });
+      fireEvent.click(screen.getByText("Next"));
+      // Test & Save
+      fireEvent.click(screen.getByText("Test Connection"));
+      await waitFor(() => {
+        expect(
+          screen.getByText("Add Account").closest("button"),
+        ).not.toBeDisabled();
+      });
+      fireEvent.click(screen.getByText("Add Account"));
+
+      await waitFor(() => {
+        expect(mockInsertImapAccount).toHaveBeenCalledWith(
+          expect.objectContaining({
+            password: "imap-pass",
+            smtpPassword: "smtp-pass-different",
+          }),
+        );
+      });
+    });
+
+    it("calls addAccount on the store after save", async () => {
+      setupSuccessfulTests();
+      renderComponent();
+      await navigateAndPassTests();
+      await waitFor(() => {
+        expect(
+          screen.getByText("Add Account").closest("button"),
+        ).not.toBeDisabled();
+      });
+      fireEvent.click(screen.getByText("Add Account"));
+
+      await waitFor(() => {
+        expect(mockAddAccount).toHaveBeenCalledWith(
+          expect.objectContaining({
+            id: "test-uuid-1234",
+            isActive: true,
+          }),
+        );
+      });
+    });
+
+    it("calls onSuccess after successful save", async () => {
+      setupSuccessfulTests();
+      renderComponent();
+      await navigateAndPassTests();
+      await waitFor(() => {
+        expect(
+          screen.getByText("Add Account").closest("button"),
+        ).not.toBeDisabled();
+      });
+      fireEvent.click(screen.getByText("Add Account"));
+
+      await waitFor(() => {
+        expect(defaultProps.onSuccess).toHaveBeenCalled();
+      });
+    });
+
+    it("displays save error when insertImapAccount fails", async () => {
+      setupSuccessfulTests();
+      mockInsertImapAccount.mockRejectedValueOnce(
+        new Error("DB write failed"),
+      );
+      renderComponent();
+      await navigateAndPassTests();
+      await waitFor(() => {
+        expect(
+          screen.getByText("Add Account").closest("button"),
+        ).not.toBeDisabled();
+      });
+      fireEvent.click(screen.getByText("Add Account"));
+
+      await waitFor(() => {
+        expect(screen.getByText("DB write failed")).toBeInTheDocument();
+      });
+    });
+
+    it("calls insertOAuthImapAccount for OAuth save", async () => {
+      mockDiscoverSettings.mockReturnValue({
+        settings: {
+          imapHost: "outlook.office365.com",
+          imapPort: 993,
+          imapSecurity: "ssl",
+          smtpHost: "smtp.office365.com",
+          smtpPort: 587,
+          smtpSecurity: "starttls",
+        },
+        authMethods: ["oauth2", "password"],
+        oauthProviderId: "microsoft",
+      });
+      mockStartProviderOAuthFlow.mockResolvedValue({
+        tokens: {
+          access_token: "acc-tok",
+          refresh_token: "ref-tok",
+          expires_in: 3600,
+        },
+        userInfo: { email: "user@outlook.com", name: "Test User" },
+      });
+      const mockInvoke = vi.mocked(invoke);
+      mockInvoke.mockImplementation(async (cmd) => {
+        if (cmd === "imap_test_connection") return "OK" as never;
+        return { success: true, message: "OK" } as never;
+      });
+
+      renderComponent();
+      // Setup OAuth
+      const emailInput = screen.getByPlaceholderText("you@example.com");
+      fireEvent.change(emailInput, {
+        target: { value: "user@outlook.com" },
+      });
+      fireEvent.blur(emailInput);
+      fireEvent.click(screen.getByText("OAuth2"));
+      fireEvent.change(
+        screen.getByPlaceholderText("Microsoft app Client ID"),
+        { target: { value: "client-123" } },
+      );
+      fireEvent.click(
+        screen.getByText("Sign in with Microsoft").closest("button")!,
+      );
+
+      await waitFor(() => {
+        expect(screen.getByText("user@outlook.com")).toBeInTheDocument();
+      });
+
+      // Navigate through steps
+      fireEvent.click(screen.getByText("Next"));
+      fireEvent.click(screen.getByText("Next"));
+      fireEvent.click(screen.getByText("Next"));
+
+      // Test connections
+      fireEvent.click(screen.getByText("Test Connection"));
+      await waitFor(() => {
+        expect(
+          screen.getByText("Add Account").closest("button"),
+        ).not.toBeDisabled();
+      });
+      fireEvent.click(screen.getByText("Add Account"));
+
+      await waitFor(() => {
+        expect(mockInsertOAuthImapAccount).toHaveBeenCalledWith(
+          expect.objectContaining({
+            oauthProvider: "microsoft",
+            oauthClientId: "client-123",
+            accessToken: "acc-tok",
+            refreshToken: "ref-tok",
+          }),
+        );
+      });
+    });
+  });
+
+  // ── Phase 2: Tests for new feature (RED) ───────────────────────────────
+
+  describe("separate SMTP credentials", () => {
+    it("checkbox label says 'Use same credentials as IMAP'", () => {
+      renderComponent();
+      navigateToStep("smtp");
+      expect(
+        screen.getByLabelText("Use same credentials as IMAP"),
+      ).toBeInTheDocument();
+    });
+
+    it("unchecking shows both SMTP username and SMTP password fields", () => {
+      renderComponent();
+      navigateToStep("smtp");
+      const checkbox = document.getElementById(
+        "smtp-same-credentials",
+      ) as HTMLInputElement;
+      fireEvent.click(checkbox);
+
+      expect(
+        screen.getByPlaceholderText("Leave blank to use IMAP username"),
+      ).toBeInTheDocument();
+      expect(
+        screen.getByPlaceholderText("SMTP password"),
+      ).toBeInTheDocument();
+    });
+
+    it("SMTP connection test uses smtpUsername when set", async () => {
+      const mockInvoke = vi.mocked(invoke);
+      mockInvoke.mockImplementation(async (cmd) => {
+        if (cmd === "imap_test_connection") return "OK" as never;
+        return { success: true, message: "OK" } as never;
+      });
+
+      renderComponent();
+      fillBasicStep();
+      fireEvent.click(screen.getByText("Next"));
+      // IMAP step
+      fireEvent.change(screen.getByPlaceholderText("imap.example.com"), {
+        target: { value: "imap.test.com" },
+      });
+      fireEvent.click(screen.getByText("Next"));
+      // SMTP step — uncheck same credentials, enter SMTP username
+      fireEvent.change(screen.getByPlaceholderText("smtp.example.com"), {
+        target: { value: "smtp.test.com" },
+      });
+      const checkbox = document.getElementById(
+        "smtp-same-credentials",
+      ) as HTMLInputElement;
+      fireEvent.click(checkbox);
+      fireEvent.change(
+        screen.getByPlaceholderText("Leave blank to use IMAP username"),
+        { target: { value: "smtp-specific-user" } },
+      );
+      fireEvent.change(screen.getByPlaceholderText("SMTP password"), {
+        target: { value: "smtp-pass" },
+      });
+      fireEvent.click(screen.getByText("Next"));
+      // Test step
+      fireEvent.click(screen.getByText("Test Connection"));
+
+      await waitFor(() => {
+        expect(mockInvoke).toHaveBeenCalledWith(
+          "smtp_test_connection",
+          expect.objectContaining({
+            config: expect.objectContaining({
+              username: "smtp-specific-user",
+              password: "smtp-pass",
+            }),
+          }),
+        );
+      });
+    });
+
+    it("save passes smtpUsername and smtpPassword to insertImapAccount", async () => {
+      const mockInvoke = vi.mocked(invoke);
+      mockInvoke.mockImplementation(async (cmd) => {
+        if (cmd === "imap_test_connection") return "OK" as never;
+        return { success: true, message: "OK" } as never;
+      });
+
+      renderComponent();
+      // Basic step
+      fireEvent.change(screen.getByPlaceholderText("you@example.com"), {
+        target: { value: "user@example.com" },
+      });
+      fireEvent.change(
+        screen.getByPlaceholderText(
+          "Enter your email password or app password",
+        ),
+        { target: { value: "imap-pass" } },
+      );
+      fireEvent.click(screen.getByText("Next"));
+      // IMAP step
+      fireEvent.change(screen.getByPlaceholderText("imap.example.com"), {
+        target: { value: "imap.test.com" },
+      });
+      fireEvent.click(screen.getByText("Next"));
+      // SMTP step — separate credentials
+      fireEvent.change(screen.getByPlaceholderText("smtp.example.com"), {
+        target: { value: "smtp.test.com" },
+      });
+      const checkbox = document.getElementById(
+        "smtp-same-credentials",
+      ) as HTMLInputElement;
+      fireEvent.click(checkbox);
+      fireEvent.change(
+        screen.getByPlaceholderText("Leave blank to use IMAP username"),
+        { target: { value: "smtp-user@relay.com" } },
+      );
+      fireEvent.change(screen.getByPlaceholderText("SMTP password"), {
+        target: { value: "smtp-secret" },
+      });
+      fireEvent.click(screen.getByText("Next"));
+      // Test & Save
+      fireEvent.click(screen.getByText("Test Connection"));
+      await waitFor(() => {
+        expect(
+          screen.getByText("Add Account").closest("button"),
+        ).not.toBeDisabled();
+      });
+      fireEvent.click(screen.getByText("Add Account"));
+
+      await waitFor(() => {
+        expect(mockInsertImapAccount).toHaveBeenCalledWith(
+          expect.objectContaining({
+            password: "imap-pass",
+            smtpUsername: "smtp-user@relay.com",
+            smtpPassword: "smtp-secret",
+          }),
+        );
+      });
+    });
+  });
+
+  // ── 9. Keyboard Navigation ────────────────────────────────────────────
+
+  describe("keyboard navigation", () => {
+    it("Enter advances step when canGoNext is true", () => {
+      renderComponent();
+      fillBasicStep();
+
+      const container = document.querySelector(".p-4")!;
+      fireEvent.keyDown(container, { key: "Enter" });
+
+      // Should have advanced to IMAP step
+      expect(
+        screen.getByPlaceholderText("imap.example.com"),
+      ).toBeInTheDocument();
+    });
+
+    it("Enter does not advance on test step", () => {
+      renderComponent();
+      navigateToStep("test");
+
+      const container = document.querySelector(".p-4")!;
+      fireEvent.keyDown(container, { key: "Enter" });
+
+      // Still on test step
+      expect(screen.getByText("Test Connection")).toBeInTheDocument();
+    });
+  });
+});

--- a/src/components/accounts/AddImapAccount.tsx
+++ b/src/components/accounts/AddImapAccount.tsx
@@ -44,8 +44,9 @@ interface FormState {
   smtpPort: number;
   smtpSecurity: SecurityType;
   password: string;
+  smtpUsername: string;
   smtpPassword: string;
-  samePassword: boolean;
+  sameCredentials: boolean;
   acceptInvalidCerts: boolean;
   // OAuth2 fields
   authMode: AuthMode;
@@ -69,8 +70,9 @@ const initialFormState: FormState = {
   smtpPort: 465,
   smtpSecurity: "ssl",
   password: "",
+  smtpUsername: "",
   smtpPassword: "",
-  samePassword: true,
+  sameCredentials: true,
   acceptInvalidCerts: false,
   authMode: "password",
   oauthProvider: null,
@@ -310,7 +312,7 @@ export function AddImapAccount({
     try {
       const smtpPassword = isOAuth
         ? (form.oauthAccessToken ?? "")
-        : form.samePassword
+        : form.sameCredentials
           ? form.password
           : form.smtpPassword;
       const result = await invoke<{ success: boolean; message: string }>(
@@ -320,7 +322,9 @@ export function AddImapAccount({
             host: form.smtpHost,
             port: form.smtpPort,
             security: mapSecurity(form.smtpSecurity),
-            username: form.imapUsername || (isOAuth ? (form.oauthEmail ?? form.email) : form.email),
+            username: (!form.sameCredentials && form.smtpUsername)
+              ? form.smtpUsername
+              : form.imapUsername || (isOAuth ? (form.oauthEmail ?? form.email) : form.email),
             password: smtpPassword,
             auth_method: isOAuth ? "oauth2" : "password",
             accept_invalid_certs: form.acceptInvalidCerts,
@@ -384,8 +388,10 @@ export function AddImapAccount({
           smtpPort: form.smtpPort,
           smtpSecurity: form.smtpSecurity,
           authMethod: "password",
-          password: form.samePassword ? form.password : form.password,
+          password: form.password,
           imapUsername,
+          smtpUsername: !form.sameCredentials && form.smtpUsername.trim() ? form.smtpUsername.trim() : null,
+          smtpPassword: !form.sameCredentials && form.smtpPassword.trim() ? form.smtpPassword : null,
           acceptInvalidCerts: form.acceptInvalidCerts,
         });
       }
@@ -785,33 +791,48 @@ export function AddImapAccount({
         <>
           <div className="flex items-center gap-2">
             <input
-              id="smtp-same-password"
+              id="smtp-same-credentials"
               type="checkbox"
-              checked={form.samePassword}
-              onChange={(e) => updateForm("samePassword", e.target.checked)}
+              checked={form.sameCredentials}
+              onChange={(e) => updateForm("sameCredentials", e.target.checked)}
               className="rounded border-border-primary text-accent focus:ring-accent"
             />
             <label
-              htmlFor="smtp-same-password"
+              htmlFor="smtp-same-credentials"
               className="text-sm text-text-secondary"
             >
-              Use same password as IMAP
+              Use same credentials as IMAP
             </label>
           </div>
-          {!form.samePassword && (
-            <div>
-              <label htmlFor="smtp-password" className={labelClass}>
-                SMTP Password
-              </label>
-              <input
-                id="smtp-password"
-                type="password"
-                value={form.smtpPassword}
-                onChange={(e) => updateForm("smtpPassword", e.target.value)}
-                placeholder="SMTP password"
-                className={inputClass}
-              />
-            </div>
+          {!form.sameCredentials && (
+            <>
+              <div>
+                <label htmlFor="smtp-username" className={labelClass}>
+                  SMTP Username (optional)
+                </label>
+                <input
+                  id="smtp-username"
+                  type="text"
+                  value={form.smtpUsername}
+                  onChange={(e) => updateForm("smtpUsername", e.target.value)}
+                  placeholder="Leave blank to use IMAP username"
+                  className={inputClass}
+                />
+              </div>
+              <div>
+                <label htmlFor="smtp-password" className={labelClass}>
+                  SMTP Password
+                </label>
+                <input
+                  id="smtp-password"
+                  type="password"
+                  value={form.smtpPassword}
+                  onChange={(e) => updateForm("smtpPassword", e.target.value)}
+                  placeholder="SMTP password"
+                  className={inputClass}
+                />
+              </div>
+            </>
           )}
         </>
       )}

--- a/src/services/db/accounts.test.ts
+++ b/src/services/db/accounts.test.ts
@@ -171,6 +171,8 @@ describe("accounts", () => {
         "password",
         "enc:my-app-password", // encrypted
         null, // imap_username
+        null, // smtp_username
+        null, // smtp_password
         0, // accept_invalid_certs
       ]);
     });
@@ -221,6 +223,75 @@ describe("accounts", () => {
       const [sql] = mockExecute.mock.calls[0] as [string, unknown[]];
       expect(sql).toContain("NULL, NULL");
       expect(sql).toContain("'imap'");
+    });
+  });
+
+  describe("insertImapAccount with SMTP credentials", () => {
+    it("stores smtp_username and encrypted smtp_password", async () => {
+      mockExecute.mockResolvedValue(undefined);
+
+      await insertImapAccount({
+        id: "imap-smtp",
+        email: "user@example.com",
+        displayName: null,
+        avatarUrl: null,
+        imapHost: "imap.example.com",
+        imapPort: 993,
+        imapSecurity: "ssl",
+        smtpHost: "smtp.relay.com",
+        smtpPort: 587,
+        smtpSecurity: "starttls",
+        authMethod: "password",
+        password: "imap-pass",
+        smtpUsername: "relay-user",
+        smtpPassword: "relay-secret",
+      });
+
+      expect(mockExecute).toHaveBeenCalledTimes(1);
+      const [sql, params] = mockExecute.mock.calls[0] as [string, unknown[]];
+      expect(sql).toContain("smtp_username");
+      expect(sql).toContain("smtp_password");
+      expect(params).toContain("relay-user");
+      expect(params).toContain("enc:relay-secret");
+    });
+
+    it("stores null for smtp_username/smtp_password when not provided", async () => {
+      mockExecute.mockResolvedValue(undefined);
+
+      await insertImapAccount({
+        id: "imap-no-smtp",
+        email: "user@example.com",
+        displayName: null,
+        avatarUrl: null,
+        imapHost: "imap.example.com",
+        imapPort: 993,
+        imapSecurity: "ssl",
+        smtpHost: "smtp.example.com",
+        smtpPort: 465,
+        smtpSecurity: "ssl",
+        authMethod: "password",
+        password: "pass",
+      });
+
+      const [sql, params] = mockExecute.mock.calls[0] as [string, unknown[]];
+      expect(sql).toContain("smtp_username");
+      expect(sql).toContain("smtp_password");
+      // smtp_username and smtp_password should be null
+      const paramArray = params as unknown[];
+      const smtpUsernameIdx = paramArray.indexOf(null, paramArray.indexOf("password"));
+      expect(smtpUsernameIdx).toBeGreaterThan(-1);
+    });
+  });
+
+  describe("decryptAccountTokens with smtp_password", () => {
+    it("decrypts smtp_password when encrypted", async () => {
+      mockSelectFirstBy.mockResolvedValue(
+        createMockImapAccount({ smtp_password: "enc:smtp-secret" }),
+      );
+
+      const result = await getAccount("acc-imap");
+
+      expect(result!.smtp_password).toBe("smtp-secret");
     });
   });
 

--- a/src/services/db/accounts.ts
+++ b/src/services/db/accounts.ts
@@ -34,42 +34,28 @@ export interface DbAccount {
   caldav_home_url: string | null;
   calendar_provider: string | null;
   accept_invalid_certs: number;
+  smtp_username: string | null;
+  smtp_password: string | null;
 }
 
+const ENCRYPTED_FIELDS: { key: keyof DbAccount; label: string }[] = [
+  { key: "access_token", label: "access token" },
+  { key: "refresh_token", label: "refresh token" },
+  { key: "imap_password", label: "IMAP password" },
+  { key: "oauth_client_secret", label: "OAuth client secret" },
+  { key: "caldav_password", label: "CalDAV password" },
+  { key: "smtp_password", label: "SMTP password" },
+];
+
 async function decryptAccountTokens(account: DbAccount): Promise<DbAccount> {
-  if (account.access_token && isEncrypted(account.access_token)) {
-    try {
-      account.access_token = await decryptValue(account.access_token);
-    } catch (err) {
-      console.warn("Failed to decrypt access token, using raw value:", err);
-    }
-  }
-  if (account.refresh_token && isEncrypted(account.refresh_token)) {
-    try {
-      account.refresh_token = await decryptValue(account.refresh_token);
-    } catch (err) {
-      console.warn("Failed to decrypt refresh token, using raw value:", err);
-    }
-  }
-  if (account.imap_password && isEncrypted(account.imap_password)) {
-    try {
-      account.imap_password = await decryptValue(account.imap_password);
-    } catch (err) {
-      console.warn("Failed to decrypt IMAP password, using raw value:", err);
-    }
-  }
-  if (account.oauth_client_secret && isEncrypted(account.oauth_client_secret)) {
-    try {
-      account.oauth_client_secret = await decryptValue(account.oauth_client_secret);
-    } catch (err) {
-      console.warn("Failed to decrypt OAuth client secret, using raw value:", err);
-    }
-  }
-  if (account.caldav_password && isEncrypted(account.caldav_password)) {
-    try {
-      account.caldav_password = await decryptValue(account.caldav_password);
-    } catch (err) {
-      console.warn("Failed to decrypt CalDAV password, using raw value:", err);
+  for (const { key, label } of ENCRYPTED_FIELDS) {
+    const value = account[key];
+    if (typeof value === "string" && isEncrypted(value)) {
+      try {
+        (account as Record<string, unknown>)[key] = await decryptValue(value);
+      } catch (err) {
+        console.warn(`Failed to decrypt ${label}, using raw value:`, err);
+      }
     }
   }
   return account;
@@ -194,13 +180,18 @@ export async function insertImapAccount(account: {
   authMethod: string;
   password: string;
   imapUsername?: string | null;
+  smtpUsername?: string | null;
+  smtpPassword?: string | null;
   acceptInvalidCerts?: boolean;
 }): Promise<void> {
   const db = await getDb();
   const encPassword = await encryptValue(account.password);
+  const encSmtpPassword = account.smtpPassword
+    ? await encryptValue(account.smtpPassword)
+    : null;
   await db.execute(
-    `INSERT INTO accounts (id, email, display_name, avatar_url, access_token, refresh_token, provider, imap_host, imap_port, imap_security, smtp_host, smtp_port, smtp_security, auth_method, imap_password, imap_username, accept_invalid_certs)
-     VALUES ($1, $2, $3, $4, NULL, NULL, 'imap', $5, $6, $7, $8, $9, $10, $11, $12, $13, $14)`,
+    `INSERT INTO accounts (id, email, display_name, avatar_url, access_token, refresh_token, provider, imap_host, imap_port, imap_security, smtp_host, smtp_port, smtp_security, auth_method, imap_password, imap_username, smtp_username, smtp_password, accept_invalid_certs)
+     VALUES ($1, $2, $3, $4, NULL, NULL, 'imap', $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16)`,
     [
       account.id,
       account.email,
@@ -215,6 +206,8 @@ export async function insertImapAccount(account: {
       account.authMethod,
       encPassword,
       account.imapUsername || null,
+      account.smtpUsername || null,
+      encSmtpPassword,
       account.acceptInvalidCerts ? 1 : 0,
     ],
   );

--- a/src/services/db/migrations.ts
+++ b/src/services/db/migrations.ts
@@ -775,6 +775,14 @@ const MIGRATIONS = [
     description: "Accept self-signed certificates for IMAP/SMTP",
     sql: `ALTER TABLE accounts ADD COLUMN accept_invalid_certs INTEGER DEFAULT 0;`,
   },
+  {
+    version: 24,
+    description: "Add separate SMTP username and password",
+    sql: `
+      ALTER TABLE accounts ADD COLUMN smtp_username TEXT;
+      ALTER TABLE accounts ADD COLUMN smtp_password TEXT;
+    `,
+  },
 ];
 
 /**

--- a/src/services/imap/imapConfigBuilder.test.ts
+++ b/src/services/imap/imapConfigBuilder.test.ts
@@ -146,6 +146,53 @@ describe("imap_username override", () => {
   });
 });
 
+describe("separate SMTP credentials", () => {
+  it("uses smtp_username when set", () => {
+    const account = createMockDbAccount({
+      smtp_username: "smtp-user",
+      imap_username: "imap-user",
+    });
+    const config = buildSmtpConfig(account);
+    expect(config.username).toBe("smtp-user");
+  });
+
+  it("falls back to imap_username when smtp_username is null", () => {
+    const account = createMockDbAccount({
+      smtp_username: null,
+      imap_username: "imap-user",
+    });
+    const config = buildSmtpConfig(account);
+    expect(config.username).toBe("imap-user");
+  });
+
+  it("falls back to email when both smtp_username and imap_username are null", () => {
+    const account = createMockDbAccount({
+      smtp_username: null,
+      imap_username: null,
+    });
+    const config = buildSmtpConfig(account);
+    expect(config.username).toBe("user@example.com");
+  });
+
+  it("uses smtp_password when set", () => {
+    const account = createMockDbAccount({
+      smtp_password: "smtp-secret",
+      imap_password: "imap-secret",
+    });
+    const config = buildSmtpConfig(account);
+    expect(config.password).toBe("smtp-secret");
+  });
+
+  it("falls back to imap_password when smtp_password is null", () => {
+    const account = createMockDbAccount({
+      smtp_password: null,
+      imap_password: "imap-secret",
+    });
+    const config = buildSmtpConfig(account);
+    expect(config.password).toBe("imap-secret");
+  });
+});
+
 describe("accept_invalid_certs", () => {
   it("defaults to false when account flag is 0", () => {
     const account = createMockDbAccount({ accept_invalid_certs: 0 });

--- a/src/services/imap/imapConfigBuilder.ts
+++ b/src/services/imap/imapConfigBuilder.ts
@@ -56,7 +56,8 @@ export function buildImapConfig(
 
 /**
  * Build a SmtpConfig from a DbAccount's SMTP fields.
- * Assumes the account's imap_password has already been decrypted.
+ * Uses smtp_username / smtp_password when set, falling back to
+ * imap_username / imap_password for backwards compatibility.
  *
  * For OAuth2 accounts, pass a fresh `accessToken` obtained from
  * `ensureFreshToken()` — it will be used as the password field.
@@ -73,13 +74,13 @@ export function buildSmtpConfig(
   const password =
     authMethod === "oauth2" && accessToken
       ? accessToken
-      : account.imap_password ?? "";
+      : account.smtp_password || account.imap_password || "";
 
   return {
     host: account.smtp_host,
     port: account.smtp_port ?? 587,
     security: mapSecurity(account.smtp_security),
-    username: account.imap_username || account.email,
+    username: account.smtp_username || account.imap_username || account.email,
     password,
     auth_method: authMethod,
     accept_invalid_certs: !!account.accept_invalid_certs,

--- a/src/test/mocks/entities.mock.ts
+++ b/src/test/mocks/entities.mock.ts
@@ -125,6 +125,8 @@ export function createMockGmailAccount(
     caldav_home_url: null,
     calendar_provider: null,
     accept_invalid_certs: 0,
+    smtp_username: null,
+    smtp_password: null,
     ...overrides,
   };
 }
@@ -165,6 +167,8 @@ export function createMockImapAccount(
     caldav_home_url: null,
     calendar_provider: null,
     accept_invalid_certs: 0,
+    smtp_username: null,
+    smtp_password: null,
     ...overrides,
   };
 }
@@ -205,6 +209,8 @@ export function createMockDbAccount(
     caldav_home_url: null,
     calendar_provider: null,
     accept_invalid_certs: 0,
+    smtp_username: null,
+    smtp_password: null,
     ...overrides,
   };
 }


### PR DESCRIPTION
  - Add smtp_username and smtp_password columns (migration v24)
  - Fix bug where SMTP password was collected but never persisted
  - Add SMTP Username field when 'Use same credentials as IMAP' is unchecked
  - buildSmtpConfig uses smtp_username/smtp_password with fallback to IMAP values
  - Refactor decryptAccountTokens to use ENCRYPTED_FIELDS loop
  - Add comprehensive test coverage for AddImapAccount (51 tests)

## Summary
<!-- Brief description of what this PR does and why -->

## Changes
<!-- List the key changes -->
-

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Enhancement (improving existing feature)
- [ ] Refactor (no behavior change)
- [ ] Documentation
- [ ] CI/Build

## Testing
- [ ] Existing tests pass (`npm run test`)
- [ ] New tests added (if applicable)
- [ ] Manually tested

## Screenshots
<!-- If applicable, add screenshots -->
