### PR TITLE
fix(ai): allow non-default ports in Tauri HTTP plugin scope

### DIFF
--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -66,9 +66,9 @@
       "identifier": "http:default",
       "allow": [
         { "url": "http://*" },
-        { "url": "http://*/*" },
+        { "url": "http://*:*" },
         { "url": "https://*" },
-        { "url": "https://*/*" }
+        { "url": "https://*:*" }
       ]
     },
     "updater:default",


### PR DESCRIPTION
## Summary

- Replaces `http://*/*` with `http://*:*` and `https://*/*` with `https://*:*` in the Tauri HTTP plugin capability scope
- The [URL Pattern spec](https://urlpattern.spec.whatwg.org/) treats `http://*` as matching port 80 only — the `*:*` form is required to allow any port
- This fixes connections to local AI servers running on non-default ports, such as LM Studio (`:1234`) and Ollama (`:11434`)

## Test plan

- [ ] Set AI provider to "Local AI (Ollama / LMStudio)" in Settings
- [ ] Set Server URL to `http://localhost:1234` (LM Studio) or `http://localhost:11434` (Ollama)
- [ ] Click "Test Connection" — should succeed where it previously silently failed

🤖 Generated with [Claude Code](https://claude.com/claude-code)