### PR TITLE
feat(sync): add "all time" sync period to fetch entire mailbox

### DIFF
--- a/src/components/settings/SettingsPage.tsx
+++ b/src/components/settings/SettingsPage.tsx
@@ -1022,10 +1022,14 @@ export function SettingsPage() {
                         <option value="90">Last 90 days</option>
                         <option value="180">Last 180 days</option>
                         <option value="365">Last 1 year</option>
+                        <option value="730">Last 2 years</option>
+                        <option value="1825">Last 5 years</option>
+                        <option value="0">All time (entire mailbox)</option>
                       </select>
                     </SettingRow>
                     <p className="text-xs text-text-tertiary">
-                      Changes apply on the next full resync.
+                      Changes apply on the next full resync. "All time" fetches your
+                      entire mailbox — this can take a while and use more disk space.
                     </p>
                   </Section>
 

--- a/src/services/gmail/sync.ts
+++ b/src/services/gmail/sync.ts
@@ -185,10 +185,14 @@ export async function initialSync(
   await syncLabels(client, accountId);
   onProgress?.({ phase: "labels", current: 1, total: 1 });
 
-  // Phase 2: Fetch thread list
-  const afterDate = new Date();
-  afterDate.setDate(afterDate.getDate() - daysBack);
-  const afterStr = `${afterDate.getFullYear()}/${afterDate.getMonth() + 1}/${afterDate.getDate()}`;
+  // Phase 2: Fetch thread list. daysBack <= 0 means "all time" — no date filter.
+  let query: string | undefined;
+  if (daysBack > 0) {
+    const afterDate = new Date();
+    afterDate.setDate(afterDate.getDate() - daysBack);
+    const afterStr = `${afterDate.getFullYear()}/${afterDate.getMonth() + 1}/${afterDate.getDate()}`;
+    query = `after:${afterStr}`;
+  }
 
   const threadStubs: { id: string }[] = [];
   let pageToken: string | undefined;
@@ -199,7 +203,7 @@ export async function initialSync(
     const response = await client.listThreads({
       maxResults: 100,
       pageToken,
-      q: `after:${afterStr}`,
+      q: query,
     });
 
     if (response.threads) {

--- a/src/services/gmail/syncManager.ts
+++ b/src/services/gmail/syncManager.ts
@@ -54,7 +54,10 @@ async function syncGmailAccount(accountId: string): Promise<void> {
   }
 
   const syncPeriodStr = await getSetting("sync_period_days");
-  const syncDays = parseInt(syncPeriodStr ?? "365", 10) || 365;
+  // 0 (or negative) means "all time" — preserve it; only fall back to 365 when
+  // the setting is missing/unparseable (NOT when it's a legitimate 0).
+  const parsedSyncDays = parseInt(syncPeriodStr ?? "365", 10);
+  const syncDays = Number.isNaN(parsedSyncDays) ? 365 : parsedSyncDays;
 
   if (account.history_id) {
     // Delta sync
@@ -95,7 +98,10 @@ async function syncImapAccount(accountId: string): Promise<void> {
   }
 
   const syncPeriodStr = await getSetting("sync_period_days");
-  const syncDays = parseInt(syncPeriodStr ?? "365", 10) || 365;
+  // 0 (or negative) means "all time" — preserve it; only fall back to 365 when
+  // the setting is missing/unparseable (NOT when it's a legitimate 0).
+  const parsedSyncDays = parseInt(syncPeriodStr ?? "365", 10);
+  const syncDays = Number.isNaN(parsedSyncDays) ? 365 : parsedSyncDays;
 
   if (account.history_id) {
     // Delta sync — IMAP uses folder-level UID tracking

--- a/src/services/imap/imapSync.ts
+++ b/src/services/imap/imapSync.ts
@@ -103,6 +103,15 @@ export function computeSinceDate(daysBack: number): string {
   return formatImapDate(date);
 }
 
+/**
+ * SINCE date string for `daysBack`, or null to fetch the whole folder.
+ * `daysBack <= 0` means "all time" — no date filter, so the Rust side issues
+ * `UID SEARCH ALL` instead of `UID SEARCH SINCE`.
+ */
+export function sinceDateForDaysBack(daysBack: number): string | null {
+  return daysBack > 0 ? computeSinceDate(daysBack) : null;
+}
+
 // ---------------------------------------------------------------------------
 // Progress reporting
 // ---------------------------------------------------------------------------
@@ -478,7 +487,7 @@ export async function imapInitialSync(
 
     try {
       // Phase 2a: Lightweight search — get UIDs only (no message bodies over IPC)
-      const sinceDate = computeSinceDate(daysBack);
+      const sinceDate = sinceDateForDaysBack(daysBack);
       const searchResult = await imapSearchFolder(config, folder.raw_path, sinceDate);
       const uidsToFetch = searchResult.uids;
 
@@ -488,7 +497,7 @@ export async function imapInitialSync(
       if (uidsToFetch.length === 0) continue;
 
       // Date filter config
-      const cutoffDate = Math.floor(Date.now() / 1000) - daysBack * 86400;
+      const cutoffDate = daysBack > 0 ? Math.floor(Date.now() / 1000) - daysBack * 86400 : 0;
       const nowSeconds = Math.floor(Date.now() / 1000);
       let dateFallbackCount = 0;
       let folderFetchedCount = 0;
@@ -867,7 +876,7 @@ export async function imapDeltaSync(accountId: string, daysBack = 365): Promise<
 
     const folderMapping = mapFolderToLabel(folder);
     try {
-      const sinceDate = computeSinceDate(daysBack);
+      const sinceDate = sinceDateForDaysBack(daysBack);
       const searchResult = await imapSearchFolder(config, folder.raw_path, sinceDate);
       consecutiveFailures = 0;
 
@@ -974,7 +983,7 @@ export async function imapDeltaSync(accountId: string, daysBack = 365): Promise<
               `(was ${savedState.uidvalidity}, now ${deltaResult.uidvalidity}). ` +
               `Doing full resync of this folder.`,
           );
-          const sinceDate = computeSinceDate(daysBack);
+          const sinceDate = sinceDateForDaysBack(daysBack);
           const searchResult = await imapSearchFolder(config, folder.raw_path, sinceDate);
           if (searchResult.uids.length === 0) continue;
 


### PR DESCRIPTION
Adds 2-year, 5-year, and "All time (entire mailbox)" options to the Sync
Period setting (previously capped at 1 year). "All time" is stored as 0,
meaning no date filter: IMAP issues UID SEARCH ALL instead of SINCE and
drops the per-message cutoff; Gmail drops the after: query filter.

Also fixes a latent bug where parseInt(setting) || 365 silently turned a
legitimate 0 back into 365; now only missing/unparseable values fall back.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
