### PR TITLE
feat: add Amazon Bedrock as an AI provider

### DIFF
--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -39,7 +39,7 @@
       }
     ],
     "security": {
-      "csp": "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; connect-src https://www.googleapis.com https://oauth2.googleapis.com https://api.anthropic.com https://api.openai.com https://generativelanguage.googleapis.com https://www.gravatar.com https://login.microsoftonline.com https://graph.microsoft.com https://api.login.yahoo.com http://localhost:11434 http://localhost:1234 http://127.0.0.1:11434 http://127.0.0.1:1234 https://models.github.ai; img-src 'self' data: https://www.gravatar.com https://lh3.googleusercontent.com https://*.googleusercontent.com; font-src 'self' data:; frame-src 'self'"
+      "csp": "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; connect-src https://www.googleapis.com https://oauth2.googleapis.com https://api.anthropic.com https://api.openai.com https://generativelanguage.googleapis.com https://www.gravatar.com https://login.microsoftonline.com https://graph.microsoft.com https://api.login.yahoo.com http://localhost:11434 http://localhost:1234 http://127.0.0.1:11434 http://127.0.0.1:1234 https://models.github.ai https://*.amazonaws.com; img-src 'self' data: https://www.gravatar.com https://lh3.googleusercontent.com https://*.googleusercontent.com; font-src 'self' data:; frame-src 'self'"
     },
     "trayIcon": null
   },

--- a/src/components/settings/SettingsPage.tsx
+++ b/src/components/settings/SettingsPage.tsx
@@ -112,7 +112,7 @@ export function SettingsPage() {
   const [phishingDetectionEnabled, setPhishingDetectionEnabled] = useState(true);
   const [phishingSensitivity, setPhishingSensitivity] = useState<"low" | "default" | "high">("default");
   const [autostartEnabled, setAutostartEnabled] = useState(false);
-  const [aiProvider, setAiProvider] = useState<"claude" | "openai" | "gemini" | "ollama" | "copilot">("claude");
+  const [aiProvider, setAiProvider] = useState<"claude" | "openai" | "gemini" | "ollama" | "copilot" | "bedrock">("claude");
   const [claudeApiKey, setClaudeApiKey] = useState("");
   const [openaiApiKey, setOpenaiApiKey] = useState("");
   const [geminiApiKey, setGeminiApiKey] = useState("");
@@ -123,12 +123,16 @@ export function SettingsPage() {
   const [openaiModel, setOpenaiModel] = useState("gpt-4o-mini");
   const [geminiModel, setGeminiModel] = useState("gemini-2.5-flash-preview-05-20");
   const [copilotModel, setCopilotModel] = useState("openai/gpt-4o-mini");
+  const [bedrockApiKey, setBedrockApiKey] = useState("");
+  const [bedrockRegion, setBedrockRegion] = useState("us-east-1");
+  const [bedrockModel, setBedrockModel] = useState("us.anthropic.claude-sonnet-4-6");
   const [aiEnabled, setAiEnabled] = useState(true);
   const [aiAutoCategorize, setAiAutoCategorize] = useState(true);
   const [aiAutoSummarize, setAiAutoSummarize] = useState(true);
   const [aiKeySaved, setAiKeySaved] = useState(false);
   const [aiTesting, setAiTesting] = useState(false);
   const [aiTestResult, setAiTestResult] = useState<"success" | "fail" | null>(null);
+  const [aiTestError, setAiTestError] = useState<string | null>(null);
   const [aiAutoDraftEnabled, setAiAutoDraftEnabled] = useState(true);
   const [aiWritingStyleEnabled, setAiWritingStyleEnabled] = useState(true);
   const [styleAnalyzing, setStyleAnalyzing] = useState(false);
@@ -174,7 +178,7 @@ export function SettingsPage() {
 
       // Load AI settings
       const provider = await getSetting("ai_provider");
-      if (provider === "openai" || provider === "gemini" || provider === "ollama" || provider === "copilot") setAiProvider(provider);
+      if (provider === "openai" || provider === "gemini" || provider === "ollama" || provider === "copilot" || provider === "bedrock") setAiProvider(provider);
       const ollamaUrl = await getSetting("ollama_server_url");
       if (ollamaUrl) setOllamaServerUrl(ollamaUrl);
       const ollamaModelVal = await getSetting("ollama_model");
@@ -195,6 +199,12 @@ export function SettingsPage() {
       setCopilotApiKey(copKey ?? "");
       const copilotModelVal = await getSetting("copilot_model");
       if (copilotModelVal) setCopilotModel(copilotModelVal);
+      const bedrockKey = await getSecureSetting("bedrock_api_key");
+      setBedrockApiKey(bedrockKey ?? "");
+      const bedrockReg = await getSetting("bedrock_region");
+      if (bedrockReg) setBedrockRegion(bedrockReg);
+      const bedrockModelVal = await getSetting("bedrock_model");
+      if (bedrockModelVal) setBedrockModel(bedrockModelVal);
       const aiEn = await getSetting("ai_enabled");
       setAiEnabled(aiEn !== "false");
       const aiCat = await getSetting("ai_auto_categorize");
@@ -1047,7 +1057,7 @@ export function SettingsPage() {
                       <select
                         value={aiProvider}
                         onChange={async (e) => {
-                          const val = e.target.value as "claude" | "openai" | "gemini" | "ollama" | "copilot";
+                          const val = e.target.value as "claude" | "openai" | "gemini" | "ollama" | "copilot" | "bedrock";
                           setAiProvider(val);
                           setAiTestResult(null);
                           await setSetting("ai_provider", val);
@@ -1061,6 +1071,7 @@ export function SettingsPage() {
                         <option value="gemini">Gemini (Google)</option>
                         <option value="ollama">Local AI (Ollama / LMStudio)</option>
                         <option value="copilot">GitHub Copilot</option>
+                        <option value="bedrock">Amazon Bedrock</option>
                       </select>
                     </SettingRow>
                     <p className="text-xs text-text-tertiary">
@@ -1069,6 +1080,7 @@ export function SettingsPage() {
                       {aiProvider === "gemini" && `Uses ${PROVIDER_MODELS.gemini.find((m) => m.id === geminiModel)?.label ?? geminiModel}.`}
                       {aiProvider === "ollama" && "Connect to a local Ollama or LMStudio server. No API key required."}
                       {aiProvider === "copilot" && `Uses ${PROVIDER_MODELS.copilot.find((m) => m.id === copilotModel)?.label ?? copilotModel}. Requires a GitHub PAT with models:read permission.`}
+                      {aiProvider === "bedrock" && `Uses ${bedrockModel}. Requires a Bedrock API key with InvokeModel access to the model.`}
                     </p>
                   </Section>
 
@@ -1133,6 +1145,87 @@ export function SettingsPage() {
                             <span className="text-xs text-danger">Connection failed</span>
                           )}
                         </div>
+                      </div>
+                    </Section>
+                  ) : aiProvider === "bedrock" ? (
+                    <Section title="API Key">
+                      <div className="space-y-3">
+                        <TextField
+                          label="Bedrock API Key"
+                          size="md"
+                          type="password"
+                          value={bedrockApiKey}
+                          onChange={(e) => setBedrockApiKey(e.target.value)}
+                          placeholder="••••••••"
+                        />
+                        <TextField
+                          label="Region"
+                          size="md"
+                          value={bedrockRegion}
+                          onChange={(e) => setBedrockRegion(e.target.value)}
+                          placeholder="us-east-1"
+                        />
+                        <TextField
+                          label="Model ID"
+                          size="md"
+                          value={bedrockModel}
+                          onChange={(e) => setBedrockModel(e.target.value)}
+                          placeholder="us.anthropic.claude-sonnet-4-6"
+                        />
+                        <p className="text-xs text-text-tertiary">
+                          Use the Bedrock model ID or inference-profile ID, e.g. <code>us.anthropic.claude-sonnet-4-6</code> or <code>us.anthropic.claude-opus-4-8</code>. The <code>us.</code> profiles require a US region; match the prefix (<code>eu.</code>, <code>apac.</code>) to your region. The model must be enabled under Bedrock → Model access.
+                        </p>
+                        <div className="flex items-center gap-2">
+                          <Button
+                            variant="primary"
+                            size="md"
+                            onClick={async () => {
+                              await setSecureSetting("bedrock_api_key", bedrockApiKey.trim());
+                              await setSetting("bedrock_region", bedrockRegion.trim());
+                              await setSetting("bedrock_model", bedrockModel);
+                              const { clearProviderClients } = await import("@/services/ai/providerManager");
+                              clearProviderClients();
+                              setAiKeySaved(true);
+                              setTimeout(() => setAiKeySaved(false), 2000);
+                            }}
+                            disabled={!bedrockApiKey.trim() || !bedrockRegion.trim()}
+                          >
+                            {aiKeySaved ? "Saved!" : "Save"}
+                          </Button>
+                          <Button
+                            variant="secondary"
+                            size="md"
+                            onClick={async () => {
+                              setAiTesting(true);
+                              setAiTestResult(null);
+                              setAiTestError(null);
+                              try {
+                                const { testConnectionDetailed } = await import("@/services/ai/aiService");
+                                const result = await testConnectionDetailed();
+                                setAiTestResult(result.ok ? "success" : "fail");
+                                if (!result.ok && result.error) setAiTestError(result.error);
+                              } catch (err) {
+                                setAiTestResult("fail");
+                                setAiTestError(err instanceof Error ? err.message : String(err));
+                              } finally {
+                                setAiTesting(false);
+                              }
+                            }}
+                            disabled={!bedrockApiKey.trim() || !bedrockRegion.trim() || aiTesting}
+                            className="bg-bg-tertiary text-text-primary border border-border-primary"
+                          >
+                            {aiTesting ? "Testing..." : "Test Connection"}
+                          </Button>
+                          {aiTestResult === "success" && (
+                            <span className="text-xs text-success">Connected!</span>
+                          )}
+                          {aiTestResult === "fail" && (
+                            <span className="text-xs text-danger">Connection failed</span>
+                          )}
+                        </div>
+                        {aiTestResult === "fail" && aiTestError && (
+                          <p className="text-xs text-danger break-all whitespace-pre-wrap">{aiTestError}</p>
+                        )}
                       </div>
                     </Section>
                   ) : (

--- a/src/services/ai/aiService.ts
+++ b/src/services/ai/aiService.ts
@@ -243,3 +243,18 @@ export async function testConnection(): Promise<boolean> {
     return false;
   }
 }
+
+/**
+ * Like testConnection, but surfaces the underlying error message. Runs a minimal
+ * completion (which propagates provider errors) instead of the provider's
+ * boolean testConnection (which swallows them) so the UI can show what failed.
+ */
+export async function testConnectionDetailed(): Promise<{ ok: boolean; error?: string }> {
+  try {
+    const provider = await getActiveProvider();
+    await provider.complete({ systemPrompt: "", userContent: "Say hi", maxTokens: 10 });
+    return { ok: true };
+  } catch (err) {
+    return { ok: false, error: err instanceof Error ? err.message : String(err) };
+  }
+}

--- a/src/services/ai/providerManager.test.ts
+++ b/src/services/ai/providerManager.test.ts
@@ -35,12 +35,18 @@ vi.mock("./providers/copilotProvider", () => ({
   clearCopilotProvider: vi.fn(),
 }));
 
+vi.mock("./providers/bedrockProvider", () => ({
+  createBedrockProvider: vi.fn(() => createMockAiProvider("bedrock response")),
+  clearBedrockProvider: vi.fn(),
+}));
+
 import { getSetting } from "@/services/db/settings";
 import { createClaudeProvider, clearClaudeProvider } from "./providers/claudeProvider";
 import { createOpenAIProvider } from "./providers/openaiProvider";
 import { createGeminiProvider } from "./providers/geminiProvider";
 import { createOllamaProvider } from "./providers/ollamaProvider";
 import { createCopilotProvider } from "./providers/copilotProvider";
+import { createBedrockProvider } from "./providers/bedrockProvider";
 import {
   getActiveProvider,
   getActiveProviderName,
@@ -80,6 +86,11 @@ describe("providerManager", () => {
     it("returns copilot when ai_provider is copilot", async () => {
       mockGetSetting.mockResolvedValue("copilot");
       expect(await getActiveProviderName()).toBe("copilot");
+    });
+
+    it("returns bedrock when ai_provider is bedrock", async () => {
+      mockGetSetting.mockResolvedValue("bedrock");
+      expect(await getActiveProviderName()).toBe("bedrock");
     });
 
     it("defaults to claude for unknown provider value", async () => {
@@ -191,6 +202,30 @@ describe("providerManager", () => {
       expect(createOllamaProvider).toHaveBeenCalledWith("http://localhost:11434", "llama3.2");
     });
 
+    it("creates bedrock provider with api key, default region and model", async () => {
+      mockGetSetting.mockImplementation(async (key: string) => {
+        if (key === "ai_provider") return "bedrock";
+        if (key === "bedrock_api_key") return "bedrock_key_test";
+        return null;
+      });
+
+      await getActiveProvider();
+      expect(createBedrockProvider).toHaveBeenCalledWith(
+        "bedrock_key_test",
+        "us-east-1",
+        "us.anthropic.claude-sonnet-4-6",
+      );
+    });
+
+    it("throws NOT_CONFIGURED when bedrock api key is missing", async () => {
+      mockGetSetting.mockImplementation(async (key: string) => {
+        if (key === "ai_provider") return "bedrock";
+        return null;
+      });
+
+      await expect(getActiveProvider()).rejects.toThrow("Bedrock API key not configured");
+    });
+
     it("throws NOT_CONFIGURED when API key is missing", async () => {
       mockGetSetting.mockImplementation(async (key: string) => {
         if (key === "ai_provider") return "openai";
@@ -294,6 +329,27 @@ describe("providerManager", () => {
       mockGetSetting.mockImplementation(async (key: string) => {
         if (key === "ai_enabled") return "true";
         if (key === "ai_provider") return "ollama";
+        return null;
+      });
+
+      expect(await isAiAvailable()).toBe(false);
+    });
+
+    it("returns true for bedrock when api key is configured", async () => {
+      mockGetSetting.mockImplementation(async (key: string) => {
+        if (key === "ai_enabled") return "true";
+        if (key === "ai_provider") return "bedrock";
+        if (key === "bedrock_api_key") return "bedrock_key_test";
+        return null;
+      });
+
+      expect(await isAiAvailable()).toBe(true);
+    });
+
+    it("returns false for bedrock when api key is not configured", async () => {
+      mockGetSetting.mockImplementation(async (key: string) => {
+        if (key === "ai_enabled") return "true";
+        if (key === "ai_provider") return "bedrock";
         return null;
       });
 

--- a/src/services/ai/providerManager.ts
+++ b/src/services/ai/providerManager.ts
@@ -7,8 +7,11 @@ import { createOpenAIProvider, clearOpenAIProvider } from "./providers/openaiPro
 import { createGeminiProvider, clearGeminiProvider } from "./providers/geminiProvider";
 import { createOllamaProvider, clearOllamaProvider } from "./providers/ollamaProvider";
 import { createCopilotProvider, clearCopilotProvider } from "./providers/copilotProvider";
+import { createBedrockProvider, clearBedrockProvider } from "./providers/bedrockProvider";
 
-const API_KEY_SETTINGS: Record<Exclude<AiProvider, "ollama">, string> = {
+// Bedrock and Ollama use their own credential shapes (not a single API key),
+// so they are handled as special cases in getActiveProvider below.
+const API_KEY_SETTINGS: Record<Exclude<AiProvider, "ollama" | "bedrock">, string> = {
   claude: "claude_api_key",
   openai: "openai_api_key",
   gemini: "gemini_api_key",
@@ -19,7 +22,14 @@ let cachedProvider: { name: AiProvider; key: string; client: AiProviderClient } 
 
 export async function getActiveProviderName(): Promise<AiProvider> {
   const setting = await getSetting("ai_provider");
-  if (setting === "openai" || setting === "gemini" || setting === "ollama" || setting === "copilot") return setting;
+  if (
+    setting === "openai" ||
+    setting === "gemini" ||
+    setting === "ollama" ||
+    setting === "copilot" ||
+    setting === "bedrock"
+  )
+    return setting;
   return "claude";
 }
 
@@ -37,6 +47,26 @@ export async function getActiveProvider(): Promise<AiProviderClient> {
 
     const client = createOllamaProvider(serverUrl, model);
     cachedProvider = { name: "ollama", key: cacheKey, client };
+    return client;
+  }
+
+  if (providerName === "bedrock") {
+    const apiKey = await getSecureSetting("bedrock_api_key");
+    const region = (await getSetting("bedrock_region")) ?? "us-east-1";
+
+    if (!apiKey) {
+      throw new AiError("NOT_CONFIGURED", "Bedrock API key not configured");
+    }
+
+    const model = (await getSetting("bedrock_model")) ?? DEFAULT_MODELS.bedrock;
+    const cacheKey = `${apiKey}|${region}|${model}`;
+
+    if (cachedProvider && cachedProvider.name === "bedrock" && cachedProvider.key === cacheKey) {
+      return cachedProvider.client;
+    }
+
+    const client = createBedrockProvider(apiKey, region, model);
+    cachedProvider = { name: "bedrock", key: cacheKey, client };
     return client;
   }
 
@@ -85,6 +115,11 @@ export async function isAiAvailable(): Promise<boolean> {
       return !!serverUrl;
     }
 
+    if (providerName === "bedrock") {
+      const apiKey = await getSecureSetting("bedrock_api_key");
+      return !!apiKey;
+    }
+
     const keySetting = API_KEY_SETTINGS[providerName];
     const key = await getSecureSetting(keySetting);
     return !!key;
@@ -100,4 +135,5 @@ export function clearProviderClients(): void {
   clearGeminiProvider();
   clearOllamaProvider();
   clearCopilotProvider();
+  clearBedrockProvider();
 }

--- a/src/services/ai/providers/bedrockProvider.ts
+++ b/src/services/ai/providers/bedrockProvider.ts
@@ -1,0 +1,80 @@
+import { fetch } from "@tauri-apps/plugin-http";
+import type { AiProviderClient, AiCompletionRequest } from "../types";
+
+/**
+ * Amazon Bedrock provider.
+ *
+ * Bedrock serves Anthropic Claude models through the InvokeModel endpoint using
+ * the standard Messages API request shape (plus `anthropic_version`). Auth uses a
+ * Bedrock API key sent as a bearer token. The region is still required because it
+ * is part of the endpoint host.
+ *
+ * The Bedrock runtime endpoint sends no CORS headers, so requests are routed
+ * through the Tauri HTTP plugin (native request) — the same workaround the Ollama
+ * provider uses for local servers.
+ */
+
+async function invoke(
+  apiKey: string,
+  region: string,
+  model: string,
+  body: Record<string, unknown>,
+): Promise<unknown> {
+  const url = `https://bedrock-runtime.${region}.amazonaws.com/model/${encodeURIComponent(model)}/invoke`;
+
+  const res = await fetch(url, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: `Bearer ${apiKey}`,
+    },
+    body: JSON.stringify(body),
+  });
+
+  if (!res.ok) {
+    const text = await res.text().catch(() => "");
+    throw new Error(`${res.status} ${text}`);
+  }
+  return res.json();
+}
+
+export function createBedrockProvider(
+  apiKey: string,
+  region: string,
+  model: string,
+): AiProviderClient {
+  return {
+    async complete(req: AiCompletionRequest): Promise<string> {
+      const body: Record<string, unknown> = {
+        anthropic_version: "bedrock-2023-05-31",
+        max_tokens: req.maxTokens ?? 1024,
+        messages: [{ role: "user", content: req.userContent }],
+      };
+      if (req.systemPrompt) body.system = req.systemPrompt;
+
+      const data = (await invoke(apiKey, region, model, body)) as {
+        content?: Array<{ type: string; text?: string }>;
+      };
+      const textBlock = data.content?.find((b) => b.type === "text");
+      return textBlock?.text ?? "";
+    },
+
+    async testConnection(): Promise<boolean> {
+      try {
+        await invoke(apiKey, region, model, {
+          anthropic_version: "bedrock-2023-05-31",
+          max_tokens: 10,
+          messages: [{ role: "user", content: "Say hi" }],
+        });
+        return true;
+      } catch (err) {
+        console.error("[Bedrock] test connection failed:", err);
+        return false;
+      }
+    },
+  };
+}
+
+// Stateless provider (no SDK client to cache); kept for symmetry with the other
+// providers' clear* functions. The provider-level cache lives in providerManager.
+export function clearBedrockProvider(): void {}

--- a/src/services/ai/types.ts
+++ b/src/services/ai/types.ts
@@ -1,4 +1,4 @@
-export type AiProvider = "claude" | "openai" | "gemini" | "ollama" | "copilot";
+export type AiProvider = "claude" | "openai" | "gemini" | "ollama" | "copilot" | "bedrock";
 
 export interface AiCompletionRequest {
   systemPrompt: string;
@@ -17,6 +17,7 @@ export const DEFAULT_MODELS: Record<AiProvider, string> = {
   gemini: "gemini-2.5-flash-preview-05-20",
   ollama: "llama3.2",
   copilot: "openai/gpt-4o-mini",
+  bedrock: "us.anthropic.claude-sonnet-4-6",
 };
 
 export interface ModelOption {
@@ -24,7 +25,9 @@ export interface ModelOption {
   label: string;
 }
 
-export const PROVIDER_MODELS: Record<Exclude<AiProvider, "ollama">, ModelOption[]> = {
+// Bedrock is excluded: its model is a free-text field (model availability varies
+// by AWS account/region and changes as versions reach end-of-life).
+export const PROVIDER_MODELS: Record<Exclude<AiProvider, "ollama" | "bedrock">, ModelOption[]> = {
   claude: [
     { id: "claude-haiku-4-5-20251001", label: "Claude Haiku 4.5" },
     { id: "claude-sonnet-4-20250514", label: "Claude Sonnet 4" },
@@ -50,7 +53,7 @@ export const PROVIDER_MODELS: Record<Exclude<AiProvider, "ollama">, ModelOption[
   ],
 };
 
-export const MODEL_SETTINGS: Record<Exclude<AiProvider, "ollama">, string> = {
+export const MODEL_SETTINGS: Record<Exclude<AiProvider, "ollama" | "bedrock">, string> = {
   claude: "claude_model",
   openai: "openai_model",
   gemini: "gemini_model",


### PR DESCRIPTION
## Summary
Adds **Amazon Bedrock** as a selectable AI provider, alongside the existing Claude, OpenAI, Gemini, Ollama, and Copilot providers. Bedrock serves Anthropic Claude models through its `InvokeModel` endpoint using the standard Messages API request shape, so it slots into Velo's existing `AiProviderClient` abstraction.

## Changes
- **New provider** `src/services/ai/providers/bedrockProvider.ts` — calls `https://bedrock-runtime.{region}.amazonaws.com/model/{id}/invoke` with the Messages API body (`anthropic_version: "bedrock-2023-05-31"`). Routed through the Tauri HTTP plugin to bypass the lack of CORS on the Bedrock runtime (same approach as the Ollama provider).
- **Auth = Bedrock API key** (bearer token) + region. No AWS SigV4 / access-key/secret handling.
- **Provider wiring** in `providerManager.ts` — Bedrock is special-cased like Ollama (reads `bedrock_api_key`, `bedrock_region`, `bedrock_model`); added to `getActiveProvider`, `isAiAvailable`, and `clearProviderClients`.
- **Types** — `"bedrock"` added to the `AiProvider` union and `DEFAULT_MODELS`. The Bedrock **model is a free-text field** (not a dropdown), since model availability varies by AWS account/region and IDs change as versions reach end-of-life.
- **Settings UI** (`SettingsPage.tsx`) — new "Amazon Bedrock" option with an API Key + Region + Model ID form. The Test Connection flow now surfaces the underlying error message (`testConnectionDetailed` in `aiService.ts`).
- **CSP** — added `https://*.amazonaws.com` to `connect-src` in `tauri.conf.json`.

## Type of Change
- [x] New feature

## Testing
- [x] Type-check clean (`npx tsc --noEmit`)
- [x] Tests pass (`npm run test`) — 1564 passed. (One unrelated, pre-existing failure in `icalHelper.test.ts`, a timezone-sensitive calendar date test; no AI/calendar code was touched here.)
- [x] New tests added — Bedrock provider selection and availability cases in `providerManager.test.ts`.
- [x] Manually tested — Test Connection succeeds against live AWS Bedrock (`us.anthropic.claude-sonnet-4-6`).

## Screenshots
_Settings → AI → Amazon Bedrock: API Key, Region, and Model ID fields._
