### PR TITLE
fix(list): reload the view the user is on, not the previous one

### DIFF
--- a/src/components/layout/EmailList.tsx
+++ b/src/components/layout/EmailList.tsx
@@ -452,19 +452,30 @@ export function EmailList({ width, listRef }: { width?: number; listRef?: React.
     }
   }, [selectedThreadId]);
 
+  // Always reload through the *current* loader.
+  //
+  // loadThreads closes over activeLabel and activeCategory, so a debounced
+  // reload scheduled before the user switches view re-runs the previous view's
+  // query and overwrites the list now on screen — the new view loads correctly
+  // and is replaced by the old one a second or two later.
+  const loadThreadsRef = useRef(loadThreads);
+  useEffect(() => {
+    loadThreadsRef.current = loadThreads;
+  }, [loadThreads]);
+
   // Listen for sync completion to reload (debounced to avoid waterfall from multiple emitters)
   useEffect(() => {
     let timer: ReturnType<typeof setTimeout> | null = null;
     const handler = () => {
       if (timer) clearTimeout(timer);
-      timer = setTimeout(() => loadThreads(), 500);
+      timer = setTimeout(() => loadThreadsRef.current(), 500);
     };
     window.addEventListener("velo-sync-done", handler);
     return () => {
       window.removeEventListener("velo-sync-done", handler);
       if (timer) clearTimeout(timer);
     };
-  }, [loadThreads, activeAccountId, activeLabel]);
+  }, []);
 
   // Infinite scroll: load more when near bottom
   useEffect(() => {


### PR DESCRIPTION
The debounced sync reload captures `loadThreads`, which closes over `activeLabel` and `activeCategory`:

```ts
timer = setTimeout(() => loadThreads(), 500);
```

A reload scheduled before the user switches view re-runs the **previous** view's query and overwrites the list now on screen.

## Symptom

Switch view while a sync is in flight and the new view loads correctly, then reverts a second or two later to results belonging to the view you just left. It looks like the new view "didn't work", when in fact it loaded and was overwritten.

Observed with instrumentation on a two-account setup, switching to a cross-account list:

```
12:43:59.371  loadThreads label=X   → 46 threads, correct
12:44:01.997  loadThreads label=Y   ← previous view's query, overwrites
12:44:02.697  loadThreads label=Y
```

The same shape is reachable on a single account by switching between Inbox and a smart folder, or between category tabs, while a sync completes.

## Change

Hold the loader in a ref and invoke `loadThreadsRef.current()` from the handler, so a reload always queries the view actually being displayed. The listener now registers once rather than re-registering on every label change.

One file. `npm test` passes: 133 files, 1560 tests.
