### PR TITLE
fix(scheduled-send): send via the provider so IMAP accounts deliver

### DIFF
--- a/src/services/snooze/scheduledSendManager.ts
+++ b/src/services/snooze/scheduledSendManager.ts
@@ -2,7 +2,7 @@ import {
   getPendingScheduledEmails,
   updateScheduledEmailStatus,
 } from "../db/scheduledEmails";
-import { getGmailClient } from "../gmail/tokenManager";
+import { getEmailProvider } from "../email/providerFactory";
 import { buildRawEmail, type EmailAttachment } from "@/utils/emailBuilder";
 import { getAccount } from "../db/accounts";
 import { createBackgroundChecker } from "../backgroundCheckers";
@@ -24,7 +24,10 @@ async function checkScheduledEmails(): Promise<void> {
       // Mark as "sending" BEFORE attempting send to prevent duplicate sends
       await updateScheduledEmailStatus(email.id, "sending");
 
-      const client = await getGmailClient(email.account_id);
+      // Route through the provider layer: a scheduled row belongs to whichever
+      // account created it, and an IMAP account has no Gmail client, so this
+      // could never deliver for IMAP/SMTP accounts.
+      const provider = await getEmailProvider(email.account_id);
 
       // Parse attachments from JSON if present
       let attachments: EmailAttachment[] | undefined;
@@ -51,7 +54,7 @@ async function checkScheduledEmails(): Promise<void> {
         attachments,
       });
 
-      await client.sendMessage(raw, email.thread_id ?? undefined);
+      await provider.sendMessage(raw, email.thread_id ?? undefined);
       await updateScheduledEmailStatus(email.id, "sent");
     } catch (err) {
       console.error(`Failed to send scheduled email ${email.id}:`, err);


### PR DESCRIPTION
Scheduled send never delivers on IMAP/SMTP accounts.

`checkScheduledEmails` reaches past the provider layer for the Gmail client:

```ts
const client = await getGmailClient(email.account_id);
...
await client.sendMessage(raw, email.thread_id ?? undefined);
```

An IMAP account has no Gmail client, so `getGmailClient` throws, the catch classifies it as permanent, and the row is marked `failed`. Nothing is sent and nothing surfaces in the UI.

## Evidence

Two messages scheduled from an IMAP account on a live install:

```
id        acct      subject         status   due
684cef8d  35271573  Testing this    failed   2026-08-11 11:15:00
2bba8d82  35271573  Testing this    failed   2026-08-11 11:00:00
```

Both accounts on that install are `provider = imap`.

## Change

Use `getEmailProvider(email.account_id).sendMessage(...)`, the same path `sendEmail` in `emailActions` already takes. Gmail accounts are unaffected — the factory returns the Gmail provider for them.

One file, three lines. `npm test` passes: 133 files, 1560 tests.

## Note

This is one instance of a wider pattern: an `EmailProvider` abstraction exists, but a number of call sites reach for `getGmailClient` directly with no provider check, so they fail silently on IMAP rather than loudly. Others I found while looking: the command palette's spam action (the toolbar button beside it goes through the provider and works), label create/rename/delete in `labelStore`, draft cleanup on permanent delete, and send-as alias fetching at launch, which throws once per IMAP account on every start. Happy to send those separately if this approach looks right.
