### PR TITLE
fix(imap): parenthesise multi-item FETCH data lists

### DIFF
--- a/src-tauri/src/imap/client.rs
+++ b/src-tauri/src/imap/client.rs
@@ -257,7 +257,7 @@ pub async fn fetch_messages(
     // Some IMAP servers return empty streams for UID FETCH despite valid UIDs.
     let fetches = tokio::time::timeout(IMAP_FETCH_TIMEOUT, async {
         let stream = session
-            .uid_fetch(uid_range, "UID FLAGS INTERNALDATE BODY.PEEK[]")
+            .uid_fetch(uid_range, "(UID FLAGS INTERNALDATE BODY.PEEK[])")
             .await
             .map_err(|e| format!("UID FETCH {folder} uids={uid_range} failed: {e}"))?;
         Ok::<_, String>(stream.collect::<Vec<_>>().await)
@@ -336,7 +336,7 @@ pub async fn fetch_message_body(
     let uid_str = uid.to_string();
     let fetches: Vec<_> = tokio::time::timeout(IMAP_FETCH_TIMEOUT, async {
         let stream = session
-            .uid_fetch(&uid_str, "UID FLAGS BODY.PEEK[]")
+            .uid_fetch(&uid_str, "(UID FLAGS BODY.PEEK[])")
             .await
             .map_err(|e| format!("UID FETCH failed: {e}"))?;
         Ok::<_, String>(stream.collect::<Vec<_>>().await)
@@ -861,7 +861,7 @@ pub async fn sync_folder(
 
         let fetches = tokio::time::timeout(IMAP_FETCH_TIMEOUT, async {
             let stream = session
-                .uid_fetch(&uid_set, "UID FLAGS INTERNALDATE BODY.PEEK[]")
+                .uid_fetch(&uid_set, "(UID FLAGS INTERNALDATE BODY.PEEK[])")
                 .await
                 .map_err(|e| format!("UID FETCH {folder} uids={uid_set} failed: {e}"))?;
             Ok::<_, String>(stream.collect::<Vec<_>>().await)


### PR DESCRIPTION
Fetching messages over IMAP returns no message bodies against servers that follow the grammar strictly. Every message ends up empty and the log fills with `has no body` warnings, while the FETCH itself reports success.

RFC 3501 §6.4.5 (and RFC 9051) require a list of several FETCH data items to be parenthesised. Three call sites in `src-tauri/src/imap/client.rs` passed the items unparenthesised:

```rust
.uid_fetch(uid_range, "UID FLAGS INTERNALDATE BODY.PEEK[]")     // before
.uid_fetch(uid_range, "(UID FLAGS INTERNALDATE BODY.PEEK[])")   // after
```

`async-imap` forwards the string verbatim, so this reaches the server as-is. Dovecot accepts the short form, which is presumably why it went unnoticed; Stalwart evaluates only the leading `UID` item and answers without `BODY[]`.

**Verified against Stalwart:** before, 291 messages produced 291 warnings and 0 stored messages. After, the same mailbox syncs 425 messages into 357 threads with no warnings.

Related: #241
