### PR TITLE
fix(db): run transactions on a dedicated SQLite connection

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -6786,7 +6786,7 @@ checksum = "f1bddf1187be692e79c5ffeab891132dfb0f236ed36a43c7ed39f1165ee20191"
 
 [[package]]
 name = "velo"
-version = "0.4.18"
+version = "0.4.21"
 dependencies = [
  "async-imap",
  "base64 0.22.1",
@@ -6799,6 +6799,7 @@ dependencies = [
  "serde",
  "serde_json",
  "socket2 0.5.10",
+ "sqlx",
  "tauri",
  "tauri-build",
  "tauri-plugin-autostart",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -45,6 +45,8 @@ base64 = "0.22"
 utf7-imap = "0.3"
 socket2 = "0.5"
 reqwest = { version = "0.12", default-features = false, features = ["native-tls", "json"] }
+# Same major/minor as the one tauri-plugin-sql pulls in, so cargo unifies them.
+sqlx = { version = "0.8", default-features = false, features = ["sqlite", "runtime-tokio"] }
 
 [target.'cfg(windows)'.dependencies]
 windows = { version = "0.58", features = ["Win32_UI_Shell"] }

--- a/src-tauri/src/db_tx.rs
+++ b/src-tauri/src/db_tx.rs
@@ -1,0 +1,232 @@
+//! Transactional SQLite access on a single, dedicated connection.
+//!
+//! Why this exists: `tauri-plugin-sql` runs every `execute()` against a sqlx
+//! *pool* (`Pool::connect()`, i.e. up to 10 connections). Issuing
+//! `BEGIN TRANSACTION`, the statements, and `COMMIT` as separate IPC calls
+//! therefore spreads one logical transaction over several connections. The
+//! connection that ran `BEGIN` keeps the write lock open indefinitely while the
+//! others block on it, which deadlocks IMAP sync (see issue #240).
+//!
+//! The commands below all run on one `SqliteConnection` that is never shared
+//! with the plugin's pool, so a transaction started by `db_tx_begin` is still
+//! open when `db_tx_execute` and `db_tx_commit` arrive.
+//!
+//! Callers must serialise transactions themselves — `withTransaction()` in
+//! `src/services/db/connection.ts` already does that with an async mutex.
+
+use serde_json::{Map, Value as JsonValue};
+use sqlx::sqlite::{SqliteConnectOptions, SqliteRow, SqliteValueRef};
+use sqlx::{Column, Connection, Row, SqliteConnection, TypeInfo, ValueRef};
+use std::path::PathBuf;
+use std::str::FromStr;
+use tokio::sync::Mutex;
+
+/// Managed state: the dedicated connection, opened lazily on first use.
+pub struct DbTxState {
+    conn: Mutex<Option<SqliteConnection>>,
+    path: Mutex<Option<PathBuf>>,
+}
+
+impl DbTxState {
+    pub fn new() -> Self {
+        Self {
+            conn: Mutex::new(None),
+            path: Mutex::new(None),
+        }
+    }
+
+    /// Remember where the database lives. Called once during setup so the
+    /// commands do not need an AppHandle.
+    pub async fn set_path(&self, path: PathBuf) {
+        *self.path.lock().await = Some(path);
+    }
+}
+
+impl Default for DbTxState {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// Open the connection if it is not open yet, then run `f` on it.
+async fn with_conn<T, F>(state: &DbTxState, f: F) -> Result<T, String>
+where
+    F: for<'a> FnOnce(
+        &'a mut SqliteConnection,
+    )
+        -> std::pin::Pin<Box<dyn std::future::Future<Output = Result<T, String>> + Send + 'a>>,
+{
+    let mut guard = state.conn.lock().await;
+
+    if guard.is_none() {
+        let path = state
+            .path
+            .lock()
+            .await
+            .clone()
+            .ok_or_else(|| "db_tx: database path not configured".to_string())?;
+
+        let opts = SqliteConnectOptions::from_str(&format!("sqlite:{}", path.display()))
+            .map_err(|e| format!("db_tx: bad connect options: {e}"))?
+            .create_if_missing(false)
+            // Matches the journal mode the plugin's pool already uses; readers
+            // stay unblocked while this connection holds the write lock.
+            .journal_mode(sqlx::sqlite::SqliteJournalMode::Wal)
+            .busy_timeout(std::time::Duration::from_secs(10));
+
+        let conn = SqliteConnection::connect_with(&opts)
+            .await
+            .map_err(|e| format!("db_tx: connect failed: {e}"))?;
+        *guard = Some(conn);
+        log::info!("db_tx: opened dedicated transaction connection");
+    }
+
+    let conn = guard.as_mut().expect("connection just ensured");
+    f(conn).await
+}
+
+/// Bind one JSON value to a query. Mirrors the subset of types the JS side
+/// actually passes: null, bool, integer, float, string. Anything structured is
+/// stored as its JSON text, which is what the plugin does too.
+fn bind_params<'q>(
+    mut query: sqlx::query::Query<'q, sqlx::Sqlite, sqlx::sqlite::SqliteArguments<'q>>,
+    params: Vec<JsonValue>,
+) -> sqlx::query::Query<'q, sqlx::Sqlite, sqlx::sqlite::SqliteArguments<'q>> {
+    for p in params {
+        query = match p {
+            JsonValue::Null => query.bind(None::<String>),
+            JsonValue::Bool(b) => query.bind(b),
+            JsonValue::Number(n) => {
+                if let Some(i) = n.as_i64() {
+                    query.bind(i)
+                } else {
+                    query.bind(n.as_f64().unwrap_or(0.0))
+                }
+            }
+            JsonValue::String(s) => query.bind(s),
+            other => query.bind(other.to_string()),
+        };
+    }
+    query
+}
+
+/// Convert one result row into a JSON object, probing the column type.
+fn row_to_json(row: &SqliteRow) -> Result<Map<String, JsonValue>, String> {
+    let mut obj = Map::new();
+
+    for (i, col) in row.columns().iter().enumerate() {
+        let raw: SqliteValueRef = row
+            .try_get_raw(i)
+            .map_err(|e| format!("db_tx: column {i} unreadable: {e}"))?;
+
+        let value = if raw.is_null() {
+            JsonValue::Null
+        } else {
+            match raw.type_info().name() {
+                "INTEGER" | "BIGINT" => row
+                    .try_get::<i64, _>(i)
+                    .map(JsonValue::from)
+                    .unwrap_or(JsonValue::Null),
+                "REAL" | "DOUBLE" | "FLOAT" => row
+                    .try_get::<f64, _>(i)
+                    .map(JsonValue::from)
+                    .unwrap_or(JsonValue::Null),
+                "BLOB" => row
+                    .try_get::<Vec<u8>, _>(i)
+                    .map(|b| JsonValue::from(b.to_vec()))
+                    .unwrap_or(JsonValue::Null),
+                // TEXT and everything SQLite reports loosely.
+                _ => row
+                    .try_get::<String, _>(i)
+                    .map(JsonValue::from)
+                    .unwrap_or(JsonValue::Null),
+            }
+        };
+
+        obj.insert(col.name().to_string(), value);
+    }
+
+    Ok(obj)
+}
+
+#[tauri::command]
+pub async fn db_tx_begin(state: tauri::State<'_, DbTxState>) -> Result<(), String> {
+    with_conn(&state, |conn| {
+        Box::pin(async move {
+            sqlx::query("BEGIN IMMEDIATE")
+                .execute(conn)
+                .await
+                .map_err(|e| format!("db_tx: BEGIN failed: {e}"))?;
+            Ok(())
+        })
+    })
+    .await
+}
+
+#[tauri::command]
+pub async fn db_tx_commit(state: tauri::State<'_, DbTxState>) -> Result<(), String> {
+    with_conn(&state, |conn| {
+        Box::pin(async move {
+            sqlx::query("COMMIT")
+                .execute(conn)
+                .await
+                .map_err(|e| format!("db_tx: COMMIT failed: {e}"))?;
+            Ok(())
+        })
+    })
+    .await
+}
+
+#[tauri::command]
+pub async fn db_tx_rollback(state: tauri::State<'_, DbTxState>) -> Result<(), String> {
+    with_conn(&state, |conn| {
+        Box::pin(async move {
+            // Ignore "no transaction is active" — the caller rolls back
+            // defensively and SQLite may have unwound already.
+            if let Err(e) = sqlx::query("ROLLBACK").execute(conn).await {
+                log::debug!("db_tx: ROLLBACK ignored: {e}");
+            }
+            Ok(())
+        })
+    })
+    .await
+}
+
+#[tauri::command]
+pub async fn db_tx_execute(
+    state: tauri::State<'_, DbTxState>,
+    sql: String,
+    params: Vec<JsonValue>,
+) -> Result<u64, String> {
+    with_conn(&state, move |conn| {
+        Box::pin(async move {
+            let query = bind_params(sqlx::query(&sql), params);
+            let res = query
+                .execute(conn)
+                .await
+                .map_err(|e| format!("db_tx: execute failed: {e}"))?;
+            Ok(res.rows_affected())
+        })
+    })
+    .await
+}
+
+#[tauri::command]
+pub async fn db_tx_select(
+    state: tauri::State<'_, DbTxState>,
+    sql: String,
+    params: Vec<JsonValue>,
+) -> Result<Vec<Map<String, JsonValue>>, String> {
+    with_conn(&state, move |conn| {
+        Box::pin(async move {
+            let query = bind_params(sqlx::query(&sql), params);
+            let rows = query
+                .fetch_all(conn)
+                .await
+                .map_err(|e| format!("db_tx: select failed: {e}"))?;
+
+            rows.iter().map(row_to_json).collect()
+        })
+    })
+    .await
+}

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -7,6 +7,7 @@ use tauri::{Emitter, Manager};
 use tauri_plugin_autostart::MacosLauncher;
 
 mod commands;
+mod db_tx;
 mod imap;
 mod oauth;
 mod smtp;
@@ -112,7 +113,13 @@ pub fn run() {
             commands::imap_delta_check,
             commands::smtp_send_email,
             commands::smtp_test_connection,
+            db_tx::db_tx_begin,
+            db_tx::db_tx_commit,
+            db_tx::db_tx_rollback,
+            db_tx::db_tx_execute,
+            db_tx::db_tx_select,
         ])
+        .manage(db_tx::DbTxState::new())
         .setup(|app| {
             {
                 let level = if cfg!(debug_assertions) {
@@ -126,6 +133,15 @@ pub fn run() {
                         .level_for("sqlx::query", log::LevelFilter::Warn)
                         .build(),
                 )?;
+            }
+
+            {
+                // Point the dedicated transaction connection at the same file
+                // tauri-plugin-sql uses (app config dir + the name from
+                // tauri.conf.json's `preload`).
+                let db_path = app.path().app_config_dir()?.join("velo.db");
+                let state = app.state::<db_tx::DbTxState>();
+                tauri::async_runtime::block_on(state.set_path(db_path));
             }
 
             #[cfg(not(target_os = "linux"))]

--- a/src/services/db/connection.test.ts
+++ b/src/services/db/connection.test.ts
@@ -11,6 +11,13 @@ vi.mock("@tauri-apps/plugin-sql", () => ({
   },
 }));
 
+// Transactions run on the dedicated Rust connection, not the plugin's pool.
+const mockInvoke = vi.fn();
+
+vi.mock("@tauri-apps/api/core", () => ({
+  invoke: (...args: unknown[]) => mockInvoke(...args),
+}));
+
 // Use dynamic import so mocks are in place
 const { withTransaction, getDb } = await import("./connection");
 
@@ -18,25 +25,34 @@ describe("withTransaction", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockExecute.mockResolvedValue(undefined);
+    mockInvoke.mockResolvedValue(undefined);
   });
 
   it("executes BEGIN, callback, COMMIT in order", async () => {
     const callOrder: string[] = [];
-    mockExecute.mockImplementation(async (sql: string) => {
-      callOrder.push(sql);
+    mockInvoke.mockImplementation(async (cmd: string) => {
+      callOrder.push(cmd);
     });
 
     await withTransaction(async () => {
       callOrder.push("callback");
     });
 
-    expect(callOrder).toEqual(["BEGIN TRANSACTION", "callback", "COMMIT"]);
+    expect(callOrder).toEqual(["db_tx_begin", "callback", "db_tx_commit"]);
+  });
+
+  it("never runs transaction statements on the pooled connection", async () => {
+    // tauri-plugin-sql hands out pooled connections, so BEGIN and COMMIT could
+    // land on different ones — the whole reason for the dedicated connection.
+    await withTransaction(async () => {});
+
+    expect(mockExecute).not.toHaveBeenCalled();
   });
 
   it("rolls back on callback error", async () => {
     const callOrder: string[] = [];
-    mockExecute.mockImplementation(async (sql: string) => {
-      callOrder.push(sql);
+    mockInvoke.mockImplementation(async (cmd: string) => {
+      callOrder.push(cmd);
     });
 
     await expect(
@@ -45,12 +61,12 @@ describe("withTransaction", () => {
       }),
     ).rejects.toThrow("callback failed");
 
-    expect(callOrder).toEqual(["BEGIN TRANSACTION", "ROLLBACK"]);
+    expect(callOrder).toEqual(["db_tx_begin", "db_tx_rollback"]);
   });
 
   it("handles ROLLBACK failure gracefully (SQLite auto-rollback)", async () => {
-    mockExecute.mockImplementation(async (sql: string) => {
-      if (sql === "ROLLBACK") {
+    mockInvoke.mockImplementation(async (cmd: string) => {
+      if (cmd === "db_tx_rollback") {
         throw new Error("cannot rollback - no transaction is active");
       }
     });
@@ -66,8 +82,8 @@ describe("withTransaction", () => {
   it("serialises concurrent transactions via mutex", async () => {
     const executionLog: string[] = [];
 
-    mockExecute.mockImplementation(async (sql: string) => {
-      executionLog.push(sql);
+    mockInvoke.mockImplementation(async (cmd: string) => {
+      executionLog.push(cmd);
     });
 
     // Launch two transactions concurrently
@@ -85,17 +101,17 @@ describe("withTransaction", () => {
     await Promise.all([tx1, tx2]);
 
     // tx1 should fully complete (BEGIN, work, done, COMMIT) before tx2 starts
-    const tx1BeginIdx = executionLog.indexOf("BEGIN TRANSACTION");
-    const tx1CommitIdx = executionLog.indexOf("COMMIT");
-    const tx2BeginIdx = executionLog.lastIndexOf("BEGIN TRANSACTION");
+    const tx1BeginIdx = executionLog.indexOf("db_tx_begin");
+    const tx1CommitIdx = executionLog.indexOf("db_tx_commit");
+    const tx2BeginIdx = executionLog.lastIndexOf("db_tx_begin");
 
     expect(tx1BeginIdx).toBeLessThan(tx1CommitIdx);
     expect(tx1CommitIdx).toBeLessThan(tx2BeginIdx);
   });
 
   it("unblocks next transaction even if current one fails", async () => {
-    mockExecute.mockImplementation(async (sql: string) => {
-      if (sql === "ROLLBACK") {
+    mockInvoke.mockImplementation(async (cmd: string) => {
+      if (cmd === "db_tx_rollback") {
         // Simulate auto-rollback already happened
         throw new Error("cannot rollback - no transaction is active");
       }
@@ -121,9 +137,57 @@ describe("withTransaction", () => {
 });
 
 describe("getDb", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockExecute.mockResolvedValue(undefined);
+    mockInvoke.mockResolvedValue(undefined);
+  });
+
   it("returns the same instance on repeated calls", async () => {
     const db1 = await getDb();
     const db2 = await getDb();
     expect(db1).toBe(db2);
+  });
+
+  it("joins the open transaction while one is running", async () => {
+    // The ~74 db modules all call getDb(); if they got a pooled connection
+    // they would block on the write lock the transaction holds.
+    await withTransaction(async () => {
+      const db = await getDb();
+      await db.execute("INSERT INTO messages (id) VALUES ($1)", ["m-1"]);
+      await db.select("SELECT * FROM messages", []);
+    });
+
+    expect(mockExecute).not.toHaveBeenCalled();
+    expect(mockInvoke).toHaveBeenCalledWith("db_tx_execute", {
+      sql: "INSERT INTO messages (id) VALUES ($1)",
+      params: ["m-1"],
+    });
+    expect(mockInvoke).toHaveBeenCalledWith("db_tx_select", {
+      sql: "SELECT * FROM messages",
+      params: [],
+    });
+  });
+
+  it("returns to the pool once the transaction ends", async () => {
+    await withTransaction(async () => {}).catch(() => {});
+
+    const db = await getDb();
+    await db.execute("SELECT 1", []);
+
+    expect(mockExecute).toHaveBeenCalledWith("SELECT 1", []);
+  });
+
+  it("returns to the pool after a failed transaction", async () => {
+    await expect(
+      withTransaction(async () => {
+        throw new Error("boom");
+      }),
+    ).rejects.toThrow("boom");
+
+    const db = await getDb();
+    await db.execute("SELECT 1", []);
+
+    expect(mockExecute).toHaveBeenCalledWith("SELECT 1", []);
   });
 });

--- a/src/services/db/connection.ts
+++ b/src/services/db/connection.ts
@@ -1,8 +1,43 @@
 import Database from "@tauri-apps/plugin-sql";
+import { invoke } from "@tauri-apps/api/core";
 
 let db: Database | null = null;
 
+/**
+ * The subset of the plugin's Database surface this codebase actually uses.
+ * Kept structural so the transaction connection can stand in for it.
+ */
+type DbLike = Pick<Database, "execute" | "select">;
+
+/**
+ * Routes statements to the dedicated Rust-side connection (see
+ * `src-tauri/src/db_tx.rs`). Set for the duration of a `withTransaction` call
+ * so that db helpers calling `getDb()` join the open transaction instead of
+ * grabbing a pooled connection that would block on its write lock.
+ */
+let activeTx: DbLike | null = null;
+
+const txConnection: DbLike = {
+  async execute(query: string, bindValues?: unknown[]) {
+    const rowsAffected = await invoke<number>("db_tx_execute", {
+      sql: query,
+      params: bindValues ?? [],
+    });
+    // The Rust side does not report it and nothing in this codebase reads it.
+    return { rowsAffected, lastInsertId: 0 };
+  },
+  async select<T>(query: string, bindValues?: unknown[]) {
+    return (await invoke("db_tx_select", {
+      sql: query,
+      params: bindValues ?? [],
+    })) as T;
+  },
+};
+
 export async function getDb(): Promise<Database> {
+  // Inside a transaction every read and write must use the same connection.
+  if (activeTx) return activeTx as Database;
+
   if (!db) {
     db = await Database.load("sqlite:velo.db");
   }
@@ -60,21 +95,25 @@ export async function withTransaction(fn: (db: Database) => Promise<void>): Prom
     // previous transaction errored — that's fine, we can still proceed
   }
 
-  const database = await getDb();
+  // Run on the dedicated Rust connection rather than the plugin's pool.
+  // tauri-plugin-sql calls Pool::connect(), so BEGIN, the statements and
+  // COMMIT would otherwise land on different connections: the one holding
+  // BEGIN keeps the write lock open while the others block on it (issue #240).
   try {
-    await database.execute("BEGIN TRANSACTION", []);
+    await invoke("db_tx_begin");
+    activeTx = txConnection;
     try {
-      await fn(database);
-      await database.execute("COMMIT", []);
+      await fn(txConnection as Database);
+      await invoke("db_tx_commit");
     } catch (err) {
-      // SQLite may auto-rollback on certain errors — guard against
-      // "cannot rollback - no transaction is active"
       try {
-        await database.execute("ROLLBACK", []);
+        await invoke("db_tx_rollback");
       } catch {
-        // ROLLBACK failed (already rolled back) — safe to ignore
+        // Already unwound by SQLite — nothing to undo.
       }
       throw err;
+    } finally {
+      activeTx = null;
     }
   } finally {
     resolve(); // always unblock the next queued transaction


### PR DESCRIPTION
Fixes #240.

`withTransaction()` deadlocks against its own connection pool. `tauri-plugin-sql` calls `Pool::connect()`, so `BEGIN TRANSACTION`, the statements and `COMMIT` are separate IPC calls that may each land on a different pooled connection:

```
conn #1: BEGIN TRANSACTION       <- takes the write lock, never sees COMMIT
conn #2: INSERT INTO messages    <- blocks on conn #1
conn #3: COMMIT                  <- no transaction on this connection
```

Surfaces as `database is locked`, with sync stalling after a couple of messages. `PRAGMA busy_timeout` does not help — it turns the immediate error into an indefinite hang, since the blocked connections wait for a lock only the caller itself could release.

## Change

`src-tauri/src/db_tx.rs` keeps one dedicated `SqliteConnection` alongside the plugin's pool and exposes `db_tx_begin` / `db_tx_execute` / `db_tx_select` / `db_tx_commit` / `db_tx_rollback` on it. `withTransaction()` runs there, and `getDb()` returns that connection while a transaction is open, so the db modules join it instead of taking one from the pool. None of the ~74 db modules change.

## Caveats

The transaction connection reports `lastInsertId` as `0` — nothing in the codebase reads it today. UI reads issued during an open transaction observe uncommitted state.

## Tests

`connection.test.ts` is rewritten against the new commands and gains coverage for the two invariants that matter: no transaction statement reaches the pooled connection, and `getDb()` joins the open transaction and returns to the pool afterwards, on both the success and the failure path.

`Cargo.lock` also picks up a stale version bump (0.4.18 → 0.4.21) that any `cargo` invocation performs.
