### PR TITLE
fix(calendar): route CalDAV requests through the Rust HTTP client

### DIFF
--- a/src/services/calendar/autoDiscovery.test.ts
+++ b/src/services/calendar/autoDiscovery.test.ts
@@ -1,12 +1,22 @@
+import { fetch as tauriFetch } from "@tauri-apps/plugin-http";
 import { discoverCalDavSettings, testCalDavConnection } from "./autoDiscovery";
+import { davFetch } from "./davFetch";
 
 vi.mock("tsdav", () => ({
   DAVClient: vi.fn(),
 }));
 
+// Discovery goes through the Rust HTTP client, not the webview's fetch.
+vi.mock("@tauri-apps/plugin-http", () => ({
+  fetch: vi.fn(),
+}));
+
+const mockDavFetch = vi.mocked(tauriFetch);
+
 describe("discoverCalDavSettings", () => {
   afterEach(() => {
     vi.restoreAllMocks();
+    mockDavFetch.mockReset();
   });
 
   it("returns Google preset for gmail.com", async () => {
@@ -45,10 +55,7 @@ describe("discoverCalDavSettings", () => {
   });
 
   it("returns null caldavUrl for unknown domain with no .well-known", async () => {
-    vi.stubGlobal(
-      "fetch",
-      vi.fn().mockRejectedValue(new Error("Network error")),
-    );
+    mockDavFetch.mockRejectedValue(new Error("Network error"));
 
     const result = await discoverCalDavSettings("user@unknown-domain.example");
     expect(result).toEqual({
@@ -59,17 +66,27 @@ describe("discoverCalDavSettings", () => {
     });
   });
 
-  it("returns redirect Location for unknown domain with .well-known 301", async () => {
-    vi.stubGlobal(
-      "fetch",
-      vi.fn().mockResolvedValue({
-        status: 301,
-        ok: false,
-        headers: new Headers({
-          Location: "https://caldav.unknown-domain.example/dav/",
-        }),
+  it("returns redirect Location for unknown domain with .well-known 307", async () => {
+    mockDavFetch.mockResolvedValue({
+      status: 307,
+      ok: false,
+      headers: new Headers({
+        Location: "https://unknown-domain.example/dav/cal",
       }),
-    );
+    } as Response);
+
+    const result = await discoverCalDavSettings("user@unknown-domain.example");
+    expect(result.caldavUrl).toBe("https://unknown-domain.example/dav/cal");
+  });
+
+  it("returns redirect Location for unknown domain with .well-known 301", async () => {
+    mockDavFetch.mockResolvedValue({
+      status: 301,
+      ok: false,
+      headers: new Headers({
+        Location: "https://caldav.unknown-domain.example/dav/",
+      }),
+    } as Response);
 
     const result = await discoverCalDavSettings("user@unknown-domain.example");
     expect(result).toEqual({
@@ -105,6 +122,26 @@ describe("testCalDavConnection", () => {
       success: true,
       message: "Connected — found 2 calendars",
       calendarCount: 2,
+    });
+  });
+
+  it("routes DAV requests through the Rust HTTP client", async () => {
+    const { DAVClient } = await import("tsdav");
+
+    vi.mocked(DAVClient).mockImplementation(function () {
+      return {
+        login: vi.fn().mockResolvedValue(undefined),
+        fetchCalendars: vi.fn().mockResolvedValue([]),
+      } as unknown as InstanceType<typeof DAVClient>;
+    });
+
+    await testCalDavConnection("https://caldav.example.com", "user", "pass");
+
+    // tsdav resolves globalThis.fetch at import time and only falls back to
+    // cross-fetch, so the override has to be handed to the client explicitly —
+    // otherwise the webview issues the request and CORS kills it.
+    expect(vi.mocked(DAVClient).mock.calls[0]?.[0]).toMatchObject({
+      fetch: davFetch,
     });
   });
 

--- a/src/services/calendar/autoDiscovery.ts
+++ b/src/services/calendar/autoDiscovery.ts
@@ -38,6 +38,8 @@ const PRESETS: CalDavPreset[] = [
   },
 ];
 
+import { davFetch } from "./davFetch";
+
 export interface CalDavDiscoveryResult {
   providerName: string | null;
   caldavUrl: string | null;
@@ -94,13 +96,15 @@ export async function discoverCalDavSettings(email: string): Promise<CalDavDisco
 
 async function tryWellKnownDiscovery(domain: string): Promise<string | null> {
   try {
-    const response = await fetch(`https://${domain}/.well-known/caldav`, {
+    // DAV hosts serve no CORS headers — go through the Rust HTTP client.
+    const response = await davFetch(`https://${domain}/.well-known/caldav`, {
       method: "GET",
       redirect: "manual",
     });
 
-    // RFC 6764: server should respond with 301/302 redirect to the CalDAV endpoint
-    if (response.status === 301 || response.status === 302) {
+    // RFC 6764: server should redirect to the CalDAV endpoint. Any 3xx counts —
+    // Stalwart answers 307, others 301/302/308.
+    if (response.status >= 300 && response.status < 400) {
       const location = response.headers.get("Location");
       if (location) {
         // Handle relative URLs
@@ -123,7 +127,7 @@ async function tryWellKnownDiscovery(domain: string): Promise<string | null> {
 
 async function tryNextcloudDiscovery(domain: string): Promise<string | null> {
   try {
-    const response = await fetch(`https://${domain}/remote.php/dav/`, {
+    const response = await davFetch(`https://${domain}/remote.php/dav/`, {
       method: "OPTIONS",
     });
     if (response.ok || response.status === 401) {
@@ -151,6 +155,7 @@ export async function testCalDavConnection(
       credentials: { username, password },
       authMethod: "Basic",
       defaultAccountType: "caldav",
+      fetch: davFetch,
     });
 
     await client.login();

--- a/src/services/calendar/caldavProvider.test.ts
+++ b/src/services/calendar/caldavProvider.test.ts
@@ -1,4 +1,10 @@
+import { DAVClient } from "tsdav";
 import { CalDAVProvider } from "./caldavProvider";
+import { davFetch } from "./davFetch";
+
+vi.mock("@tauri-apps/plugin-http", () => ({
+  fetch: vi.fn(),
+}));
 
 const MOCK_ICAL_DATA =
   "BEGIN:VCALENDAR\r\nVERSION:2.0\r\nBEGIN:VEVENT\r\nUID:test-uid\r\nSUMMARY:Test Event\r\nDTSTART:20240101T100000Z\r\nDTEND:20240101T110000Z\r\nEND:VEVENT\r\nEND:VCALENDAR";
@@ -41,6 +47,18 @@ describe("CalDAVProvider", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     provider = new CalDAVProvider("acc-1");
+  });
+
+  it("routes DAV requests through the Rust HTTP client", async () => {
+    mockFetchCalendars.mockResolvedValue([]);
+
+    await provider.listCalendars();
+
+    // Without an explicit override tsdav uses the webview's fetch, whose
+    // requests DAV servers answer without CORS headers.
+    expect(vi.mocked(DAVClient).mock.calls[0]?.[0]).toMatchObject({
+      fetch: davFetch,
+    });
   });
 
   describe("listCalendars", () => {

--- a/src/services/calendar/caldavProvider.ts
+++ b/src/services/calendar/caldavProvider.ts
@@ -8,6 +8,7 @@ import type {
   CreateEventInput,
   UpdateEventInput,
 } from "./types";
+import { davFetch } from "./davFetch";
 import { generateVEvent, parseVEvent } from "./icalHelper";
 import { getAccount } from "@/services/db/accounts";
 
@@ -36,6 +37,7 @@ export class CalDAVProvider implements CalendarProvider {
       credentials: { username, password },
       authMethod: "Basic",
       defaultAccountType: "caldav",
+      fetch: davFetch,
     });
 
     await this.client.login();

--- a/src/services/calendar/davFetch.test.ts
+++ b/src/services/calendar/davFetch.test.ts
@@ -1,0 +1,43 @@
+import { fetch as tauriFetch } from "@tauri-apps/plugin-http";
+import { davFetch } from "./davFetch";
+
+vi.mock("@tauri-apps/plugin-http", () => ({
+  fetch: vi.fn().mockResolvedValue(new Response(null, { status: 200 })),
+}));
+
+const mockTauriFetch = vi.mocked(tauriFetch);
+
+describe("davFetch", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("translates redirect: manual into maxRedirections: 0", async () => {
+    await davFetch("https://dav.example.com/.well-known/caldav", {
+      method: "PROPFIND",
+      redirect: "manual",
+    });
+
+    // The Rust client has no notion of `redirect` — without the translation it
+    // follows the well-known redirect and the 3xx response tsdav's service
+    // discovery looks for never reaches the caller.
+    const init = mockTauriFetch.mock.calls[0]?.[1];
+    expect(init).toMatchObject({ method: "PROPFIND", maxRedirections: 0 });
+    expect(init).not.toHaveProperty("redirect");
+  });
+
+  it("leaves other requests untouched", async () => {
+    await davFetch("https://dav.example.com/dav/cal", { method: "PROPFIND" });
+
+    const init = mockTauriFetch.mock.calls[0]?.[1];
+    expect(init).toEqual({ method: "PROPFIND" });
+  });
+
+  it("does not mutate the caller's init object", async () => {
+    const init: RequestInit = { method: "PROPFIND", redirect: "manual" };
+
+    await davFetch("https://dav.example.com/.well-known/caldav", init);
+
+    expect(init.redirect).toBe("manual");
+  });
+});

--- a/src/services/calendar/davFetch.ts
+++ b/src/services/calendar/davFetch.ts
@@ -1,0 +1,43 @@
+/**
+ * HTTP transport for DAV requests.
+ *
+ * CalDAV/CardDAV servers are ordinary HTTP servers that send no CORS headers —
+ * they were never meant to be called from a browser context. A PROPFIND issued
+ * by the webview therefore fails with "Load failed" regardless of what
+ * `connect-src` permits, because the response carries no
+ * `Access-Control-Allow-Origin`.
+ *
+ * `@tauri-apps/plugin-http` performs the request in Rust, where neither CORS
+ * nor CSP applies, and `capabilities/default.json` already grants it
+ * `https://*`.
+ *
+ * Every `DAVClient` must be constructed with `fetch: davFetch`. tsdav resolves
+ * its transport once at import time (`const fetch = getFetch()`), preferring
+ * `globalThis.fetch` and falling back to cross-fetch only where no global
+ * exists — in a webview there always is one, so patching or aliasing the
+ * fallback has no effect. The per-client `fetch` option is the only hook that
+ * reaches the actual request.
+ */
+import { fetch as tauriFetch } from "@tauri-apps/plugin-http";
+
+type TauriFetchInput = Parameters<typeof tauriFetch>[0];
+type TauriFetchInit = Parameters<typeof tauriFetch>[1];
+
+/**
+ * `fetch` for DAV requests, backed by the Rust HTTP client.
+ *
+ * RFC 6764 discovery hinges on reading the redirect itself: a PROPFIND against
+ * `/.well-known/caldav` answers 301/302/307/308 with the real endpoint in
+ * `Location`, which is why tsdav asks for `redirect: "manual"`. The Rust client
+ * ignores that field and only understands `maxRedirections`, so it would follow
+ * the hop and hand back the endpoint's response (a bare 401) instead — leaving
+ * discovery empty and the account pinned to the bare server URL. Translate the
+ * request so the redirect survives.
+ */
+export const davFetch = (input: TauriFetchInput, init?: TauriFetchInit): Promise<Response> => {
+  if (init?.redirect === "manual") {
+    const { redirect: _redirect, ...rest } = init;
+    return tauriFetch(input, { ...rest, maxRedirections: 0 });
+  }
+  return tauriFetch(input, init);
+};


### PR DESCRIPTION
CalDAV never connects — every server, including the four in velo's own presets, fails the connection test with `Load failed`.

## Cause 1 — CORS

DAV servers send no `Access-Control-Allow-Origin`; they were never meant to be called from a browser. The webview discards the response before it reaches the caller, and no `connect-src` entry changes that.

`@tauri-apps/plugin-http` performs the request in Rust, where neither CORS nor CSP applies, and `capabilities/default.json` already grants it `https://*`. Getting tsdav to use it is the subtle part: tsdav resolves its transport once at import time and prefers `globalThis.fetch`, falling back to `cross-fetch` only where no global exists. In a webview there always is one, so patching the global or aliasing `cross-fetch` has no effect — the per-client `fetch` option is the only hook that reaches the request.

## Cause 2 — redirects

The Rust client understands `maxRedirections`, not `redirect: "manual"`. It silently followed the `/.well-known/caldav` hop and returned the endpoint's `401`. tsdav's service discovery never saw the 3xx, so the account stayed pinned to the bare server URL, whose PROPFIND then failed.

`davFetch` translates the option, and velo's own well-known probe now accepts any 3xx — it previously matched 301/302 only, while Stalwart answers 307.

**Verified** against Stalwart, both with an explicit collection URL and with the bare server URL relying on RFC 6764 discovery.
