### PR TITLE
fix(calendar): attach CalDAV to an existing account for the same address

### DIFF
--- a/src/components/accounts/AddCalDavAccount.tsx
+++ b/src/components/accounts/AddCalDavAccount.tsx
@@ -9,7 +9,7 @@ import {
 } from "lucide-react";
 import { Modal } from "@/components/ui/Modal";
 import { TextField } from "@/components/ui/TextField";
-import { insertCalDavAccount } from "@/services/db/accounts";
+import { saveCalDavAccount } from "@/services/db/accounts";
 import { useAccountStore } from "@/stores/accountStore";
 import { discoverCalDavSettings, testCalDavConnection } from "@/services/calendar/autoDiscovery";
 
@@ -41,6 +41,7 @@ export function AddCalDavAccount({ onClose, onSuccess, onBack }: AddCalDavAccoun
 
   // Creating account
   const [creating, setCreating] = useState(false);
+  const [attachedToExisting, setAttachedToExisting] = useState(false);
 
   const handleDiscoverAndNext = useCallback(async () => {
     if (!email.trim()) return;
@@ -68,9 +69,8 @@ export function AddCalDavAccount({ onClose, onSuccess, onBack }: AddCalDavAccoun
   const handleCreate = useCallback(async () => {
     setCreating(true);
     try {
-      const id = crypto.randomUUID();
-      await insertCalDavAccount({
-        id,
+      const { accountId, attachedToExisting } = await saveCalDavAccount({
+        id: crypto.randomUUID(),
         email,
         displayName: displayName || null,
         caldavUrl,
@@ -78,18 +78,26 @@ export function AddCalDavAccount({ onClose, onSuccess, onBack }: AddCalDavAccoun
         caldavPassword: password,
       });
 
-      addAccount({
-        id,
-        email,
-        displayName: displayName || null,
-        avatarUrl: null,
-        isActive: true,
-      });
+      // An existing account is already in the store — adding it again would
+      // duplicate it in the switcher.
+      if (!attachedToExisting) {
+        addAccount({
+          id: accountId,
+          email,
+          displayName: displayName || null,
+          avatarUrl: null,
+          isActive: true,
+        });
+      }
 
+      setAttachedToExisting(attachedToExisting);
       setStep("done");
     } catch (err) {
       console.error("Failed to create CalDAV account:", err);
-      setTestResult({ success: false, message: "Failed to save account" });
+      setTestResult({
+        success: false,
+        message: err instanceof Error ? err.message : "Failed to save account",
+      });
     } finally {
       setCreating(false);
     }
@@ -270,9 +278,13 @@ export function AddCalDavAccount({ onClose, onSuccess, onBack }: AddCalDavAccoun
         {step === "done" && (
           <div className="text-center py-6">
             <CheckCircle2 size={32} className="text-success mx-auto mb-3" />
-            <p className="text-sm font-medium text-text-primary">CalDAV account added!</p>
+            <p className="text-sm font-medium text-text-primary">
+              {attachedToExisting ? "CalDAV calendar connected!" : "CalDAV account added!"}
+            </p>
             <p className="text-xs text-text-tertiary mt-1">
-              Your calendars will sync automatically.
+              {attachedToExisting
+                ? `Added to your existing ${email} account. Your calendars will sync automatically.`
+                : "Your calendars will sync automatically."}
             </p>
             <button
               onClick={onSuccess}

--- a/src/services/db/accounts.test.ts
+++ b/src/services/db/accounts.test.ts
@@ -4,6 +4,7 @@ import {
   getAccountByEmail,
   insertImapAccount,
   insertAccount,
+  saveCalDavAccount,
   deleteAccount,
   updateAccountTokens,
   updateAccountSyncState,
@@ -280,6 +281,57 @@ describe("accounts", () => {
       const [sql, params] = mockExecute.mock.calls[0] as [string, unknown[]];
       expect(sql).toContain("UPDATE accounts SET history_id");
       expect(params).toEqual(["history-999", "acc-1"]);
+    });
+  });
+
+  describe("saveCalDavAccount", () => {
+    const input = {
+      id: "new-acc",
+      email: "user@example.com",
+      displayName: null,
+      caldavUrl: "https://dav.example.com/dav/cal",
+      caldavUsername: "user@example.com",
+      caldavPassword: "secret",
+    };
+
+    it("inserts a new account when the address is unknown", async () => {
+      mockSelectFirstBy.mockResolvedValue(null);
+      mockExecute.mockResolvedValue(undefined);
+
+      const result = await saveCalDavAccount(input);
+
+      const [sql] = mockExecute.mock.calls[0] as [string];
+      expect(sql).toContain("INSERT INTO accounts");
+      expect(result).toEqual({ accountId: "new-acc", attachedToExisting: false });
+    });
+
+    it("attaches to the existing account instead of violating UNIQUE(email)", async () => {
+      // A CalDAV calendar usually belongs to an address that already has a mail
+      // account; inserting a second row fails on accounts.email.
+      mockSelectFirstBy.mockResolvedValue(
+        createMockImapAccount({ id: "existing-acc", email: "user@example.com" }),
+      );
+      mockExecute.mockResolvedValue(undefined);
+
+      const result = await saveCalDavAccount(input);
+
+      const [sql, params] = mockExecute.mock.calls[0] as [string, unknown[]];
+      expect(sql).toContain("UPDATE accounts SET caldav_url");
+      expect(params).toContain("existing-acc");
+      expect(params).toContain("enc:secret");
+      expect(result).toEqual({ accountId: "existing-acc", attachedToExisting: true });
+    });
+
+    it("marks the existing account as CalDAV-enabled", async () => {
+      mockSelectFirstBy.mockResolvedValue(
+        createMockImapAccount({ id: "existing-acc", email: "user@example.com" }),
+      );
+      mockExecute.mockResolvedValue(undefined);
+
+      await saveCalDavAccount(input);
+
+      const [, params] = mockExecute.mock.calls[0] as [string, unknown[]];
+      expect(params).toContain("caldav");
     });
   });
 });

--- a/src/services/db/accounts.ts
+++ b/src/services/db/accounts.ts
@@ -248,6 +248,38 @@ export async function insertCalDavAccount(account: {
   );
 }
 
+/**
+ * Store CalDAV settings for an address, creating the account only if needed.
+ *
+ * `accounts.email` is UNIQUE, and a CalDAV calendar usually belongs to an
+ * address that already has a mail account — inserting a second row for it fails
+ * with "UNIQUE constraint failed: accounts.email". Reports which account now
+ * carries the settings so callers can tell the two cases apart.
+ */
+export async function saveCalDavAccount(account: {
+  id: string;
+  email: string;
+  displayName: string | null;
+  caldavUrl: string;
+  caldavUsername: string;
+  caldavPassword: string;
+}): Promise<{ accountId: string; attachedToExisting: boolean }> {
+  const existing = await getAccountByEmail(account.email);
+
+  if (existing) {
+    await updateAccountCalDav(existing.id, {
+      caldavUrl: account.caldavUrl,
+      caldavUsername: account.caldavUsername,
+      caldavPassword: account.caldavPassword,
+      calendarProvider: "caldav",
+    });
+    return { accountId: existing.id, attachedToExisting: true };
+  }
+
+  await insertCalDavAccount(account);
+  return { accountId: account.id, attachedToExisting: false };
+}
+
 export async function updateAccountCalDav(
   accountId: string,
   fields: {


### PR DESCRIPTION
Adding a CalDAV calendar for an address that already has a mail account fails with `Failed to save account`, while the calendar itself ends up working — a confusing combination.

`accounts.email` is `UNIQUE`, and a CalDAV calendar usually belongs to an address that already has a mail account. The add-account dialog inserted a second row and hit `UNIQUE constraint failed: accounts.email`; the settings page updates the existing row instead, so a user who had been there first sees a working calendar alongside the error.

`saveCalDavAccount()` updates the account for that address when one exists and inserts only when it does not, keeping the account switcher free of duplicates. The dialog says which of the two happened, and reports the underlying error rather than a blanket `Failed to save account`.
