### PR TITLE
perf(sync): metadata-first sync with lazy body loading

### DIFF
--- a/docs/investigations/2026-08-27-0641-sync-engine-performance.md
+++ b/docs/investigations/2026-08-27-0641-sync-engine-performance.md
@@ -1,0 +1,320 @@
+# Investigation: Sync engine performance & first-sync completion
+
+**Timestamp**: 2026-08-27 06:41 CEST **Status**: Partially implemented (`perf/sync-metadata-first`) **Area**: sync engine, Gmail API sync, IMAP sync, SQLite writes,
+first-sync UX
+
+> Prior investigations: none found in this repo before this file was opened.
+
+## Problem Statement
+
+Velo's sync engine feels unacceptably slow for an email client. On a live
+three-account setup (`sync_period_days = 0`), first sync is either still running,
+marked complete with stale folder coverage, or failing to persist delta updates
+with `database is locked` errors. The inbox is not usable quickly because the
+client downloads full message bodies for every message before treating sync as
+done, serialises accounts and SQLite writes, and throttles IMAP folder walks.
+
+## Rationale
+
+Email clients are judged in the first minutes after account add. If initial sync
+takes tens of minutes (or appears hung), users churn regardless of keyboard
+shortcuts or AI features. Competitors — both desktop-native and local-first
+Rust projects — solve this with metadata-first sync, progressive UI, dedicated
+search indexes, and incremental checkpoints. We need to understand what they do
+differently before redesigning our pipeline.
+
+---
+
+## Hypotheses
+
+### H1: First sync is not finished for all accounts
+
+**Test**: Query live app DB (`~/Library/Application Support/com.velomail.app/velo.db`)
+for `accounts.history_id`, thread/message counts, and `folder_sync_state.last_sync_at`.
+Check `velo-webview.log` for active sync errors on 2026-08-27.
+
+**Run**:
+
+```
+sqlite3 "~/Library/Application Support/com.velomail.app/velo.db" \
+  "SELECT email, provider, history_id, sync_window_days FROM accounts;"
+
+rg "2026-08-27" velo-webview.log | rg -c "Failed to re-sync thread"
+```
+
+**Result**: Two IMAP accounts have `imap-synced-*` history IDs but realdigit.co
+shows folders last synced Aug 12–17 while INBOX/Sent/Trash updated Aug 27.
+Gmail has a real `history_id` but 295 thread re-sync failures today with DB lock
+errors. Setting is `sync_period_days = 0` (all mail).
+
+**Verdict**: `correct`
+
+---
+
+### H2: Full-body-first sync is the dominant latency source
+
+**Test**: Read sync code paths — what is fetched on initial sync vs on thread open?
+
+**Run**:
+
+```
+src/services/gmail/sync.ts     → getThread(id, "full") for every thread stub
+src/services/imap/imapSync.ts  → BODY.PEEK[] via Rust uid_fetch
+src-tauri/velo-core/src/imap/client.rs → "UID FLAGS INTERNALDATE BODY.PEEK[]"
+```
+
+**Result**: Both Gmail and IMAP initial sync download complete MIME bodies up
+front. Gmail uses 10 concurrent API fetches but serialises SQLite writes.
+IMAP walks folders sequentially with 1 s inter-folder delay and fetches 50
+messages per IPC batch (200 UIDs per chunk).
+
+**Verdict**: `correct`
+
+---
+
+### H3: SQLite write contention is causing active sync failures
+
+**Test**: Compare initial vs delta Gmail sync — does delta wrap stores in
+`withTransaction`? Count lock errors in today's log.
+
+**Run**:
+
+```
+grep withTransaction src/services/gmail/sync.ts   # initial sync: yes (line ~275)
+grep withTransaction src/services/gmail/sync.ts   # deltaSync processAndStoreThread: no (line ~403)
+
+rg "database is locked" velo-webview.log | rg "2026-08-27" | wc -l
+```
+
+**Result**: Delta sync calls `processAndStoreThread` without `withTransaction`
+while running 10 concurrent thread re-fetches. Logs show hundreds of
+`Failed to re-sync thread …: database is locked` plus `pool timed out` today.
+DB is 818 MB with 29 MB WAL.
+
+**Verdict**: `correct`
+
+---
+
+### H4: Fast email projects use metadata-first + separate search index
+
+**Test**: Survey open-source mail/sync projects that advertise fast indexing.
+Document their stated architecture.
+
+**Run**: Web/repo survey (see **Comparable projects** below).
+
+**Result**: Every project promising fast search or fast first-run uses at least
+one of: metadata-only initial pass, lazy body fetch, dedicated search engine
+(Tantivy), streaming/chunk commits, or a background sync worker decoupled from
+UI. None fetch full bodies for the entire mailbox before showing an inbox.
+
+**Verdict**: `correct`
+
+---
+
+## TL;DR — live state (2026-08-27)
+
+| Account | Provider | Done signal | Threads | Messages | Verdict |
+|---------|----------|-------------|---------|----------|---------|
+| heath.weaver@twigl.it | IMAP | `imap-synced-*` | 124 | 144 | Likely complete |
+| heath.weaver@realdigit.co | IMAP | `imap-synced-*` | 7,114 | 15,596 | Marked done; Archive etc. stale since Aug 12–17 |
+| heath.weaver@remote-executive.com | Gmail | `history_id=393888` | 1,301 | 1,506 | Delta sync failing (295 lock errors today) |
+
+**Setting:** `sync_period_days = 0` → sync all mail (worst case for initial sync).
+
+**Log excerpt (Gmail, 2026-08-27 ~04:33–04:44 UTC):**
+
+```
+Failed to re-sync thread …: database is locked        (×295)
+Failed to re-sync thread …: pool timed out while waiting for an open connection
+[syncManager] Sync failed for account …: database is locked
+```
+
+---
+
+## Our sync architecture (summary)
+
+### Orchestration (`syncManager.ts`)
+
+- 30 s background interval; accounts synced **sequentially**
+- Window widen (`sync_period_days` 30 → 0) triggers full rescan (`syncWindow.ts`)
+
+### Gmail (`gmail/sync.ts`)
+
+1. `listLabels`
+2. `listThreads` (100/page)
+3. `getThread(full)` × N — 10 concurrent fetch, serialised DB write (initial only)
+
+Delta: `history.list` → re-fetch affected threads with `getThread(full)`, 10
+concurrent, **no** `withTransaction` on store.
+
+### IMAP (`imap/imapSync.ts` + Rust)
+
+1. List/map folders
+2. Per folder (sequential, 1 s delay): SEARCH UIDs → FETCH `BODY.PEEK[]` in
+   batches of 50 / chunks of 200
+3. JWZ threading pass over all headers
+4. Materialise threads, delete placeholders
+
+`modseq` always stored as `null` — CONDSTORE/QRESYNC unused.
+
+### Constants
+
+```
+SYNC_INTERVAL_MS = 30_000
+BATCH_SIZE = 50, CHUNK_SIZE = 200
+INTER_FOLDER_DELAY_MS = 1_000
+CIRCUIT_BREAKER_DELAY_MS = 15_000
+Gmail parallelLimit = 10
+Rust: uid_fetch(..., "UID FLAGS INTERNALDATE BODY.PEEK[]")
+```
+
+---
+
+## Comparable projects — what they promise and how
+
+Projects that explicitly optimise for fast sync/indexing. Grouped by pattern.
+
+### 1. Metadata-first, bodies lazy
+
+| Project | Claim | What they do |
+|---------|-------|--------------|
+| **[mail-index](https://github.com/unsoldgroup/mail-index)** | "Metadata for whole mailbox in minutes; bodies fetched selectively" | Progressive Gmail sync: index headers for entire mailbox (~50 msg/min claimed), full text only for messages that matter. Local index ~1.5% of Gmail size. MCP server reads local index; hits Gmail again only for missing bodies. Recommends `--since 1mo` first, expand later. |
+| **[allodia sync engine](https://github.com/allodia-eu/email-calendar-sync-engine)** | "Streaming sync… UI can render recent mail before full mailbox finishes" | Rust PIM engine: normalised model across JMAP/IMAP/CalDAV/Graph. Commits chunks as they arrive. Metadata + raw payloads preserved; search via SQLite FTS. Designed to embed in native apps. |
+| **Google Gmail API guidance** | Partial sync for responsiveness | [Sync guide](https://developers.google.com/gmail/api/guides/sync): list recent messages first; use `history.list` for delta; defer full bodies. `threads.list?format=metadata` avoids N× `threads.get` for inbox paint. |
+| **Thunderbird / Apple Mail** | Instant-ish inbox | FETCH `ENVELOPE FLAGS UID` headers only; bodies on open. Persistent connection + IDLE. |
+
+**Velo gap:** We always `getThread(format=full)` and IMAP `BODY.PEEK[]`.
+
+### 2. Dedicated search index (separate from message store)
+
+| Project | Claim | What they do |
+|---------|-------|--------------|
+| **[Pebble](https://github.com/RichardZhong/Pebble)** | "Fast full-text search" | Tauri + Rust workspace: SQLite for mail data, **Tantivy** for search index, bodies on disk. Crate split (`pebble-mail`, `pebble-store`, `pebble-search`). |
+| **[Bichon](https://github.com/rustmailer/bichon)** | "High-performance archiver" | Rust IMAP archiver: **Tantivy** (Zstd) for FTS, **Fjall** for blob bodies, memdb for metadata. Async envelope indexing queue; batch commit every 1k docs / 60 s. Multi-account concurrent download. Content-hash dedup (BLAKE3). |
+| **[imapped](https://github.com/esaiaswestberg/imapped)** | "Blazing-fast caching and search" | IMAP **caching proxy**: mirrors upstream into Postgres (metadata) + object storage (bodies). Serves clients over IMAP locally. **Tantivy** for full-text search. Sync engine + upstream reconciliation; mutations pushed back. |
+| **[ESS](https://github.com/krasmussen37/ess)** | "Sub-second search across thousands" | SQLite canonical store + **Tantivy** index. Gmail/Graph delta sync. Honest about Gmail initial sync slowness (1 HTTP req/message); delta is fast. |
+| **[msgvault](https://github.com/foreseaz/msgvault)** | "Search at the speed of thought" | Gmail backup: SQLite FTS5 + **DuckDB/Parquet** analytics cache. Resumable checkpoints. Content-addressed attachment dedup. |
+
+**Velo gap:** FTS5 updated inline on every message insert during sync — write
+amplification on the same SQLite file that sync is fighting over.
+
+### 3. Background worker / streaming pipeline
+
+| Project | Claim | What they do |
+|---------|-------|--------------|
+| **[pmh-only/mail](https://deepwiki.com/pmh-only/mail/3.1-imap-synchronization)** | Efficient IMAP sync | Dual-process: background worker owns IMAP connections + job queue. STATUS fast-path (`UIDNEXT` / `HIGHESTMODSEQ`) before fetch. IDLE watchers per mailbox. Local actions queued as `imap_job`, replayed to server. |
+| **[Twenty IMAP refactor](https://github.com/twentyhq/twenty/pull/14053)** | "Syncs are faster now" | UID-based fetch (no Message-ID lookups). **QRESYNC** when available. Composite folder+UID keys. Tested on Gmail, Dovecot, FastMail. |
+| **[Bichon IMAP sync](https://deepwiki.com/rustmailer/bichon/3.5-imap-synchronization)** | High-concurrency multi-account | Periodic tasks per account. UID SEARCH differential sync. Configurable `download_batch_size`. UI shows live progress. |
+| **[mailintel](https://github.com/ghassan-ai-projects/email-intelligence-platform)** | Local knowledge base | **mbsync → Maildir** (immutable source) → ingest to SQLite (FTS5 + vectors). Sync/ingest/enrich as separate stages. Watch mode for continuous loop. |
+
+**Velo gap:** Sync runs in JS main thread path via Tauri IPC; one account at a
+time; no STATUS gate; no QRESYNC; artificial inter-folder delays.
+
+### 4. Commercial "fast" clients (architecture, not open source)
+
+| Client | Claim | What they actually do |
+|--------|-------|----------------------|
+| **Superhuman** | "Built for speed" / 100 ms rule | Local SQLite cache of emails; preload/prerender likely-next threads; metadata-first UI; same Gmail API but optimised read path + keyboard UX. [Blog post](https://blog.superhuman.com/superhuman-is-built-for-speed/) |
+| **Spark / Marco / Edison** | Instant mobile inbox | **Backend server** maintains IMAP connections, builds index, relays push. Device reads pre-synced cache. Trade-off: mail transits vendor infra. [Marco IMAP post](https://marcoapp.io/blog/how-imap-actually-works) |
+
+**Velo gap:** Local-first (good for privacy) but without the optimisations
+desktop-native or backend-sync clients use.
+
+---
+
+## Cross-project patterns (what actually makes sync fast)
+
+1. **Inbox paint in seconds** — headers/metadata for recent mail first; bodies
+   on open or background prefetch queue.
+2. **Separate concerns** — message store vs search index vs blob storage (avoid
+   one SQLite writer doing everything).
+3. **Stream commits** — UI updates after each chunk, not after full mailbox +
+   threading pass.
+4. **Incremental checkpoints** — resumable sync; honest "done" per folder.
+5. **IMAP extensions** — STATUS before SEARCH; CONDSTORE/QRESYNC; IDLE not 30 s
+   poll.
+6. **Parallelism** — concurrent accounts/folders with a single writer queue, not
+   concurrent writers.
+7. **Scoped initial sync** — recent window first (`--since 1mo`), expand on
+   demand; never default to "all mail".
+8. **Defer enrichment** — filters, AI categorization, smart labels after inbox
+   is visible.
+
+---
+
+## Gap analysis — Velo vs field
+
+| Capability | Velo today | Fast-project pattern |
+|------------|------------|-------------------|
+| Inbox before full sync | No | Yes (metadata first) |
+| Body fetch | Always full upfront | Lazy / prefetch |
+| Search index | SQLite FTS5 inline | Tantivy or deferred FTS build |
+| IMAP fetch | `BODY.PEEK[]` | Headers first; body on read |
+| IMAP incremental | UID > last_uid | + STATUS gate, QRESYNC |
+| Parallelism | 1 account, 1 folder chain | Multi-folder/account + writer queue |
+| Sync scope default | User set to 0 (all mail) | Recent window; opt-in full |
+| Done signal | Account-level flag | Per-folder success |
+
+---
+
+## Recommended next steps
+
+### P0 — Stabilise
+
+- [x] Fix delta sync write serialisation (`storeThread` wraps `withTransaction`)
+- [x] Don't mark IMAP sync done if circuit breaker skipped folders
+- [ ] Add sync telemetry: phase timings, bytes fetched, lock wait time
+
+### P1 — Metadata-first (biggest UX win)
+
+- [x] Gmail: `threads.list` + `format=metadata` for inbox; defer `format=full`
+- [x] IMAP: header FETCH pass; body via existing `imap_fetch_message_body`
+- [x] Lazy body load on thread open (`ensureMessageBodies`)
+- [ ] Show inbox after first header page (~100 messages)
+
+### P2 — Reduce redundant work
+
+- [x] Default sync window 30 days; `0` = all mail (no falsy fallback)
+- [ ] Parallel IMAP folders (2–3) with shared connection pool
+- [ ] Remove/reduce `INTER_FOLDER_DELAY_MS` when server allows
+- [ ] Defer filters / AI / smart labels until after inbox paint
+
+### P3 — Modern IMAP + indexing
+
+- [ ] CONDSTORE / QRESYNC (`HIGHESTMODSEQ` already returned, stored as null)
+- [ ] STATUS pre-check before SEARCH/FETCH
+- [ ] Evaluate Tantivy for search (decouple from sync write path)
+- [ ] Rust-side sync worker decoupled from UI thread
+
+---
+
+## Key files
+
+| Area | Path |
+|------|------|
+| Orchestration | `src/services/gmail/syncManager.ts` |
+| Gmail sync | `src/services/gmail/sync.ts` |
+| IMAP sync | `src/services/imap/imapSync.ts` |
+| Sync window | `src/services/sync/syncWindow.ts` |
+| DB mutex | `src/services/db/connection.ts` |
+| IMAP fetch (Rust) | `src-tauri/src/imap/client.rs` |
+| Live DB | `~/Library/Application Support/com.velomail.app/velo.db` |
+| Live logs | `~/Library/Application Support/com.velomail.app/velo-webview.log` |
+
+---
+
+## References
+
+- [Google Gmail API sync guide](https://developers.google.com/gmail/api/guides/sync)
+- [Nylas: Gmail pagination & sync](https://developer.nylas.com/docs/cookbook/email/gmail-api-pagination-sync/)
+- [Superhuman: built for speed](https://blog.superhuman.com/superhuman-is-built-for-speed/)
+- [Marco: how IMAP works / why backends exist](https://marcoapp.io/blog/how-imap-actually-works)
+- [mail-index](https://github.com/unsoldgroup/mail-index) — progressive metadata sync
+- [Pebble](https://github.com/RichardZhong/Pebble) — SQLite + Tantivy
+- [Bichon](https://github.com/rustmailer/bichon) — Rust archiver + Tantivy/Fjall
+- [imapped](https://github.com/esaiaswestberg/imapped) — IMAP caching proxy
+- [allodia sync engine](https://github.com/allodia-eu/email-calendar-sync-engine) — streaming sync
+- [ESS](https://github.com/krasmussen37/ess) — SQLite + Tantivy MCP search
+- [msgvault](https://github.com/foreseaz/msgvault) — Gmail backup + DuckDB analytics
+- [Twenty IMAP refactor (QRESYNC)](https://github.com/twentyhq/twenty/pull/14053)
+- [pmh-only/mail IMAP sync](https://deepwiki.com/pmh-only/mail/3.1-imap-synchronization)

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -5,6 +5,7 @@ use crate::imap::types::{
 };
 use crate::smtp::client as smtp_client;
 use crate::smtp::types::{SmtpConfig, SmtpSendResult};
+use serde::Deserialize;
 
 // ---------- IMAP commands ----------
 
@@ -26,6 +27,7 @@ pub async fn imap_fetch_messages(
     config: ImapConfig,
     folder: String,
     uids: Vec<u32>,
+    #[serde(default)] headers_only: bool,
 ) -> Result<ImapFetchResult, String> {
     if uids.is_empty() {
         return Err("No UIDs provided".to_string());
@@ -39,7 +41,7 @@ pub async fn imap_fetch_messages(
         .join(",");
 
     let mut session = imap_client::connect(&config).await?;
-    let result = imap_client::fetch_messages(&mut session, &folder, &uid_set).await;
+    let result = imap_client::fetch_messages(&mut session, &folder, &uid_set, headers_only).await;
     let _ = session.logout().await;
 
     match result {
@@ -47,7 +49,7 @@ pub async fn imap_fetch_messages(
         Err(e) if e.starts_with("ASYNC_IMAP_EMPTY:") => {
             // async-imap can't parse this server's responses — use raw TCP fallback
             log::info!("Falling back to raw TCP fetch for folder {folder}");
-            imap_client::raw_fetch_messages(&config, &folder, &uid_set).await
+            imap_client::raw_fetch_messages(&config, &folder, &uid_set, headers_only).await
         }
         Err(e) => Err(e),
     }

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -5,7 +5,6 @@ use crate::imap::types::{
 };
 use crate::smtp::client as smtp_client;
 use crate::smtp::types::{SmtpConfig, SmtpSendResult};
-use serde::Deserialize;
 
 // ---------- IMAP commands ----------
 
@@ -27,8 +26,9 @@ pub async fn imap_fetch_messages(
     config: ImapConfig,
     folder: String,
     uids: Vec<u32>,
-    #[serde(default)] headers_only: bool,
+    headers_only: Option<bool>,
 ) -> Result<ImapFetchResult, String> {
+    let headers_only = headers_only.unwrap_or(false);
     if uids.is_empty() {
         return Err("No UIDs provided".to_string());
     }

--- a/src-tauri/src/imap/client.rs
+++ b/src-tauri/src/imap/client.rs
@@ -227,11 +227,13 @@ pub async fn list_folders(session: &mut ImapSession) -> Result<Vec<ImapFolder>, 
     Ok(folders)
 }
 
-/// Fetch messages from a folder by UID range (e.g. "1:100" or "500:*").
+/// Fetch messages from a folder by UID range (e.g. "1,5,10" or "500:*").
+/// When `headers_only` is true, fetches `BODY.PEEK[HEADER]` instead of full bodies.
 pub async fn fetch_messages(
     session: &mut ImapSession,
     folder: &str,
     uid_range: &str,
+    headers_only: bool,
 ) -> Result<ImapFetchResult, String> {
     let mailbox = tokio::time::timeout(IMAP_CMD_TIMEOUT, session.select(folder))
         .await
@@ -255,9 +257,14 @@ pub async fn fetch_messages(
 
     // Try UID FETCH first; if the stream is empty, fall back to sequence-number FETCH.
     // Some IMAP servers return empty streams for UID FETCH despite valid UIDs.
+    let fetch_items = if headers_only {
+        "UID FLAGS INTERNALDATE BODY.PEEK[HEADER]"
+    } else {
+        "UID FLAGS INTERNALDATE BODY.PEEK[]"
+    };
     let fetches = tokio::time::timeout(IMAP_FETCH_TIMEOUT, async {
         let stream = session
-            .uid_fetch(uid_range, "UID FLAGS INTERNALDATE BODY.PEEK[]")
+            .uid_fetch(uid_range, fetch_items)
             .await
             .map_err(|e| format!("UID FETCH {folder} uids={uid_range} failed: {e}"))?;
         Ok::<_, String>(stream.collect::<Vec<_>>().await)
@@ -940,6 +947,7 @@ pub async fn raw_fetch_messages(
     config: &ImapConfig,
     folder: &str,
     uid_range: &str,
+    headers_only: bool,
 ) -> Result<ImapFetchResult, String> {
     log::info!("RAW IMAP FETCH: connecting to {}:{} for folder {folder}, UIDs {uid_range}", config.host, config.port);
 
@@ -1001,8 +1009,13 @@ pub async fn raw_fetch_messages(
         highest_modseq: None,
     };
 
-    // UID FETCH with full body
-    let fetch_cmd = format!("a3 UID FETCH {uid_range} (UID FLAGS INTERNALDATE BODY.PEEK[])\r\n");
+    // UID FETCH — headers only during sync, full body on demand
+    let fetch_body = if headers_only {
+        "BODY.PEEK[HEADER]"
+    } else {
+        "BODY.PEEK[]"
+    };
+    let fetch_cmd = format!("a3 UID FETCH {uid_range} (UID FLAGS INTERNALDATE {fetch_body})\r\n");
     reader.get_mut().write_all(fetch_cmd.as_bytes()).await
         .map_err(|e| format!("FETCH write: {e}"))?;
 
@@ -1627,7 +1640,7 @@ fn parse_message(
     let body_text = message.body_text(0).map(|s| s.to_string());
     let body_html = message.body_html(0).map(|s| s.to_string());
 
-    // Generate snippet from text body (truncate at char boundary)
+    // Generate snippet from text body, or subject when headers-only
     let snippet = body_text.as_ref().map(|text| {
         let cleaned: String = text
             .chars()
@@ -1640,6 +1653,16 @@ fn parse_message(
         } else {
             trimmed.to_string()
         }
+    }).or_else(|| {
+        subject.as_ref().map(|s| {
+            let trimmed = s.trim();
+            if trimmed.chars().count() > 200 {
+                let end: String = trimmed.chars().take(200).collect();
+                format!("{end}...")
+            } else {
+                trimmed.to_string()
+            }
+        })
     });
 
     // List-Unsubscribe headers

--- a/src/components/email/ThreadView.tsx
+++ b/src/components/email/ThreadView.tsx
@@ -2,6 +2,7 @@ import { useEffect, useState, useRef, useCallback } from "react";
 import { MessageItem } from "./MessageItem";
 import { ActionBar } from "./ActionBar";
 import { getMessagesForThread, type DbMessage } from "@/services/db/messages";
+import { ensureMessageBodies } from "@/services/email/messageBodies";
 import { useAccountStore } from "@/stores/accountStore";
 import { useUIStore } from "@/stores/uiStore";
 import { useThreadStore, type Thread } from "@/stores/threadStore";
@@ -81,6 +82,7 @@ export function ThreadView({ thread }: ThreadViewProps) {
     if (!activeAccountId) return;
     setLoading(true);
     getMessagesForThread(activeAccountId, thread.id)
+      .then((msgs) => ensureMessageBodies(activeAccountId, msgs))
       .then(setMessages)
       .catch(console.error)
       .finally(() => setLoading(false));

--- a/src/services/email/messageBodies.test.ts
+++ b/src/services/email/messageBodies.test.ts
@@ -1,0 +1,107 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import type { DbMessage } from "../db/messages";
+
+vi.mock("./providerFactory", () => ({
+  getEmailProvider: vi.fn(),
+}));
+
+vi.mock("../db/messages", () => ({
+  getMessagesForThread: vi.fn(),
+  upsertMessage: vi.fn(),
+}));
+
+vi.mock("../db/attachments", () => ({
+  upsertAttachment: vi.fn(),
+}));
+
+import { getEmailProvider } from "./providerFactory";
+import { getMessagesForThread, upsertMessage } from "../db/messages";
+import { ensureMessageBodies } from "./messageBodies";
+
+function makeMessage(overrides: Partial<DbMessage> = {}): DbMessage {
+  return {
+    id: "msg-1",
+    account_id: "acct-1",
+    thread_id: "thread-1",
+    from_address: "sender@example.com",
+    from_name: "Sender",
+    to_addresses: "recipient@example.com",
+    cc_addresses: "",
+    bcc_addresses: "",
+    reply_to: "",
+    subject: "Hello",
+    snippet: "Preview",
+    date: 1_700_000_000_000,
+    is_read: 1,
+    is_starred: 0,
+    body_html: null,
+    body_text: null,
+    body_cached: 0,
+    raw_size: 0,
+    internal_date: 1_700_000_000_000,
+    list_unsubscribe: null,
+    list_unsubscribe_post: null,
+    auth_results: null,
+    message_id_header: null,
+    references_header: null,
+    in_reply_to_header: null,
+    imap_uid: null,
+    imap_folder: null,
+    ...overrides,
+  };
+}
+
+describe("ensureMessageBodies", () => {
+  const mockGetEmailProvider = vi.mocked(getEmailProvider);
+  const mockUpsertMessage = vi.mocked(upsertMessage);
+  const mockGetMessagesForThread = vi.mocked(getMessagesForThread);
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns messages unchanged when bodies are already cached", async () => {
+    const messages = [makeMessage({ body_cached: 1, body_text: "Already here" })];
+    const result = await ensureMessageBodies("acct-1", messages);
+    expect(result).toBe(messages);
+    expect(mockGetEmailProvider).not.toHaveBeenCalled();
+  });
+
+  it("fetches and persists bodies for metadata-only messages", async () => {
+    const messages = [makeMessage()];
+    const refreshed = [makeMessage({ body_cached: 1, body_text: "Full body" })];
+
+    mockGetEmailProvider.mockResolvedValue({
+      fetchMessage: vi.fn().mockResolvedValue({
+        id: "msg-1",
+        fromAddress: "sender@example.com",
+        fromName: "Sender",
+        toAddresses: "recipient@example.com",
+        ccAddresses: "",
+        bccAddresses: "",
+        replyTo: "",
+        subject: "Hello",
+        snippet: "Full body",
+        date: 1_700_000_000_000,
+        isRead: true,
+        isStarred: false,
+        bodyHtml: "<p>Full body</p>",
+        bodyText: "Full body",
+        rawSize: 100,
+        internalDate: 1_700_000_000_000,
+        attachments: [],
+        listUnsubscribe: null,
+        listUnsubscribePost: null,
+        authResults: null,
+      }),
+    } as never);
+
+    mockGetMessagesForThread.mockResolvedValue(refreshed);
+
+    const result = await ensureMessageBodies("acct-1", messages);
+
+    expect(mockUpsertMessage).toHaveBeenCalledOnce();
+    expect(mockGetMessagesForThread).toHaveBeenCalledWith("acct-1", "thread-1");
+    expect(result).toEqual(refreshed);
+  });
+});

--- a/src/services/email/messageBodies.ts
+++ b/src/services/email/messageBodies.ts
@@ -1,0 +1,81 @@
+import { getEmailProvider } from "./providerFactory";
+import {
+  getMessagesForThread,
+  upsertMessage,
+  type DbMessage,
+} from "../db/messages";
+import { upsertAttachment } from "../db/attachments";
+
+function messageNeedsBody(msg: DbMessage): boolean {
+  return msg.body_cached === 0 && !msg.body_html && !msg.body_text;
+}
+
+/**
+ * Fetch and persist full bodies for messages that were indexed metadata-only.
+ * Returns refreshed rows for the thread when possible.
+ */
+export async function ensureMessageBodies(
+  accountId: string,
+  messages: DbMessage[],
+): Promise<DbMessage[]> {
+  const missing = messages.filter(messageNeedsBody);
+  if (missing.length === 0) return messages;
+
+  const provider = await getEmailProvider(accountId);
+
+  for (const msg of missing) {
+    try {
+      const parsed = await provider.fetchMessage(msg.id);
+      await upsertMessage({
+        id: parsed.id,
+        accountId,
+        threadId: msg.thread_id,
+        fromAddress: parsed.fromAddress,
+        fromName: parsed.fromName,
+        toAddresses: parsed.toAddresses,
+        ccAddresses: parsed.ccAddresses,
+        bccAddresses: parsed.bccAddresses,
+        replyTo: parsed.replyTo,
+        subject: parsed.subject,
+        snippet: parsed.snippet || msg.snippet,
+        date: parsed.date,
+        isRead: parsed.isRead,
+        isStarred: parsed.isStarred,
+        bodyHtml: parsed.bodyHtml,
+        bodyText: parsed.bodyText,
+        rawSize: parsed.rawSize,
+        internalDate: parsed.internalDate,
+        listUnsubscribe: parsed.listUnsubscribe,
+        listUnsubscribePost: parsed.listUnsubscribePost,
+        authResults: parsed.authResults,
+        messageIdHeader: msg.message_id_header,
+        referencesHeader: msg.references_header,
+        inReplyToHeader: msg.in_reply_to_header,
+        imapUid: msg.imap_uid,
+        imapFolder: msg.imap_folder,
+      });
+
+      for (const att of parsed.attachments) {
+        await upsertAttachment({
+          id: `${parsed.id}_${att.gmailAttachmentId}`,
+          messageId: parsed.id,
+          accountId,
+          filename: att.filename,
+          mimeType: att.mimeType,
+          size: att.size,
+          gmailAttachmentId: att.gmailAttachmentId,
+          contentId: att.contentId,
+          isInline: att.isInline,
+        });
+      }
+    } catch (err) {
+      console.error(`[messageBodies] Failed to load body for ${msg.id}:`, err);
+    }
+  }
+
+  const threadId = messages[0]?.thread_id;
+  if (threadId) {
+    return getMessagesForThread(accountId, threadId);
+  }
+  return messages;
+}

--- a/src/services/gmail/sync.test.ts
+++ b/src/services/gmail/sync.test.ts
@@ -3,6 +3,9 @@ import { deltaSync } from "./sync";
 import { GmailClient } from "./client";
 
 // Mock all DB modules
+vi.mock("../db/connection", () => ({
+  withTransaction: vi.fn(async (fn: (db: unknown) => Promise<void>) => fn({})),
+}));
 vi.mock("../db/threads", () => ({
   upsertThread: vi.fn(),
   setThreadLabels: vi.fn(),

--- a/src/services/gmail/sync.ts
+++ b/src/services/gmail/sync.ts
@@ -2,7 +2,9 @@ import { GmailClient } from "./client";
 import { parseGmailMessage, type ParsedMessage } from "./messageParser";
 import { upsertLabel } from "../db/labels";
 import { upsertThread, setThreadLabels } from "../db/threads";
+import { withTransaction } from "../db/connection";
 import { upsertMessage } from "../db/messages";
+import { buildDateQuery } from "../sync/syncWindow";
 import { upsertAttachment } from "../db/attachments";
 import { updateAccountSyncState } from "../db/accounts";
 import { shouldNotifyForMessage, queueNewEmailNotification } from "../notifications/notificationManager";
@@ -26,6 +28,27 @@ export interface SyncProgress {
 }
 
 export type SyncProgressCallback = (progress: SyncProgress) => void;
+
+/** Gmail thread fetch format during sync — metadata only; bodies load on open. */
+const SYNC_THREAD_FORMAT = "metadata" as const;
+
+async function storeThread(
+  thread: { id: string },
+  accountId: string,
+  parsedMessages: ParsedMessage[],
+  client?: GmailClient,
+  autoArchiveCategories?: Set<string>,
+): Promise<void> {
+  await withTransaction(async () => {
+    await processAndStoreThread(
+      thread,
+      accountId,
+      parsedMessages,
+      client,
+      autoArchiveCategories,
+    );
+  });
+}
 
 /**
  * Store a fetched thread's data (messages, labels, attachments) into the local DB.
@@ -186,9 +209,7 @@ export async function initialSync(
   onProgress?.({ phase: "labels", current: 1, total: 1 });
 
   // Phase 2: Fetch thread list
-  const afterDate = new Date();
-  afterDate.setDate(afterDate.getDate() - daysBack);
-  const afterStr = `${afterDate.getFullYear()}/${afterDate.getMonth() + 1}/${afterDate.getDate()}`;
+  const query = buildDateQuery(daysBack);
 
   const threadStubs: { id: string }[] = [];
   let pageToken: string | undefined;
@@ -199,7 +220,7 @@ export async function initialSync(
     const response = await client.listThreads({
       maxResults: 100,
       pageToken,
-      q: `after:${afterStr}`,
+      ...(query ? { q: query } : {}),
     });
 
     if (response.threads) {
@@ -230,7 +251,7 @@ export async function initialSync(
       });
 
       try {
-        const thread = await client.getThread(stub.id, "full");
+        const thread = await client.getThread(stub.id, SYNC_THREAD_FORMAT);
 
         if (BigInt(thread.historyId) > BigInt(historyId)) {
           historyId = thread.historyId;
@@ -239,7 +260,7 @@ export async function initialSync(
         if (!thread.messages || thread.messages.length === 0) return;
 
         const parsedMessages = thread.messages.map(parseGmailMessage);
-        await processAndStoreThread(thread, accountId, parsedMessages, client, autoArchiveCategories);
+        await storeThread(thread, accountId, parsedMessages, client, autoArchiveCategories);
       } catch (err) {
         console.error(`Failed to sync thread ${stub.id}:`, err);
       }
@@ -360,12 +381,12 @@ export async function deltaSync(
             return;
           }
 
-          const thread = await client.getThread(threadId, "full");
+          const thread = await client.getThread(threadId, SYNC_THREAD_FORMAT);
 
           if (!thread.messages || thread.messages.length === 0) return;
 
           const parsedMessages = thread.messages.map(parseGmailMessage);
-          await processAndStoreThread(thread, accountId, parsedMessages, client, autoArchiveCategories);
+          await storeThread(thread, accountId, parsedMessages, client, autoArchiveCategories);
 
           // Auto-archive muted threads that reappear in INBOX
           if (mutedThreadIds.has(threadId)) {

--- a/src/services/gmail/syncManager.ts
+++ b/src/services/gmail/syncManager.ts
@@ -2,6 +2,7 @@ import { getGmailClient } from "./tokenManager";
 import { initialSync, deltaSync, type SyncProgress } from "./sync";
 import { getAccount, clearAccountHistoryId } from "../db/accounts";
 import { getSetting } from "../db/settings";
+import { parseSyncPeriodDays } from "../sync/syncWindow";
 import { getThreadCountForAccount, deleteAllThreadsForAccount } from "../db/threads";
 import { deleteAllMessagesForAccount } from "../db/messages";
 import { imapInitialSync, imapDeltaSync } from "../imap/imapSync";
@@ -53,8 +54,7 @@ async function syncGmailAccount(accountId: string): Promise<void> {
     throw new Error("Account not found");
   }
 
-  const syncPeriodStr = await getSetting("sync_period_days");
-  const syncDays = parseInt(syncPeriodStr ?? "365", 10) || 365;
+  const syncDays = parseSyncPeriodDays(await getSetting("sync_period_days"));
 
   if (account.history_id) {
     // Delta sync
@@ -94,8 +94,7 @@ async function syncImapAccount(accountId: string): Promise<void> {
     await ensureFreshToken(account);
   }
 
-  const syncPeriodStr = await getSetting("sync_period_days");
-  const syncDays = parseInt(syncPeriodStr ?? "365", 10) || 365;
+  const syncDays = parseSyncPeriodDays(await getSetting("sync_period_days"));
 
   if (account.history_id) {
     // Delta sync — IMAP uses folder-level UID tracking

--- a/src/services/imap/imapSync.test.ts
+++ b/src/services/imap/imapSync.test.ts
@@ -457,6 +457,7 @@ describe("imapInitialSync", () => {
       expect.objectContaining({ host: "imap.example.com" }),
       "INBOX",
       [1], // UIDs from search
+      true, // headers-only during sync
     );
   });
 
@@ -616,12 +617,12 @@ describe("computeSinceDate", () => {
     expect(result).toMatch(/^\d{1,2}-[A-Z][a-z]{2}-\d{4}$/);
   });
 
-  it("adds 1-day safety margin", () => {
-    // For daysBack=0, should still go back 1 day
-    const result = computeSinceDate(0);
-    const yesterday = new Date();
-    yesterday.setUTCDate(yesterday.getUTCDate() - 1);
-    expect(result).toBe(formatImapDate(yesterday));
+  it("returns null when daysBack is 0 (sync all mail)", () => {
+    expect(computeSinceDate(0)).toBeNull();
+  });
+
+  it("returns null when daysBack is negative", () => {
+    expect(computeSinceDate(-30)).toBeNull();
   });
 });
 

--- a/src/services/imap/imapSync.ts
+++ b/src/services/imap/imapSync.ts
@@ -94,10 +94,10 @@ export function formatImapDate(date: Date): string {
 
 /**
  * Compute a `DD-Mon-YYYY` SINCE date string for the given `daysBack` value.
- * Subtracts an extra day as a safety margin for timezone differences
- * (IMAP SINCE has date-only granularity, no time component).
+ * Returns null when `daysBack <= 0` (sync everything — no SINCE filter).
  */
-export function computeSinceDate(daysBack: number): string {
+export function computeSinceDate(daysBack: number): string | null {
+  if (daysBack <= 0) return null;
   const date = new Date();
   date.setUTCDate(date.getUTCDate() - daysBack - 1);
   return formatImapDate(date);
@@ -356,6 +356,7 @@ async function fetchMessagesInBatches(
   config: ImapConfig,
   folder: string,
   uids: number[],
+  headersOnly = true,
   onBatch?: (fetched: number, total: number) => void,
 ): Promise<{ messages: ImapMessage[]; lastUid: number; uidvalidity: number }> {
   const allMessages: ImapMessage[] = [];
@@ -364,7 +365,7 @@ async function fetchMessagesInBatches(
 
   for (let i = 0; i < uids.length; i += BATCH_SIZE) {
     const batch = uids.slice(i, i + BATCH_SIZE);
-    const result = await imapFetchMessages(config, folder, batch);
+    const result = await imapFetchMessages(config, folder, batch, headersOnly);
 
     allMessages.push(...result.messages);
     uidvalidity = result.folder_status.uidvalidity;
@@ -446,6 +447,7 @@ export async function imapInitialSync(
   let storedCount = 0;
   let consecutiveFailures = 0;
   const folderErrors: string[] = [];
+  let syncIncomplete = false;
 
   for (let folderIdx = 0; folderIdx < syncableFolders.length; folderIdx++) {
     const folder = syncableFolders[folderIdx]!;
@@ -457,6 +459,7 @@ export async function imapInitialSync(
         `[imapSync] Circuit breaker: ${consecutiveFailures} consecutive connection failures, ` +
         `skipping remaining ${syncableFolders.length - folderIdx} folders`,
       );
+      syncIncomplete = true;
       break;
     }
 
@@ -487,8 +490,11 @@ export async function imapInitialSync(
 
       if (uidsToFetch.length === 0) continue;
 
-      // Date filter config
-      const cutoffDate = Math.floor(Date.now() / 1000) - daysBack * 86400;
+      // Date filter config — unlimited when syncing everything
+      const cutoffDate =
+        daysBack <= 0
+          ? Number.NEGATIVE_INFINITY
+          : Math.floor(Date.now() / 1000) - daysBack * 86400;
       const nowSeconds = Math.floor(Date.now() / 1000);
       let dateFallbackCount = 0;
       let folderFetchedCount = 0;
@@ -501,14 +507,14 @@ export async function imapInitialSync(
         const chunkUids = uidsToFetch.slice(chunkStart, chunkStart + CHUNK_SIZE);
         let chunkResult;
         try {
-          chunkResult = await imapFetchMessages(config, folder.raw_path, chunkUids);
+          chunkResult = await imapFetchMessages(config, folder.raw_path, chunkUids, true);
         } catch (chunkErr) {
           // Retry once for transient connection errors
           if (isConnectionError(chunkErr)) {
             console.warn(`[imapSync] Chunk fetch failed in ${folder.path}, retrying in 2s:`, chunkErr);
             await delay(2_000);
             try {
-              chunkResult = await imapFetchMessages(config, folder.raw_path, chunkUids);
+              chunkResult = await imapFetchMessages(config, folder.raw_path, chunkUids, true);
             } catch (retryErr) {
               console.error(`[imapSync] Chunk retry failed in ${folder.path}:`, retryErr);
               continue;
@@ -589,7 +595,7 @@ export async function imapInitialSync(
                 imapFolder: msg.folder ?? null,
               });
 
-              // Store attachments
+              // Headers-only sync — attachments load with the body on open
               for (const att of parsed.attachments) {
                 await upsertAttachment({
                   id: `${parsed.id}_${att.gmailAttachmentId}`,
@@ -798,8 +804,12 @@ export async function imapInitialSync(
     `[imapSync] Stored ${storedCount} messages in ${threadGroups.length} threads (found ${totalMessagesFound} on server)`,
   );
 
-  // Only mark sync as complete if messages were stored OR no messages exist on server.
-  if (storedCount > 0 || totalMessagesFound === 0) {
+  // Only mark sync as complete when all folders were processed.
+  if (syncIncomplete) {
+    console.warn(
+      `[imapSync] Sync incomplete — circuit breaker skipped folders, NOT marking sync as complete`,
+    );
+  } else if (storedCount > 0 || totalMessagesFound === 0) {
     await updateAccountSyncState(accountId, `imap-synced-${Date.now()}`);
   } else {
     console.warn(

--- a/src/services/imap/tauriCommands.test.ts
+++ b/src/services/imap/tauriCommands.test.ts
@@ -99,6 +99,7 @@ describe('IMAP Tauri commands', () => {
       config: testImapConfig,
       folder: 'INBOX',
       uids: [1, 2, 3],
+      headersOnly: false,
     });
     expect(result).toEqual(fetchResult);
   });

--- a/src/services/imap/tauriCommands.ts
+++ b/src/services/imap/tauriCommands.ts
@@ -142,9 +142,10 @@ export async function imapListFolders(config: ImapConfig): Promise<ImapFolder[]>
 export async function imapFetchMessages(
   config: ImapConfig,
   folder: string,
-  uids: number[]
+  uids: number[],
+  headersOnly = false,
 ): Promise<ImapFetchResult> {
-  return invoke<ImapFetchResult>('imap_fetch_messages', { config, folder, uids });
+  return invoke<ImapFetchResult>('imap_fetch_messages', { config, folder, uids, headersOnly });
 }
 
 /**

--- a/src/services/sync/syncWindow.test.ts
+++ b/src/services/sync/syncWindow.test.ts
@@ -1,0 +1,25 @@
+import { describe, it, expect } from "vitest";
+import { buildDateQuery, parseSyncPeriodDays, windowReach } from "./syncWindow";
+
+describe("syncWindow", () => {
+  it("parseSyncPeriodDays treats 0 as all mail", () => {
+    expect(parseSyncPeriodDays("0")).toBe(0);
+    expect(parseSyncPeriodDays(null)).toBe(30);
+    expect(parseSyncPeriodDays("365")).toBe(365);
+    expect(parseSyncPeriodDays("nope")).toBe(30);
+  });
+
+  it("buildDateQuery returns undefined for unlimited window", () => {
+    expect(buildDateQuery(0)).toBeUndefined();
+    expect(buildDateQuery(-1)).toBeUndefined();
+  });
+
+  it("buildDateQuery returns after: query for finite windows", () => {
+    expect(buildDateQuery(30)).toMatch(/^after:\d+\/\d+\/\d+$/);
+  });
+
+  it("windowReach ranks unlimited above finite windows", () => {
+    expect(windowReach(0)).toBeGreaterThan(windowReach(30));
+    expect(windowReach(365)).toBe(365);
+  });
+});

--- a/src/services/sync/syncWindow.ts
+++ b/src/services/sync/syncWindow.ts
@@ -1,0 +1,30 @@
+/**
+ * Sync-window helpers shared by Gmail and IMAP sync paths.
+ *
+ * `0` means "no date restriction" (sync everything). Callers must not treat
+ * `0` as falsy and fall back to a default window.
+ */
+
+/** How far back a sync window reaches; `0` / negative = unlimited. */
+export function windowReach(days: number | null | undefined): number {
+  if (days === null || days === undefined) return 0;
+  return days <= 0 ? Number.POSITIVE_INFINITY : days;
+}
+
+/** Parse `sync_period_days` from settings. `0` = all mail; default 30 days. */
+export function parseSyncPeriodDays(raw: string | null | undefined): number {
+  if (raw === null || raw === undefined) return 30;
+  const parsed = parseInt(raw, 10);
+  if (Number.isNaN(parsed)) return 30;
+  return parsed;
+}
+
+/**
+ * Gmail search query for a sync window, or `undefined` when syncing everything.
+ */
+export function buildDateQuery(daysBack: number): string | undefined {
+  if (daysBack <= 0) return undefined;
+  const after = new Date();
+  after.setDate(after.getDate() - daysBack);
+  return `after:${after.getFullYear()}/${after.getMonth() + 1}/${after.getDate()}`;
+}


### PR DESCRIPTION
## Summary
- Gmail and IMAP initial/delta sync now index metadata/headers only; full bodies load when a thread is opened via `ensureMessageBodies`
- Adds shared `syncWindow` helpers (default 30-day window; `0` = all mail without falsy fallback)
- IMAP Rust fetch supports `headersOnly`; circuit-breaker skips no longer mark sync complete

## Test plan
- [x] `npm run test -- src/services/sync/syncWindow.test.ts src/services/gmail/sync.test.ts src/services/imap/imapSync.test.ts src/services/imap/tauriCommands.test.ts src/services/email/messageBodies.test.ts` (66 passed)
- [ ] Add a Gmail account and confirm inbox threads appear before bodies finish loading
- [ ] Open a thread and confirm body content loads on demand
- [ ] Add an IMAP account and confirm initial sync completes faster (headers-only fetch in logs)
- [ ] Set `sync_period_days = 0` and confirm all-mail sync still works (no SINCE filter)


Made with [Cursor](https://cursor.com)