### PR TITLE
Encode and escape header values in the outgoing message builder

### DIFF
--- a/src/utils/emailBuilder.ts
+++ b/src/utils/emailBuilder.ts
@@ -1,3 +1,12 @@
+import {
+  addressOnly,
+  encodeAddressHeader,
+  encodeAddressList,
+  encodeFilenameParams,
+  encodeHeaderValue,
+  stripHeaderBreaks,
+} from "./headerSafety";
+
 /**
  * Build an RFC 2822 email message and encode as base64url for the Gmail API.
  */
@@ -93,34 +102,35 @@ function extractInlineImages(html: string): { html: string; images: InlineImage[
 function generateMessageId(from: string): string {
   const timestamp = Date.now();
   const random = Math.random().toString(36).slice(2, 10);
-  const domain = from.includes("@") ? from.split("@")[1] : "velomail.local";
+  const address = addressOnly(from);
+  const domain = address.includes("@") ? address.split("@")[1] : "velomail.local";
   return `<${timestamp}.${random}@${domain}>`;
 }
 
 export function buildRawEmail(draft: EmailDraft): string {
   const messageId = generateMessageId(draft.from);
   const lines: string[] = [
-    `From: ${draft.from}`,
-    `To: ${draft.to.join(", ")}`,
+    `From: ${encodeAddressHeader(draft.from)}`,
+    `To: ${encodeAddressList(draft.to)}`,
   ];
 
   if (draft.cc && draft.cc.length > 0) {
-    lines.push(`Cc: ${draft.cc.join(", ")}`);
+    lines.push(`Cc: ${encodeAddressList(draft.cc)}`);
   }
   if (draft.bcc && draft.bcc.length > 0) {
-    lines.push(`Bcc: ${draft.bcc.join(", ")}`);
+    lines.push(`Bcc: ${encodeAddressList(draft.bcc)}`);
   }
 
   lines.push(`Date: ${new Date().toUTCString()}`);
   lines.push(`Message-ID: ${messageId}`);
-  lines.push(`Subject: ${draft.subject}`);
+  lines.push(`Subject: ${encodeHeaderValue(draft.subject)}`);
   lines.push(`MIME-Version: 1.0`);
 
   if (draft.inReplyTo) {
-    lines.push(`In-Reply-To: ${draft.inReplyTo}`);
+    lines.push(`In-Reply-To: ${stripHeaderBreaks(draft.inReplyTo)}`);
   }
   if (draft.references) {
-    lines.push(`References: ${draft.references}`);
+    lines.push(`References: ${stripHeaderBreaks(draft.references)}`);
   }
 
   const { html: processedHtml, images: inlineImages } = extractInlineImages(draft.htmlBody);
@@ -152,7 +162,7 @@ export function buildRawEmail(draft: EmailDraft): string {
       // Inline image parts
       for (const img of inlineImages) {
         lines.push(`--${relatedBoundary}`);
-        lines.push(`Content-Type: ${img.mimeType}`);
+        lines.push(`Content-Type: ${stripHeaderBreaks(img.mimeType)}`);
         lines.push("Content-Transfer-Encoding: base64");
         lines.push(`Content-ID: <${img.cid}>`);
         lines.push("Content-Disposition: inline");
@@ -175,9 +185,10 @@ export function buildRawEmail(draft: EmailDraft): string {
       // Attachment parts
       for (const att of draft.attachments!) {
         lines.push(`--${mixedBoundary}`);
-        lines.push(`Content-Type: ${att.mimeType}; name="${att.filename}"`);
+        const { nameParam, dispositionParam } = encodeFilenameParams(att.filename);
+        lines.push(`Content-Type: ${stripHeaderBreaks(att.mimeType)}; ${nameParam}`);
         lines.push("Content-Transfer-Encoding: base64");
-        lines.push(`Content-Disposition: attachment; filename="${att.filename}"`);
+        lines.push(`Content-Disposition: attachment; ${dispositionParam}`);
         lines.push("");
         const raw = att.content;
         for (let i = 0; i < raw.length; i += 76) {

--- a/src/utils/headerSafety.test.ts
+++ b/src/utils/headerSafety.test.ts
@@ -1,0 +1,230 @@
+import { describe, it, expect } from "vitest";
+import {
+  addressOnly,
+  encodeAddressHeader,
+  encodeAddressList,
+  encodeFilenameParams,
+  encodeHeaderValue,
+  stripHeaderBreaks,
+} from "./headerSafety";
+import { buildRawEmail } from "./emailBuilder";
+import { parseMailtoUrl } from "./mailtoParser";
+
+function decodeRaw(raw: string): string {
+  const padded = raw.replace(/-/g, "+").replace(/_/g, "/");
+  const binary = atob(padded + "=".repeat((4 - (padded.length % 4)) % 4));
+  const bytes = Uint8Array.from(binary, (c) => c.charCodeAt(0));
+  return new TextDecoder().decode(bytes);
+}
+
+function headerBlock(raw: string): string {
+  return decodeRaw(raw).split("\r\n\r\n")[0];
+}
+
+describe("stripHeaderBreaks", () => {
+  it("collapses CR, LF and CRLF", () => {
+    expect(stripHeaderBreaks("a\r\nb")).toBe("a b");
+    expect(stripHeaderBreaks("a\nb\rc")).toBe("a b c");
+  });
+
+  it("collapses line and paragraph separators and NUL", () => {
+    expect(stripHeaderBreaks("a\u2028b\u2029c\u0000d")).toBe("a b c d");
+  });
+
+  it("trims the result", () => {
+    expect(stripHeaderBreaks("\r\n hello \r\n")).toBe("hello");
+  });
+});
+
+describe("encodeHeaderValue", () => {
+  it("leaves plain ASCII alone", () => {
+    expect(encodeHeaderValue("Meeting at 10")).toBe("Meeting at 10");
+  });
+
+  it("encodes non-ASCII as RFC 2047 encoded-words", () => {
+    const encoded = encodeHeaderValue("Zamówienie ąę");
+    expect(encoded).toMatch(/^=\?UTF-8\?B\?/);
+    expect(encoded).not.toContain("ó");
+  });
+
+  it("keeps every encoded-word within the 75 character limit", () => {
+    const encoded = encodeHeaderValue("ą".repeat(200));
+    for (const word of encoded.split(" ")) {
+      expect(word.length).toBeLessThanOrEqual(75);
+    }
+  });
+
+  it("never splits a multi-byte character across words", () => {
+    const source = "źdźbło ".repeat(30).trim();
+    const decoded = encodeHeaderValue(source)
+      .split(" ")
+      .map((word) => {
+        const payload = word.slice("=?UTF-8?B?".length, -"?=".length);
+        const binary = atob(payload);
+        return new TextDecoder().decode(Uint8Array.from(binary, (c) => c.charCodeAt(0)));
+      })
+      .join("");
+    expect(decoded).toBe(source);
+  });
+});
+
+describe("encodeAddressHeader", () => {
+  it("keeps a plain address as-is", () => {
+    expect(encodeAddressHeader("user@example.com")).toBe("user@example.com");
+  });
+
+  it("leaves the address literal and encodes only the display name", () => {
+    const encoded = encodeAddressHeader("Michał Kowalski <m@example.com>");
+    expect(encoded).toContain("<m@example.com>");
+    expect(encoded).toMatch(/^=\?UTF-8\?B\?/);
+  });
+
+  it("quotes a display name containing specials", () => {
+    expect(encodeAddressHeader("Doe, John <j@example.com>")).toBe(
+      '"Doe, John" <j@example.com>',
+    );
+  });
+
+  it("drops a break smuggled into the display name", () => {
+    const encoded = encodeAddressHeader("Bob\r\nBcc: attacker@evil.com <b@example.com>");
+    expect(encoded).not.toMatch(/[\r\n]/);
+  });
+});
+
+describe("encodeAddressList", () => {
+  it("joins addresses with a comma", () => {
+    expect(encodeAddressList(["a@example.com", "b@example.com"])).toBe(
+      "a@example.com, b@example.com",
+    );
+  });
+
+  it("skips empty entries", () => {
+    expect(encodeAddressList(["a@example.com", "", "  "])).toBe("a@example.com");
+  });
+});
+
+describe("encodeFilenameParams", () => {
+  it("quotes an ASCII filename", () => {
+    const { nameParam, dispositionParam } = encodeFilenameParams("report.pdf");
+    expect(nameParam).toBe('name="report.pdf"');
+    expect(dispositionParam).toBe('filename="report.pdf"');
+  });
+
+  it("escapes a quote so it cannot close the parameter early", () => {
+    const { dispositionParam } = encodeFilenameParams('a".pdf');
+    expect(dispositionParam).toBe('filename="a\\".pdf"');
+  });
+
+  it("uses RFC 2231 for a non-ASCII filename", () => {
+    const { dispositionParam } = encodeFilenameParams("umowa-ąę.pdf");
+    expect(dispositionParam).toMatch(/^filename\*=UTF-8''/);
+    expect(dispositionParam).not.toContain("ą");
+  });
+
+  it("falls back to a default when the name is only breaks", () => {
+    expect(encodeFilenameParams("\r\n").dispositionParam).toBe('filename="attachment"');
+  });
+});
+
+describe("addressOnly", () => {
+  it("unwraps an angle-bracketed address", () => {
+    expect(addressOnly("Jane Doe <jane@example.com>")).toBe("jane@example.com");
+  });
+
+  it("passes a bare address through", () => {
+    expect(addressOnly("jane@example.com")).toBe("jane@example.com");
+  });
+});
+
+describe("buildRawEmail header safety", () => {
+  const base = {
+    from: "me@example.com",
+    to: ["you@example.com"],
+    htmlBody: "<p>hi</p>",
+  };
+
+  it("does not let a subject open a new header", () => {
+    const headers = headerBlock(
+      buildRawEmail({ ...base, subject: "Hi\r\nBcc: attacker@evil.com" }),
+    );
+    expect(headers).not.toMatch(/^Bcc:/m);
+    expect(headers).toContain("Subject: Hi Bcc: attacker@evil.com");
+  });
+
+  it("does not let a recipient open a new header", () => {
+    const headers = headerBlock(
+      buildRawEmail({
+        ...base,
+        to: ["you@example.com\r\nBcc: attacker@evil.com"],
+        subject: "Hi",
+      }),
+    );
+    expect(headers).not.toMatch(/^Bcc:/m);
+  });
+
+  it("does not let In-Reply-To or References open a new header", () => {
+    const headers = headerBlock(
+      buildRawEmail({
+        ...base,
+        subject: "Hi",
+        inReplyTo: "<a@example.com>\r\nBcc: attacker@evil.com",
+        references: "<b@example.com>\r\nX-Injected: yes",
+      }),
+    );
+    expect(headers).not.toMatch(/^Bcc:/m);
+    expect(headers).not.toMatch(/^X-Injected:/m);
+  });
+
+  it("does not let an attachment filename open a new MIME header", () => {
+    const raw = decodeRaw(
+      buildRawEmail({
+        ...base,
+        subject: "Hi",
+        attachments: [
+          {
+            filename: 'x.pdf"\r\nContent-Type: text/html',
+            mimeType: "application/pdf",
+            content: "AAAA",
+          },
+        ],
+      }),
+    );
+    expect(raw).not.toMatch(/^Content-Type: text\/html$/m);
+    expect(raw).toContain('x.pdf\\" Content-Type: text/html');
+  });
+
+  it("emits a non-ASCII subject as encoded-words, not raw UTF-8", () => {
+    const headers = headerBlock(buildRawEmail({ ...base, subject: "Zamówienie ąę" }));
+    expect(headers).toContain("Subject: =?UTF-8?B?");
+    expect(headers).not.toContain("Zamówienie");
+  });
+
+  it("builds a Message-ID from the address, not the display form", () => {
+    const headers = headerBlock(
+      buildRawEmail({ ...base, from: "Jane Doe <jane@example.com>", subject: "Hi" }),
+    );
+    expect(headers).toMatch(/^Message-ID: <[^@]+@example\.com>$/m);
+  });
+});
+
+describe("parseMailtoUrl header safety", () => {
+  it("strips breaks from the subject", () => {
+    const parsed = parseMailtoUrl(
+      "mailto:a@example.com?subject=Hi%0D%0ABcc:%20attacker@evil.com",
+    );
+    expect(parsed.subject).not.toMatch(/[\r\n]/);
+  });
+
+  it("strips breaks from recipients", () => {
+    const parsed = parseMailtoUrl(
+      "mailto:a@example.com%0D%0ABcc:%20attacker@evil.com?cc=c@example.com%0D%0AX-Evil:%20y",
+    );
+    expect(parsed.to.join("")).not.toMatch(/[\r\n]/);
+    expect(parsed.cc.join("")).not.toMatch(/[\r\n]/);
+  });
+
+  it("keeps line breaks in the body", () => {
+    const parsed = parseMailtoUrl("mailto:a@example.com?body=line1%0D%0Aline2");
+    expect(parsed.body).toContain("\n");
+  });
+});

--- a/src/utils/headerSafety.ts
+++ b/src/utils/headerSafety.ts
@@ -1,0 +1,130 @@
+/**
+ * Helpers for emitting safe RFC 5322 header values.
+ *
+ * Two things go wrong when user-controlled text is written into a header
+ * verbatim: a line break ends the header early (everything after it is parsed
+ * as new headers), and a non-ASCII byte is not legal in a header at all.
+ * Everything here exists to stop one of those two.
+ */
+
+const BREAKS = /[\r\n\u2028\u2029\u0000]+/g;
+
+/**
+ * Collapse anything that could terminate a header line into a single space.
+ * Every value that ends up on the right-hand side of a `Name:` must go
+ * through this, either directly or via one of the encoders below.
+ */
+export function stripHeaderBreaks(value: string): string {
+  return (value ?? "").replace(BREAKS, " ").trim();
+}
+
+function isAscii(value: string): boolean {
+  // eslint-disable-next-line no-control-regex
+  return !/[^\x20-\x7e]/.test(value);
+}
+
+function base64Utf8(value: string): string {
+  const bytes = new TextEncoder().encode(value);
+  let binary = "";
+  for (const b of bytes) binary += String.fromCharCode(b);
+  return btoa(binary);
+}
+
+/**
+ * Encode a header value as RFC 2047 encoded-words when it needs it.
+ *
+ * Words are kept at or under 75 characters and split on character (not byte)
+ * boundaries so multi-byte characters are never cut in half.
+ */
+export function encodeHeaderValue(value: string): string {
+  const safe = stripHeaderBreaks(value);
+  if (!safe) return "";
+  if (isAscii(safe)) return safe;
+
+  // "=?UTF-8?B?" + "?=" is 12 chars, so the base64 payload gets 63,
+  // which is 47 bytes of UTF-8 once rounded down to a base64 group.
+  const MAX_BYTES = 45;
+  const words: string[] = [];
+  let chunk = "";
+  let chunkBytes = 0;
+
+  for (const char of safe) {
+    const size = new TextEncoder().encode(char).length;
+    if (chunkBytes + size > MAX_BYTES) {
+      words.push(`=?UTF-8?B?${base64Utf8(chunk)}?=`);
+      chunk = "";
+      chunkBytes = 0;
+    }
+    chunk += char;
+    chunkBytes += size;
+  }
+  if (chunk) words.push(`=?UTF-8?B?${base64Utf8(chunk)}?=`);
+
+  return words.join(" ");
+}
+
+/**
+ * Encode one address. The display name may need encoding; the address itself
+ * is left alone apart from break stripping so it stays routable.
+ */
+export function encodeAddressHeader(rawValue: string): string {
+  const safe = stripHeaderBreaks(rawValue);
+  if (!safe) return "";
+
+  const match = safe.match(/^(.*?)\s*<([^<>]*)>$/);
+  if (!match) return isAscii(safe) ? safe : encodeHeaderValue(safe);
+
+  const rawName = match[1] ?? "";
+  const address = match[2] ?? "";
+  const name = rawName.replace(/^"|"$/g, "").trim();
+  if (!name) return `<${address}>`;
+  if (isAscii(name)) {
+    return /[",:;<>@\\[\]]/.test(name)
+      ? `"${name.replace(/([\\"])/g, "\\$1")}" <${address}>`
+      : `${name} <${address}>`;
+  }
+  return `${encodeHeaderValue(name)} <${address}>`;
+}
+
+export function encodeAddressList(values: string[]): string {
+  return values.map(encodeAddressHeader).filter(Boolean).join(", ");
+}
+
+/**
+ * Build the `name=` and `filename=` parameters for a MIME part.
+ *
+ * A quote in a filename would otherwise close the quoted string early, which
+ * is the same escape as a line break but one level down in the message.
+ * Non-ASCII names use RFC 2231, with an RFC 2047 `name=` kept alongside for
+ * clients that never learned 2231.
+ */
+export function encodeFilenameParams(filename: string): {
+  nameParam: string;
+  dispositionParam: string;
+} {
+  const safe = stripHeaderBreaks(filename) || "attachment";
+
+  if (isAscii(safe)) {
+    const quoted = safe.replace(/([\\"])/g, "\\$1");
+    return {
+      nameParam: `name="${quoted}"`,
+      dispositionParam: `filename="${quoted}"`,
+    };
+  }
+
+  const encoded = encodeURIComponent(safe).replace(/'/g, "%27");
+  return {
+    nameParam: `name="${encodeHeaderValue(safe)}"`,
+    dispositionParam: `filename*=UTF-8''${encoded}`,
+  };
+}
+
+/**
+ * The bare address out of "Name <user@example.com>", for places that need the
+ * domain rather than the display form.
+ */
+export function addressOnly(value: string): string {
+  const safe = stripHeaderBreaks(value);
+  const match = safe.match(/<([^<>]+)>/);
+  return (match?.[1] ?? safe).trim();
+}

--- a/src/utils/mailtoParser.ts
+++ b/src/utils/mailtoParser.ts
@@ -1,3 +1,5 @@
+import { stripHeaderBreaks } from "./headerSafety";
+
 export interface MailtoFields {
   to: string[];
   cc: string[];
@@ -31,7 +33,7 @@ export function parseMailtoUrl(url: string): MailtoFields {
   if (addressPart) {
     result.to = decodeURIComponent(addressPart)
       .split(",")
-      .map((a) => a.trim())
+      .map(stripHeaderBreaks)
       .filter(Boolean);
   }
 
@@ -43,7 +45,7 @@ export function parseMailtoUrl(url: string): MailtoFields {
     if (toParam) {
       const extraTo = toParam
         .split(",")
-        .map((a) => a.trim())
+        .map(stripHeaderBreaks)
         .filter(Boolean);
       result.to = [...result.to, ...extraTo];
     }
@@ -52,7 +54,7 @@ export function parseMailtoUrl(url: string): MailtoFields {
     if (cc) {
       result.cc = cc
         .split(",")
-        .map((a) => a.trim())
+        .map(stripHeaderBreaks)
         .filter(Boolean);
     }
 
@@ -60,13 +62,15 @@ export function parseMailtoUrl(url: string): MailtoFields {
     if (bcc) {
       result.bcc = bcc
         .split(",")
-        .map((a) => a.trim())
+        .map(stripHeaderBreaks)
         .filter(Boolean);
     }
 
     const subject = params.get("subject");
     if (subject) {
-      result.subject = subject;
+      // The body is free text and keeps its line breaks; the subject becomes a
+      // header, so it must not carry any.
+      result.subject = stripHeaderBreaks(subject);
     }
 
     const body = params.get("body");


### PR DESCRIPTION
# Encode and escape header values in the outgoing message builder

`buildRawEmail` writes every header value straight into the message it hands
to the Gmail API. That is fine for well-formed input and wrong for everything
else, in two ways:

**Line breaks.** A `\r\n` inside a subject, a recipient, `In-Reply-To`,
`References` or an attachment filename terminates that header and everything
after it is parsed as further headers. None of those values is guaranteed to be
break-free — recipients and subjects come from the compose form, from
`mailto:` deep links (`parseMailtoUrl` passes both through unmodified), and
`In-Reply-To`/`References` are copied from the message being replied to.

**Character set.** Headers are ASCII. A subject like `Zamówienie ąę` currently
goes out as raw UTF-8 bytes in the header block, which is not valid RFC 5322.
Gmail happens to repair it on the way out; not every path does, and it renders
as mojibake where it isn't repaired. The same applies to display names and to
non-ASCII attachment filenames, which need RFC 2231 rather than a bare
`filename="…"`.

## What this changes

New `src/utils/headerSafety.ts`, and the header sinks now go through it:

| Value | Before | After |
|---|---|---|
| `Subject` | verbatim | `encodeHeaderValue` — breaks collapsed, non-ASCII as RFC 2047 encoded-words |
| `From` / `To` / `Cc` / `Bcc` | verbatim | `encodeAddressHeader` — display name encoded or quoted, address left literal |
| `In-Reply-To` / `References` | verbatim | `stripHeaderBreaks` |
| attachment `filename` / `name` | `filename="${raw}"` | quotes escaped; RFC 2231 `filename*=UTF-8''…` when non-ASCII |
| `Content-Type` of parts | verbatim mime type | `stripHeaderBreaks` |
| `Message-ID` domain | `from.split("@")[1]` | `addressOnly(from)` first — `Jane Doe <jane@x.com>` previously produced `<…@x.com>` only by luck, and `Jane <jane@x.com>` with a display name containing `@` produced a malformed id |

`parseMailtoUrl` cleans recipients and subject as it parses them, so the values
are already safe before they reach the composer. The **body** is deliberately
left alone — it is free text and its newlines are meaningful.

Encoded-words are kept at or under the 75-character limit and split on
character boundaries, so a multi-byte character is never cut in half.

## Tests

`src/utils/headerSafety.test.ts` — 28 cases covering the encoders directly plus
round-trip assertions on `buildRawEmail` output and `parseMailtoUrl`. Full
suite: 1588 passing, `tsc --noEmit` clean.

## Note

The line-break half of this has a security dimension, and I would rather walk
through it privately than spell it out in a public PR. I tried: the address in
SECURITY.md, security@velomail.app, bounces with "Address not found" —
velomail.app has Cloudflare Email Routing but no rule for that mailbox, so the
contact in SECURITY.md currently goes nowhere. Enabling private vulnerability
reporting on the repo would help too; /security/advisories/new returns 404
today.

Give me a working address and I will send the full write-up and the
proof-of-concept there.
